### PR TITLE
Support moving theta and models to a specific device.

### DIFF
--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -6,6 +6,8 @@
 
 """Inference support for the PagedLLMV1 protocol of models."""
 
+from typing import Optional
+
 import math
 import sys
 
@@ -50,8 +52,8 @@ class TorchGenerator:
         token_ids, seq_lens = self.tokenizer.encode(
             prompts, pad_to_multiple_of=self.model.cache.pad_sequence_stride
         )
-        token_ids = torch.tensor(token_ids)
-        seq_lens = torch.tensor(seq_lens)
+        token_ids = torch.tensor(token_ids, device=self.model.device)
+        seq_lens = torch.tensor(seq_lens, device=self.model.device)
         if self.shared_cache_state is not None:
             cache_state = self.shared_cache_state
         else:
@@ -153,6 +155,8 @@ class Batch:
             seq_block_ids=seq_block_ids_tensor,
             cache_state=self.cache_state,
         )
+
+        # TODO: Generalize the sampling and don't make it swap on/off cpu.
         # TODO: Normalize the output of extract_tokens_from_logits into
         # tensor [bs, 1].
         tokens = torch.tensor(
@@ -160,7 +164,7 @@ class Batch:
         ).unsqueeze(1)
         print(f":: Prefill results:\n{tokens.tolist()}")
         self.add_result_token(tokens)
-        self.next_tokens = tokens
+        self.next_tokens = tokens.to(device=model.device)
 
     def decode(self):
         model = self.parent.model
@@ -191,7 +195,8 @@ class Batch:
         # TODO: Normalize the output of extract_tokens_from_logits into
         # tensor [bs, 1].
         tokens = torch.tensor(
-            model.extract_tokens_from_logits(logits, [1] * self.bs)
+            model.extract_tokens_from_logits(logits, [1] * self.bs),
+            device=self.parent.model.device,
         ).unsqueeze(1)
         self.add_result_token(tokens)
         self.next_tokens = tokens
@@ -199,7 +204,7 @@ class Batch:
     def pad_block_ids(self) -> torch.Tensor:
         max_length = max(len(r) for r in self.seq_block_ids)
         rows = [r + (max_length - len(r)) * [0] for r in self.seq_block_ids]
-        return torch.tensor(rows)
+        return torch.tensor(rows, device=self.parent.model.device)
 
 
 def main():
@@ -208,19 +213,22 @@ def main():
     parser = cli.create_parser()
     parser.add_argument("prompt", nargs="+", help="Prompt strings")
     parser.add_argument("--kv-cache-type", default="paged", help="KV cache type")
+    parser.add_argument("--device", help="Torch device (or default)")
     cli.add_gguf_dataset_options(parser)
     cli.add_tokenizer_options(parser)
     args = cli.parse(parser)
 
+    device = torch.device(args.device) if args.device else None
     data_files = cli.get_gguf_data_files(args)
     tokenizer = cli.get_tokenizer(args, data_files=data_files)
-    dataset = Dataset.load(data_files["gguf"])
+    dataset = Dataset.load(data_files["gguf"], device=device)
     prompts = args.prompt
 
     config = LlamaModelConfig(
         hp=configs.LlamaHParams.from_gguf_props(dataset.properties),
         block_seq_stride=16,
         kv_cache_type=args.kv_cache_type,
+        device=device,
     )
     model = PagedLlamaModelV1(dataset.root_theta, config)
     generator = TorchGenerator(model, tokenizer)

