### PR TITLE
[cache] Pipeline cache to avoid `writeable` arguments

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -65,13 +65,13 @@ def main():
             sl = tokens.shape[1]
             input_mask = model.input_mask(seq_lens, sl)
             attention_mask = model.attention_mask(input_mask, dtype=torch.float32)
-            logits = model.prefill(
+            logits, cache_state = model.prefill(
                 tokens,
                 attention_mask=attention_mask,
                 seq_block_ids=seq_block_ids,
                 cache_state=cache_state,
             )
-            return logits
+            return logits, cache_state
 
     def generate_batch_decode(bs: int):
         tokens = torch.ones(bs, 1, dtype=torch.int64)
@@ -123,7 +123,7 @@ def main():
                 seq_block_ids=seq_block_ids,
                 cache_state=cache_state,
             )
-            return logits
+            return logits, cache_state
 
     generate_batch_prefill(4)
     generate_batch_decode(4)

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -147,7 +147,7 @@ class Batch:
         trace_tensor("prefill.token_ids", self.token_ids)
         trace_tensor("prefill.seq_block_ids", seq_block_ids_tensor)
         trace_tensor("prefill.attention_mask", attention_mask)
-        logits = model.prefill(
+        logits, self.cache_state = model.prefill(
             self.token_ids,
             attention_mask=attention_mask,
             seq_block_ids=seq_block_ids_tensor,
@@ -180,7 +180,7 @@ class Batch:
         trace_tensor("decode.start_positions", start_positions)
         trace_tensor("decode.seq_block_ids", seq_block_ids_tensor)
         trace_tensor("decode.attention_mask", decode_attention_mask)
-        logits = model.decode(
+        logits, self.cache_state = model.decode(
             self.next_tokens,
             attention_mask=decode_attention_mask,
             start_positions=start_positions,

--- a/sharktank/sharktank/examples/validate_paged_llama_model.py
+++ b/sharktank/sharktank/examples/validate_paged_llama_model.py
@@ -85,7 +85,7 @@ def main(args: list[str]):
     )
 
     print(f"Step {start_index}")
-    logits = model.prefill(
+    logits, cache_state = model.prefill(
         next_batch,
         attention_mask=attention_mask,
         seq_block_ids=seq_block_ids,
@@ -114,7 +114,7 @@ def main(args: list[str]):
         ),
         dtype=torch.float32,
     )
-    logits = model.decode(
+    logits, cache_state = model.decode(
         tokens,
         attention_mask=decode_attention_mask,
         start_positions=start_positions,

--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -348,3 +348,4 @@ class PagedKVCache(BaseKVCache):
 
         for index, partition in enumerate(cache_partitions):
             write_cache_partition(index, partition)
+        return [subblock_table]

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -140,6 +140,8 @@ class PagedLlamaModelV1(BaseCausalLMModel):
         h = self.token_embedding(tokens)
         self.trace_tensor("llama.token_embedding", h)
 
+        cache_state = [torch.clone(c) for c in cache_state]
+
         # Iterate over attention blocks.
         for block_idx, block in enumerate(self.attn_blocks):
             if block_idx == 0:
@@ -156,7 +158,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
 
         h = self.output_norm(h)
         logits = self.output_lm_head(h)
-        return logits
+        return logits, cache_state
 
     def decode(
         self,
@@ -201,6 +203,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
         )
 
         h = self.token_embedding(tokens)
+        cache_state = [torch.clone(c) for c in cache_state]
         self.trace_tensor("llama.token_embedding", h)
 
         # Iterate over attention blocks.
@@ -222,7 +225,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
 
         h = self.output_norm(h)
         logits = self.output_lm_head(h)
-        return logits
+        return logits, cache_state
 
 
 ################################################################################

--- a/sharktank/sharktank/models/llama/llama_ref.py
+++ b/sharktank/sharktank/models/llama/llama_ref.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ...layers import *
+from ...types import Theta
 
 __all__ = [
     "DirectCacheLlamaModelV1",


### PR DESCRIPTION
Writing to an `arg` value results in a `!torch.tensor` argument type which violates write semantics. As scatters  are inherently mutative operations on the destination buffer we can internally create a copy then scatter to this copy. This should result in an in-place mutative operation as the dispatch takes ownership of the passed buffer.