--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -24,9 +24,15 @@ class BaseCausalLMModel(ThetaLayer):
     """
 
     def __init__(
-        self, theta: Theta, *, context_length: int, static_context_mask: bool = True
+        self,
+        theta: Theta,
+        *,
+        context_length: int,
+        static_context_mask: bool = True,
+        device: Optional[torch.device] = None,
     ):
         super().__init__(theta)
+        self.device = device
         self.context_length = context_length
 
         if static_context_mask:
@@ -35,6 +41,13 @@ class BaseCausalLMModel(ThetaLayer):
             )
         else:
             self.causal_context_mask = None
+
+    def _assert_device(self, *ts: torch.Tensor):
+        if self.device is not None:
+            for t in ts:
+                assert (
+                    t.device == self.device
+                ), f"Expected tensor to be on device {self.device} but it is on {t.device}"
 
     def _maximally_negative_value(self, dtype):
         """Returns a maximally negative value for the given dtype.
@@ -46,7 +59,9 @@ class BaseCausalLMModel(ThetaLayer):
     def generate_causal_context_mask(self) -> torch.Tensor:
         context_length = self.context_length
         causal_context_mask = torch.triu(
-            torch.ones([context_length, context_length], dtype=torch.bool),
+            torch.ones(
+                [context_length, context_length], dtype=torch.bool, device=self.device
+            ),
             diagonal=1,
         )[None, None, :, :]
         return causal_context_mask
@@ -62,7 +77,7 @@ class BaseCausalLMModel(ThetaLayer):
         The mask will be [bs, batch_seqlen] with True at any position that is
         masked.
         """
-        range_vector = torch.arange(0, batch_seqlen, 1)
+        range_vector = torch.arange(0, batch_seqlen, 1, device=self.device)
         matrix = torch.unsqueeze(seq_lens, dim=-1)
         mask = range_vector >= matrix
         return mask
@@ -74,14 +89,14 @@ class BaseCausalLMModel(ThetaLayer):
         numeric_mask.masked_fill_(
             boolean_input_mask, self._maximally_negative_value(dtype)
         )
-        return numeric_mask.unsqueeze(1).unsqueeze(1)
+        return numeric_mask.unsqueeze(1).unsqueeze(1).to(self.device)
 
     def attention_mask(
         self,
         input_mask: torch.Tensor,
         *,
         dtype: torch.dtype,
-        causal_context_mask: Optional[torch.Tensor] = None
+        causal_context_mask: Optional[torch.Tensor] = None,
     ):
         """Generates a causal attention mask of [1, 1, sl, sl] of activation dtype.
 
@@ -103,7 +118,7 @@ class BaseCausalLMModel(ThetaLayer):
         boolean_mask = causal_mask + input_mask[:, None, None, :]
         numeric_mask = torch.zeros_like(boolean_mask, dtype=dtype)
         numeric_mask.masked_fill_(boolean_mask, self._maximally_negative_value(dtype))
-        return numeric_mask
+        return numeric_mask.to(self.device)
 
     def extract_tokens_from_logits(
         self, logits: torch.Tensor, seq_lens: list[int]

--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -11,6 +11,8 @@ tightly coupled transformer blocks a bit less "stringy" with loose tensors
 and dims floating around everywhere.
 """
 
+from typing import Optional
+
 import abc
 import math
 
@@ -88,12 +90,14 @@ class DirectKVCache(BaseKVCache):
         attn_head_count: int,
         attn_head_dim: int,
         seq_length: int,
+        device: Optional[torch.device] = None,
     ):
         self.block_seq_stride = block_seq_stride
         self.transformer_block_count = transformer_block_count
         self.attn_head_count = attn_head_count
         self.attn_head_dim = attn_head_dim
         self.seq_length = seq_length
+        self.device = device
 
     @property
     def pad_sequence_stride(self) -> int:
@@ -109,6 +113,7 @@ class DirectKVCache(BaseKVCache):
             torch.empty(
                 [bs, self.seq_length, self.attn_head_count, self.attn_head_dim],
                 dtype=dtype,
+                device=self.device,
             )
             for _ in range(2 * self.transformer_block_count)
         ]
@@ -141,6 +146,7 @@ class PagedKVCache(BaseKVCache):
         attn_head_dim: int,
         cache_partition_count: int = 2,
         block_seq_stride: int = 16,
+        device: Optional[torch.device] = None,
     ):
         self.transformer_block_count = transformer_block_count
         self.attn_head_count = attn_head_count
@@ -157,6 +163,7 @@ class PagedKVCache(BaseKVCache):
             self.attn_head_dim,
         ]
         self.page_slab_flat_dim = math.prod(self.sub_page_dims)
+        self.device = device
 
     def unflatten_page_table(self, state: list[torch.Tensor]) -> torch.Tensor:
         """Unflattens the 2D page table to a 6D tensor."""
@@ -181,7 +188,11 @@ class PagedKVCache(BaseKVCache):
         """Allocates tensor state for a page table for the given capacity in
         pages.
         """
-        return [torch.empty([page_count, self.page_slab_flat_dim], dtype=dtype)]
+        return [
+            torch.empty(
+                [page_count, self.page_slab_flat_dim], dtype=dtype, device=self.device
+            )
+        ]
 
     def read(
         self,
@@ -272,6 +283,7 @@ class PagedKVCache(BaseKVCache):
         Note that this internally loops over the batch size, which cannot be
         dynamic.
         """
+        device = self.device
         page_table = self.unflatten_page_table(state)  # 6D
         bs, *_ = seq_positions.shape
         assert len(cache_partitions) == self.cache_partition_count
@@ -285,8 +297,8 @@ class PagedKVCache(BaseKVCache):
                 cache_partition = cache_partitions[partition_index]
                 indices = (
                     page_id,
-                    torch.tensor([transformer_block_index]),
-                    torch.tensor([partition_index]),
+                    torch.tensor([transformer_block_index], device=device),
+                    torch.tensor([partition_index], device=device),
                     page_offset.unsqueeze(0),
                 )
                 page_table.index_put_(indices=indices, values=cache_partition[i, 0])

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -33,7 +33,8 @@ MetaDataValueType = Union[int, bool, float, str]
 
 class QuantizedLayout(ABC):
     @abstractmethod
-    def dequant(self, dtype: Optional[torch.dtype] = None) -> torch.Tensor: ...
+    def dequant(self, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+        ...
 
     @classmethod
     @abstractmethod
@@ -48,7 +49,8 @@ class QuantizedLayout(ABC):
         shape: list[int],
         metadata: Optional[dict[str, MetaDataValueType]],
         planes: dict[str, torch.Tensor],
-    ) -> "QuantizedLayout": ...
+    ) -> "QuantizedLayout":
+        ...
 
     @property
     @abstractmethod
@@ -329,7 +331,8 @@ class QuantizedTensor(InferenceTensor, Generic[QuantizedLayoutT]):
         self.layout_type = layout_type
 
     @abstractmethod
-    def unpack(self) -> QuantizedLayoutT: ...
+    def unpack(self) -> QuantizedLayoutT:
+        ...
 
     def to_planar(self) -> "PlanarQuantizedTensor":
         """Converts this QuantizedTensor to a generic planar form.

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -4,14 +4,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, Optional, Union, TypeVar, Generic, Type
+from typing import Any, Callable, Optional, Union, TypeVar, Generic, Type
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
 
-from shark_turbine.aot import ParameterArchiveBuilder
+from shark_turbine.aot import (
+    ExternalTensorTrait,
+    ParameterArchiveBuilder,
+)
 
 __all__ = [
     "register_quantized_layout",
@@ -30,8 +33,7 @@ MetaDataValueType = Union[int, bool, float, str]
 
 class QuantizedLayout(ABC):
     @abstractmethod
-    def dequant(self, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
-        ...
+    def dequant(self, dtype: Optional[torch.dtype] = None) -> torch.Tensor: ...
 
     @classmethod
     @abstractmethod
@@ -46,8 +48,7 @@ class QuantizedLayout(ABC):
         shape: list[int],
         metadata: Optional[dict[str, MetaDataValueType]],
         planes: dict[str, torch.Tensor],
-    ) -> "QuantizedLayout":
-        ...
+    ) -> "QuantizedLayout": ...
 
     @property
     @abstractmethod
@@ -185,6 +186,48 @@ class InferenceTensor(ABC):
         """Adds this tensor to the global archive."""
         ...
 
+    def transform_globals(
+        self, *transforms: Callable[[dict[str, torch.Tensor]], dict[str, torch.Tensor]]
+    ) -> "InferenceTensor":
+        """Appplies transformation functions to the InferenceTensors backing
+        globals.
+
+        Each transformation must produce a new dict of a form that the subclass
+        can handle. Practically, this means that placement and layout related
+        changes are always allowed, while more invasive changes (like dtype)
+        are more case by case.
+
+        Returns a new InferenceTensor, mutated.
+        """
+        prev_globals = self.globals
+        for transform in transforms:
+            next_globals = transform(prev_globals)
+            # Copy any metadata from prior to next.
+            for k, prev_t in prev_globals.items():
+                new_t = next_globals.get(k)
+                if new_t is None:
+                    continue
+                if new_t is not prev_t:
+                    ext_trait = ExternalTensorTrait.get(prev_t)
+                    if ext_trait is not None:
+                        ext_trait.set(new_t)
+            prev_globals = next_globals
+        return self._clone_with_globals(prev_globals)
+
+    def to(
+        self, *, device: Optional[Union[str, torch.device]] = None
+    ) -> "InferenceTensor":
+        return self.transform_globals(
+            lambda d: {k: t.to(device=device) for k, t in d.items()}
+        )
+
+    def _clone_with_globals(
+        self, new_globals: dict[str, torch.Tensor]
+    ) -> "InferenceTensor":
+        raise NotImplementedError(
+            f"InferenceTensor {type(self)} does not implement _clone_with_globals"
+        )
+
 
 REGISTERED_INFERENCE_TENSOR_CLASSES: dict[str, Type[InferenceTensor]] = {}
 
@@ -263,6 +306,11 @@ class DefaultPrimitiveTensor(PrimitiveTensor):
         builder.add_tensor(self.name, self._data)
         return InferenceTensorMetadata(self.serialized_name(), {"": self.name})
 
+    def _clone_with_globals(
+        self, new_globals: dict[str, torch.Tensor]
+    ) -> "InferenceTensor":
+        return DefaultPrimitiveTensor(name=self.name, data=new_globals[self.name])
+
     def __repr__(self):
         return f"PrimitiveTensor({self.name}, {self.shape}, {self._data.dtype})"
 
@@ -281,8 +329,7 @@ class QuantizedTensor(InferenceTensor, Generic[QuantizedLayoutT]):
         self.layout_type = layout_type
 
     @abstractmethod
-    def unpack(self) -> QuantizedLayoutT:
-        ...
+    def unpack(self) -> QuantizedLayoutT: ...
 
     def to_planar(self) -> "PlanarQuantizedTensor":
         """Converts this QuantizedTensor to a generic planar form.
@@ -332,6 +379,35 @@ class PlanarQuantizedTensor(QuantizedTensor):
         global_name = self.name
         planes = self.layout.planes
         return {f"{global_name}:{k}": v for k, v in planes.items()}
+
+    def _clone_with_globals(
+        self, new_globals: dict[str, torch.Tensor]
+    ) -> "InferenceTensor":
+        # Clone it via layout serialization.
+        serialized_name = self.layout.serialized_name()
+        global_prefix = f"{self.name}:"
+        orig_planes = self.layout.planes
+        new_planes = {}
+        for plane_name in orig_planes.keys():
+            # Planes are stored in the globals dict with the inference
+            # tensor's name and colon prepended, so look up that way.
+            new_planes[plane_name] = new_globals[f"{global_prefix}{plane_name}"]
+
+        # Create a new layout via the serialization adaptor.
+        try:
+            layout_clazz = REGISTERED_LAYOUT_CLASSES[serialized_name]
+        except KeyError:
+            raise IOError(
+                f"Cannot deserialize PlanarQuantizedTensor because of unregistered layout "
+                f"{serialized_name}"
+            )
+        new_layout = layout_clazz.create(self.shape, self.layout.metadata, new_planes)
+
+        return PlanarQuantizedTensor(
+            name=self.name,
+            shape=self.shape,
+            layout=new_layout,
+        )
 
     @classmethod
     def create(

--- a/sharktank/sharktank/utils/tokenizer.py
+++ b/sharktank/sharktank/utils/tokenizer.py
@@ -12,7 +12,6 @@ from typing import Optional, Union
 import math
 import os
 
-
 __all__ = [
     "load_tokenizer",
     "InferenceTokenizer",
@@ -53,12 +52,10 @@ class InferenceTokenizer(ABC):
         return self._decode(tokens)
 
     @abstractmethod
-    def _encode(self, texts: list[str]) -> list[list[int]]:
-        ...
+    def _encode(self, texts: list[str]) -> list[list[int]]: ...
 
     @abstractmethod
-    def _decode(self, tokens: list[list[int]]) -> list[str]:
-        ...
+    def _decode(self, tokens: list[list[int]]) -> list[str]: ...
 
 
 def load_tokenizer(*posargs, tokenizer_type: str = "transformers", **kwargs):

--- a/sharktank/sharktank/utils/tokenizer.py
+++ b/sharktank/sharktank/utils/tokenizer.py
@@ -52,10 +52,12 @@ class InferenceTokenizer(ABC):
         return self._decode(tokens)
 
     @abstractmethod
-    def _encode(self, texts: list[str]) -> list[list[int]]: ...
+    def _encode(self, texts: list[str]) -> list[list[int]]:
+        ...
 
     @abstractmethod
-    def _decode(self, tokens: list[list[int]]) -> list[str]: ...
+    def _decode(self, tokens: list[list[int]]) -> list[str]:
+        ...
 
 
 def load_tokenizer(*posargs, tokenizer_type: str = "transformers", **kwargs):

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.types import *
+
+
+def _createTestLayout():
+    n = 128
+    k = 1024
+    bs = 32
+
+    return BlockScaledLayout(
+        [n, k],
+        d=torch.empty(n, k // bs, 1, dtype=torch.float32),
+        qs=torch.empty(n, k // bs, bs, dtype=torch.int8),
+        m=torch.empty(n, k // bs, bs, dtype=torch.float32),
+    )
+
+
+class PlanarQuantizedTensorTest(unittest.TestCase):
+    def testTransform(self):
+        pqt1 = PlanarQuantizedTensor("t1", [128, 1024], _createTestLayout())
+
+        def transform1(d):
+            new_d = {}
+            for k, t in d.items():
+                if k.endswith(":qs"):
+                    t = t.to(torch.int16)
+                new_d[k] = t
+            return new_d
+
+        def transform2(d):
+            new_d = {}
+            for k, t in d.items():
+                if k.endswith(":d") or k.endswith(":m"):
+                    t = t.to(torch.float16)
+                new_d[k] = t
+            return new_d
+
+        pqt2 = pqt1.transform_globals(transform1, transform2)
+        self.assertIsNot(pqt1, pqt2)
+        print(pqt2)
+        self.assertEqual(pqt2.name, pqt1.name)
+        self.assertEqual(pqt2.shape, pqt1.shape)
+        new_planes = pqt2.layout.planes
+        self.assertEqual(new_planes["qs"].dtype, torch.int16)
+        self.assertEqual(new_planes["m"].dtype, torch.float16)
+        self.assertEqual(new_planes["d"].dtype, torch.float16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Threads explicit device through models.
* Implements functional InferenceTensor, Theta and Dataset transformations and uses it to implement `to(device=)`.
* Adds `--device foo` to example runner.
* With https://github.com/iree-org/iree-turbine/pull/3 and supporting patches, this allows custom ops and kernels to transparently be used on CUDA/ROCM devices (instead of just CPU).