### PR TITLE
Add explicit activation and attention dtypes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
+# Runtime deps.
 gguf==0.6.0
 numpy==1.26.3
 onnx==1.15.0
-pytest==8.0.0
-pytest-xdist==3.5.0
-mypy==1.8.0
-types-requests==2.31.0.20240125
 
 # It is expected that you have installed a PyTorch version/variant specific
 # to your needs, so we only include a minimum version spec.
@@ -13,3 +10,12 @@ torch>=2.3.0.dev1
 
 # Used for managing pre-commit flows.
 pre-commit
+
+# Type checking
+mypy==1.8.0
+types-requests==2.31.0.20240125
+
+# Testing
+parameterized
+pytest==8.0.0
+pytest-xdist==3.5.0

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -43,7 +43,7 @@ def main():
         tokens = torch.empty(bs, 64, dtype=torch.int64)
         seq_lens = torch.empty(bs, dtype=torch.int64)
         seq_block_ids = torch.empty(bs, 4, dtype=torch.int64)
-        cache_state = model.cache.allocate(128, torch.float32)
+        cache_state = model.cache.allocate(128)
         block_dim = torch.export.Dim("block", max=2047 // 16)
         sl_dim = 16 * block_dim
         page_dim = torch.export.Dim("page")
@@ -64,7 +64,7 @@ def main():
         def _(model, tokens, seq_lens, seq_block_ids, cache_state):
             sl = tokens.shape[1]
             input_mask = model.input_mask(seq_lens, sl)
-            attention_mask = model.attention_mask(input_mask, dtype=torch.float32)
+            attention_mask = model.attention_mask(input_mask)
             logits = model.prefill(
                 tokens,
                 attention_mask=attention_mask,
@@ -78,7 +78,7 @@ def main():
         seq_lens = torch.ones(bs, dtype=torch.int64)
         start_positions = torch.ones(bs, dtype=torch.int64)
         seq_block_ids = torch.zeros(bs, 4, dtype=torch.int64)
-        cache_state = model.cache.allocate(128, torch.float32)
+        cache_state = model.cache.allocate(128)
         block_dim = torch.export.Dim("block", max=2047 // 16)
         page_dim = torch.export.Dim("page")
         dynamic_shapes = {
@@ -113,9 +113,7 @@ def main():
             input_mask = model.input_mask(
                 seq_lens, seq_block_ids.shape[1] * model.cache.block_seq_stride
             )
-            attention_mask = model.decode_attention_mask(
-                input_mask, dtype=torch.float32
-            )
+            attention_mask = model.decode_attention_mask(input_mask)
             logits = model.decode(
                 tokens,
                 attention_mask=attention_mask,

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -41,8 +41,6 @@ class LlamaHParams:
     attention_layer_norm_rms_epsilon: float
     attention_head_count_kv: int
 
-    activation_dtype: torch.dtype = torch.float32
-
     @staticmethod
     def from_gguf_props(p: dict[str, Any]):
         attention_head_count = _int_prop(p, "llama.attention.head_count")

--- a/sharktank/sharktank/layers/norm.py
+++ b/sharktank/sharktank/layers/norm.py
@@ -10,7 +10,12 @@ from .base import Theta, ThetaLayer
 
 
 class RMSNormLayer(ThetaLayer):
-    """Computes the unbiased full RMS layer normalization."""
+    """Computes the unbiased full RMS layer normalization.
+
+    Because normalization is sensitive to floating point error, we support
+    an explicit dtype that the input will be casted to prior to performing
+    the compute. The result will be cast back to the input dtype.
+    """
 
     def __init__(
         self,
@@ -18,10 +23,18 @@ class RMSNormLayer(ThetaLayer):
         *,
         weight_name: str = "weight",
         epsilon: float = 1e-6,
+        dtype: torch.dtype = torch.float32,
     ):
         super().__init__(theta)
         self.weight = self.theta_tensor(weight_name)
         self.epsilon = epsilon
+        self.dtype = dtype
 
     def forward(self, x: torch.Tensor):
-        return self.theta.ops.rms_norm(x, self.weight, epsilon=self.epsilon)
+        orig_dtype = x.dtype
+        x = x.to(self.dtype)
+        norm = self.theta.ops.rms_norm(x, self.weight, epsilon=self.epsilon)
+        # Will automatically upcast to the dtype of the weight, which is
+        # often in higher precision. Downcast back to expected.
+        norm = norm.to(orig_dtype)
+        return norm

--- a/sharktank/sharktank/ops/base.py
+++ b/sharktank/sharktank/ops/base.py
@@ -4,11 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 import logging
 from pathlib import Path
 import textwrap
+
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 from shark_turbine.support.ir_imports import (
     util_d,
@@ -37,6 +39,15 @@ LIBRARY = def_library("sharktank")
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 logger = get_logger("sharktank.ops")
 
+_JINJA2_ENVIRONMENT: Optional[Environment] = None
+
+
+def _get_jinja2_env() -> Environment:
+    global _JINJA2_ENVIRONMENT
+    if _JINJA2_ENVIRONMENT is None:
+        _JINJA2_ENVIRONMENT = Environment(loader=PackageLoader(__name__, "templates"))
+    return _JINJA2_ENVIRONMENT
+
 
 def call_function(target_function: Operation, *operands: Value) -> Sequence[Value]:
     target_symbol = FlatSymbolRefAttr.get(
@@ -54,7 +65,11 @@ def call_function(target_function: Operation, *operands: Value) -> Sequence[Valu
 
 
 def inline_template_function(
-    kb: KernelBuilder, template_file: str, function_name: str, **kwargs
+    kb: KernelBuilder,
+    template_file: str,
+    function_name: str,
+    template_type: str = "format",
+    **kwargs,
 ) -> Operation:
     """Inlines a template module by first expanding its ASM via **kwargs.
 
@@ -65,7 +80,12 @@ def inline_template_function(
         return kb.symbol_table[function_name]
     except KeyError:
         pass
-    source_module_op = load_mlir_template(kb, template_file, **kwargs)
+    if template_type == "format":
+        source_module_op = load_mlir_template(kb, template_file, **kwargs)
+    elif template_type == "jinja":
+        source_module_op = load_jinja_template(kb, template_file, **kwargs)
+    else:
+        raise ValueError(f"Unsupported template_type: {template_type}")
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(
             "Generated kernel IR %s:\n%s", function_name, str(source_module_op)
@@ -75,6 +95,26 @@ def inline_template_function(
     )
     merger.merge()
     return kb.symbol_table[function_name]
+
+
+def load_jinja_template(kb: KernelBuilder, template_file: str, **kwargs) -> Operation:
+    """Loads an MLIR jinja-based template by name.
+
+    The file is loaded relative to the templates/ directory. It is interpolated
+    with **kwargs and loaded into the KernelBuilder.
+    """
+    # template_path = TEMPLATES_DIR / template_file
+    # template_text = template_path.read_text()
+    asm = _get_jinja2_env().get_template(template_file).render(**kwargs)
+    try:
+        module_op = Operation.parse(asm, context=kb.context)
+    except MLIRError as e:
+        raise RuntimeError(
+            f"Error parsing generated op template:"
+            f"\n{textwrap.indent(str(e), '  ')}"
+            f"\n{textwrap.indent(asm, '    >> ')}"
+        )
+    return module_op.operation
 
 
 def load_mlir_template(kb: KernelBuilder, template_file: str, **kwargs) -> Operation:

--- a/sharktank/sharktank/ops/mmt_block_scaled_q8.py
+++ b/sharktank/sharktank/ops/mmt_block_scaled_q8.py
@@ -91,6 +91,7 @@ class mmt_block_scaled_q8(CustomOp):
             kb,
             template_file,
             target_function_name,
+            template_type="jinja",
             n=n,
             k=k,
             bs=bs,

--- a/sharktank/sharktank/ops/mmt_block_scaled_q8.py
+++ b/sharktank/sharktank/ops/mmt_block_scaled_q8.py
@@ -91,7 +91,6 @@ class mmt_block_scaled_q8(CustomOp):
             kb,
             template_file,
             target_function_name,
-            template_type="jinja",
             n=n,
             k=k,
             bs=bs,

--- a/sharktank/sharktank/ops/templates/mmt_block_scaled_offset_q4_unsigned.mlir
+++ b/sharktank/sharktank/ops/templates/mmt_block_scaled_offset_q4_unsigned.mlir
@@ -4,26 +4,28 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+{% set accum_type = "f32" %}
+
 !lowp_type = i4
-!a_type = {a_type}
-!scale_type = {scale_type}
-!a_tensor_type = tensor<?x?x{k}x!a_type>
-!aexp_tensor_type = tensor<?x?x{group0}x{bs}x!a_type>
-!qs_raw_tensor_type = tensor<{n}x{group0}x{bs_i8}xi8>
-!qs_tensor_type = tensor<{n}x{group0}x{bs}x!lowp_type>
-!d_tensor_type = tensor<{n}x{group0}x1x!scale_type>
-!m_tensor_type = tensor<{n}x{group0}x1x!scale_type>
-// TODO: We should really have an accumulator type, which will be needed for
-// f16 and below.
-!c_tensor_type = tensor<?x?x{n}x!a_type>
-!b_grouped_tensor_type = tensor<{n}x{group0}x{bs}x!a_type>
+!a_type = {{a_type}}
+!scale_type = {{scale_type}}
+!accum_type = {{accum_type}}
+!a_tensor_type = tensor<?x?x{{k}}x!a_type>
+!aexp_tensor_type = tensor<?x?x{{group0}}x{{bs}}x!a_type>
+!qs_raw_tensor_type = tensor<{{n}}x{{group0}}x{{bs_i8}}xi8>
+!qs_tensor_type = tensor<{{n}}x{{group0}}x{{bs}}x!lowp_type>
+!d_tensor_type = tensor<{{n}}x{{group0}}x1x!scale_type>
+!m_tensor_type = tensor<{{n}}x{{group0}}x1x!scale_type>
+!accum_tensor_type = tensor<?x?x{{n}}x!accum_type>
+!c_tensor_type = tensor<?x?x{{n}}x!a_type>
+!b_grouped_tensor_type = tensor<{{n}}x{{group0}}x{{bs}}x!a_type>
 
-module {{
+module {
 
-util.func private @sharktank_mmt_block_scaled_offset_q4_unsigned_3d_{n}_{k}_{bs}_{a_type}(
+util.func private @sharktank_mmt_block_scaled_offset_q4_unsigned_3d_{{n}}_{{k}}_{{bs}}_{{a_type}}(
     %a: !a_tensor_type, %d: !d_tensor_type, %qs_raw: !qs_raw_tensor_type, %m: !m_tensor_type)
-    -> !c_tensor_type {{
-  %zero = arith.constant 0.0: !a_type
+    -> !c_tensor_type {
+  %zero = arith.constant 0.0: !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %batch0_dim = tensor.dim %a, %c0 : !a_tensor_type
@@ -34,47 +36,63 @@ util.func private @sharktank_mmt_block_scaled_offset_q4_unsigned_3d_{n}_{k}_{bs}
 
   // Dequantize.
   %b_grouped = tensor.empty() : !b_grouped_tensor_type
-  %b_grouped_dequant = linalg.generic {{
+  %b_grouped_dequant = linalg.generic {
       indexing_maps = [
           affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
           affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
-      iterator_types = ["parallel", "parallel", "parallel"] }}
+      iterator_types = ["parallel", "parallel", "parallel"] }
       ins(%d, %m, %qs : !d_tensor_type, !m_tensor_type, !qs_tensor_type)
-      outs(%b_grouped : !b_grouped_tensor_type) {{
+      outs(%b_grouped : !b_grouped_tensor_type) {
   ^bb0(%d_element: !scale_type, %m_element: !scale_type, %q_element: !lowp_type, %out: !a_type):
       %q_element_ext = arith.extui %q_element : !lowp_type to i32
       %q_element_fp = arith.uitofp %q_element_ext : i32 to !a_type
+    {% if scale_type == a_type %}
+      %q_element_scaled = arith.mulf %q_element_fp, %d_element : !a_type
+      %q_element_offset = arith.addf %q_element_scaled, %m_element : !a_type
+    {% else %}
       %d_element_ext = arith.extf %d_element : !scale_type to !a_type
       %m_element_ext = arith.extf %m_element : !scale_type to !a_type
       %q_element_scaled = arith.mulf %q_element_fp, %d_element_ext : !a_type
       %q_element_offset = arith.addf %q_element_scaled, %m_element_ext : !a_type
+    {% endif %}
       linalg.yield %q_element_offset : !a_type
-  }} -> !b_grouped_tensor_type
+  } -> !b_grouped_tensor_type
 
   // Expand %a to have the same blocked reduction structure.
   %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] : !a_tensor_type into !aexp_tensor_type
 
   // Grouped, batch mm.
-  %result_empty = tensor.empty(%batch0_dim, %m_dim) : !c_tensor_type
-  %result_fill = linalg.fill ins(%zero: !a_type) outs(%result_empty: !c_tensor_type) -> !c_tensor_type
-  %result = linalg.generic {{
+  %result_empty = tensor.empty(%batch0_dim, %m_dim) : !accum_tensor_type
+  %result_fill = linalg.fill ins(%zero: !accum_type) outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
+  %result = linalg.generic {
       indexing_maps = [
           // d0 = b, d1 = m, d2 = n, d3 = group0 (r), d4 = block (r)
           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>,
           affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>,
           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>],
-      iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"] }}
+      iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"] }
       ins(%aexp, %b_grouped_dequant : !aexp_tensor_type,  !b_grouped_tensor_type)
-      outs(%result_fill : !c_tensor_type) {{
-  ^bb0(%a_element: !a_type, %b_element: !a_type, %out: !a_type):
+      outs(%result_fill : !accum_tensor_type) {
+  ^bb0(%a_element: !a_type, %b_element: !a_type, %out: !accum_type):
       %bmm_mul = arith.mulf %a_element, %b_element : !a_type
+    {% if accum_type == a_type %}
       %bmm_accum = arith.addf %bmm_mul, %out : !a_type
-      linalg.yield %bmm_accum : !a_type
-  }} -> !c_tensor_type
+    {% else %}
+      %bmm_mul_ext = arith.extf %bmm_mul : !a_type to !accum_type
+      %bmm_accum = arith.addf %bmm_mul_ext, %out : !accum_type
+    {% endif %}
+      linalg.yield %bmm_accum : !accum_type
+  } -> !accum_tensor_type
 
-  util.return %result : !c_tensor_type
-}}
+  // Cast.
+  %result_cast_empty = tensor.empty(%batch0_dim, %m_dim) : !c_tensor_type
+  %result_cast = linalg.copy
+    ins(%result : !accum_tensor_type)
+    outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
 
-}}
+  util.return %result_cast : !c_tensor_type
+}
+
+}

--- a/sharktank/sharktank/ops/templates/mmt_block_scaled_q8_3d.mlir
+++ b/sharktank/sharktank/ops/templates/mmt_block_scaled_q8_3d.mlir
@@ -4,24 +4,26 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+{% set accum_type = "f32" %}
+
 !lowp_type = i8
-!a_type = {a_type}
-!scale_type = {scale_type}
-!a_tensor_type = tensor<?x?x{k}x!a_type>
-!aexp_tensor_type = tensor<?x?x{group0}x{bs}x!a_type>
-!qs_tensor_type = tensor<{n}x{group0}x{bs}x!lowp_type>
-!d_tensor_type = tensor<{n}x{group0}x1x!scale_type>
-// TODO: We should really have an accumulator type, which will be needed for
-// f16 and below.
-!c_tensor_type = tensor<?x?x{n}x!a_type>
-!b_grouped_tensor_type = tensor<{n}x{group0}x{bs}x!a_type>
+!a_type = {{a_type}}
+!scale_type = {{scale_type}}
+!accum_type = {{accum_type}}
+!a_tensor_type = tensor<?x?x{{k}}x!a_type>
+!aexp_tensor_type = tensor<?x?x{{group0}}x{{bs}}x!a_type>
+!qs_tensor_type = tensor<{{n}}x{{group0}}x{{bs}}x!lowp_type>
+!d_tensor_type = tensor<{{n}}x{{group0}}x1x!scale_type>
+!accum_tensor_type = tensor<?x?x{{n}}x!accum_type>
+!c_tensor_type = tensor<?x?x{{n}}x!a_type>
+!b_grouped_tensor_type = tensor<{{n}}x{{group0}}x{{bs}}x!a_type>
 
-module {{
+module {
 
-util.func private @sharktank_mmt_block_scaled_q8_3d_{n}_{k}_{bs}_{a_type}(
+util.func private @sharktank_mmt_block_scaled_q8_3d_{{n}}_{{k}}_{{bs}}_{{a_type}}(
     %a: !a_tensor_type, %d: !d_tensor_type, %qs: !qs_tensor_type)
-    -> !c_tensor_type {{
-  %zero = arith.constant 0.0: !a_type
+    -> !c_tensor_type {
+  %zero = arith.constant 0.0: !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %batch0 = tensor.dim %a, %c0 : !a_tensor_type
@@ -29,44 +31,58 @@ util.func private @sharktank_mmt_block_scaled_q8_3d_{n}_{k}_{bs}_{a_type}(
 
   // Dequantize.
   %b_grouped = tensor.empty() : !b_grouped_tensor_type
-  %b_grouped_dequant = linalg.generic {{
+  %b_grouped_dequant = linalg.generic {
       indexing_maps = [
           affine_map<(d0, d1, d2) -> (d0, d1, 0)>,
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
           affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
-      iterator_types = ["parallel", "parallel", "parallel"] }}
+      iterator_types = ["parallel", "parallel", "parallel"] }
       ins(%d, %qs : !d_tensor_type, !qs_tensor_type)
-      outs(%b_grouped : !b_grouped_tensor_type) {{
+      outs(%b_grouped : !b_grouped_tensor_type) {
   ^bb0(%d_element: !scale_type, %q_element: !lowp_type, %out: !a_type):
       %q_element_ext = arith.extsi %q_element : !lowp_type to i32
       %q_element_fp = arith.sitofp %q_element_ext : i32 to !a_type
+    {% if scale_type == a_type %}
+      %q_element_scaled = arith.mulf %q_element_fp, %d_element : !a_type
+    {% else %}
       %d_element_ext = arith.extf %d_element : !scale_type to !a_type
       %q_element_scaled = arith.mulf %q_element_fp, %d_element_ext : !a_type
+    {% endif %}
       linalg.yield %q_element_scaled : !a_type
-  }} -> !b_grouped_tensor_type
+  } -> !b_grouped_tensor_type
 
   // Expand %a to have the same blocked reduction structure.
   %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] : !a_tensor_type into !aexp_tensor_type
 
   // Grouped, batch mm.
-  %result_empty = tensor.empty(%batch0, %m) : !c_tensor_type
-  %result_fill = linalg.fill ins(%zero: !a_type) outs(%result_empty: !c_tensor_type) -> !c_tensor_type
-  %result = linalg.generic {{
+  %result_empty = tensor.empty(%batch0, %m) : !accum_tensor_type
+  %result_fill = linalg.fill ins(%zero: !accum_type) outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
+  %result = linalg.generic {
       indexing_maps = [
           // d0 = b, d1 = m, d2 = n, d3 = group0 (r), d4 = block (r)
           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>,
           affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>,
           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>],
-      iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"] }}
+      iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"] }
       ins(%aexp, %b_grouped_dequant : !aexp_tensor_type,  !b_grouped_tensor_type)
-      outs(%result_fill : !c_tensor_type) {{
-  ^bb0(%a_element: !a_type, %b_element: !a_type, %out: !a_type):
+      outs(%result_fill : !accum_tensor_type) {
+  ^bb0(%a_element: !a_type, %b_element: !a_type, %out: !accum_type):
       %bmm_mul = arith.mulf %a_element, %b_element : !a_type
-      %bmm_accum = arith.addf %bmm_mul, %out : !a_type
-      linalg.yield %bmm_accum : !a_type
-  }} -> !c_tensor_type
+    {% if accum_type == a_type %}
+      %bmm_accum = arith.addf %bmm_mul, %out : !accum_type
+    {% else %}
+      %bmm_mul_ext = arith.extf %bmm_mul : !a_type to !accum_type
+      %bmm_accum = arith.addf %bmm_mul_ext, %out : !accum_type
+    {% endif %}
+      linalg.yield %bmm_accum : !accum_type
+  } -> !accum_tensor_type
 
-  util.return %result : !c_tensor_type
-}}
+  // Cast.
+  %result_cast_empty = tensor.empty(%batch0, %m) : !c_tensor_type
+  %result_cast = linalg.copy
+    ins(%result : !accum_tensor_type)
+    outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
+  util.return %result_cast : !c_tensor_type
+}
 
-}}
+}

--- a/sharktank/sharktank/ops/templates/mmtfp_2d.mlir
+++ b/sharktank/sharktank/ops/templates/mmtfp_2d.mlir
@@ -6,27 +6,33 @@
 
 !a_type = {a_type}
 !bT_type = {bT_type}
+!accum_type = {accum_type}
 !a_tensor_type = tensor<?x{k}x!a_type>
 !bT_tensor_type = tensor<{n}x{k}x!bT_type>
+!accum_tensor_type = tensor<?x{n}x!accum_type>
 !c_tensor_type = tensor<?x{n}x!a_type>
 
 module {{
 
-util.func private @sharktank_mmtfp_2d_{n}_{k}_{a_type}{bT_type}(
+util.func private @sharktank_mmtfp_2d_{n}_{k}_{a_type}{bT_type}{accum_type}(
     %a: !a_tensor_type, %bT: !bT_tensor_type)
     -> !c_tensor_type {{
-  %zero = arith.constant 0.000000e+00 : {a_type}
+  %zero = arith.constant 0.000000e+00 : !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %m = tensor.dim %a, %c0 : !a_tensor_type
-  %result_empty = tensor.empty(%m) : !c_tensor_type
+  %result_empty = tensor.empty(%m) : !accum_tensor_type
   %result_init = linalg.fill
-    ins(%zero : {a_type})
-    outs(%result_empty: !c_tensor_type) -> !c_tensor_type
-  %result = linalg.matmul_transpose_b
+    ins(%zero : !accum_type)
+    outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
+  %result_accum = linalg.matmul_transpose_b
     ins (%a, %bT: !a_tensor_type, !bT_tensor_type)
-    outs (%result_init: !c_tensor_type) -> !c_tensor_type
-  util.return %result : !c_tensor_type
+    outs (%result_init: !accum_tensor_type) -> !accum_tensor_type
+  %result_cast_empty = tensor.empty(%m) : !c_tensor_type
+  %result_cast = linalg.copy
+    ins(%result_accum : !accum_tensor_type)
+    outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
+  util.return %result_cast : !c_tensor_type
 }}
 
 }}

--- a/sharktank/sharktank/ops/templates/mmtfp_2d.mlir
+++ b/sharktank/sharktank/ops/templates/mmtfp_2d.mlir
@@ -4,19 +4,19 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!a_type = {a_type}
-!bT_type = {bT_type}
-!accum_type = {accum_type}
-!a_tensor_type = tensor<?x{k}x!a_type>
-!bT_tensor_type = tensor<{n}x{k}x!bT_type>
-!accum_tensor_type = tensor<?x{n}x!accum_type>
-!c_tensor_type = tensor<?x{n}x!a_type>
+!a_type = {{a_type}}
+!bT_type = {{bT_type}}
+!accum_type = {{accum_type}}
+!a_tensor_type = tensor<?x{{k}}x!a_type>
+!bT_tensor_type = tensor<{{n}}x{{k}}x!bT_type>
+!accum_tensor_type = tensor<?x{{n}}x!accum_type>
+!c_tensor_type = tensor<?x{{n}}x!a_type>
 
-module {{
+module {
 
-util.func private @sharktank_mmtfp_2d_{n}_{k}_{a_type}{bT_type}{accum_type}(
+util.func private @sharktank_mmtfp_2d_{{n}}_{{k}}_{{a_type}}{{bT_type}}{{accum_type}}(
     %a: !a_tensor_type, %bT: !bT_tensor_type)
-    -> !c_tensor_type {{
+    -> !c_tensor_type {
   %zero = arith.constant 0.000000e+00 : !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -33,6 +33,6 @@ util.func private @sharktank_mmtfp_2d_{n}_{k}_{a_type}{bT_type}{accum_type}(
     ins(%result_accum : !accum_tensor_type)
     outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
   util.return %result_cast : !c_tensor_type
-}}
+}
 
-}}
+}

--- a/sharktank/sharktank/ops/templates/mmtfp_3d.mlir
+++ b/sharktank/sharktank/ops/templates/mmtfp_3d.mlir
@@ -6,17 +6,19 @@
 
 !a_type = {a_type}
 !bT_type = {bT_type}
+!accum_type = {accum_type}
 !a_tensor_type = tensor<?x?x{k}x!a_type>
 !bT_tensor_type = tensor<{n}x{k}x!bT_type>
+!accum_tensor_type = tensor<?x?x{n}x!accum_type>
 !c_tensor_type = tensor<?x?x{n}x!a_type>
 !bT_broadcast_tensor_type = tensor<?x{n}x{k}x!bT_type>
 
 module {{
 
-util.func private @sharktank_mmtfp_3d_{n}_{k}_{a_type}{bT_type}(
+util.func private @sharktank_mmtfp_3d_{n}_{k}_{a_type}{bT_type}{accum_type}(
     %a: !a_tensor_type, %bT: !bT_tensor_type)
     -> !c_tensor_type {{
-  %zero = arith.constant 0.000000e+00 : !a_type
+  %zero = arith.constant 0.000000e+00 : !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %b0 = tensor.dim %a, %c0 : !a_tensor_type
@@ -33,14 +35,18 @@ util.func private @sharktank_mmtfp_3d_{n}_{k}_{a_type}{bT_type}(
       ^bb0(%in: !bT_type, %out: !bT_type):
         linalg.yield %in : !bT_type
     }} -> !bT_broadcast_tensor_type
-  %result_empty = tensor.empty(%b0, %m) : !c_tensor_type
+  %result_empty = tensor.empty(%b0, %m) : !accum_tensor_type
   %result_init = linalg.fill
-    ins(%zero : !a_type)
-    outs(%result_empty: !c_tensor_type) -> !c_tensor_type
-  %result = linalg.batch_matmul_transpose_b
+    ins(%zero : !accum_type)
+    outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
+  %result_accum = linalg.batch_matmul_transpose_b
     ins (%a, %bT_broadcast: !a_tensor_type, !bT_broadcast_tensor_type)
-    outs (%result_init: !c_tensor_type) -> !c_tensor_type
-  util.return %result : !c_tensor_type
+    outs (%result_init: !accum_tensor_type) -> !accum_tensor_type
+  %result_cast_empty = tensor.empty(%b0, %m) : !c_tensor_type
+  %result_cast = linalg.copy
+    ins(%result_accum : !accum_tensor_type)
+    outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
+  util.return %result_cast : !c_tensor_type
 }}
 
 }}

--- a/sharktank/sharktank/ops/templates/mmtfp_3d.mlir
+++ b/sharktank/sharktank/ops/templates/mmtfp_3d.mlir
@@ -4,37 +4,37 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!a_type = {a_type}
-!bT_type = {bT_type}
-!accum_type = {accum_type}
-!a_tensor_type = tensor<?x?x{k}x!a_type>
-!bT_tensor_type = tensor<{n}x{k}x!bT_type>
-!accum_tensor_type = tensor<?x?x{n}x!accum_type>
-!c_tensor_type = tensor<?x?x{n}x!a_type>
-!bT_broadcast_tensor_type = tensor<?x{n}x{k}x!bT_type>
+!a_type = {{a_type}}
+!bT_type = {{bT_type}}
+!accum_type = {{accum_type}}
+!a_tensor_type = tensor<?x?x{{k}}x!a_type>
+!bT_tensor_type = tensor<{{n}}x{{k}}x!bT_type>
+!accum_tensor_type = tensor<?x?x{{n}}x!accum_type>
+!c_tensor_type = tensor<?x?x{{n}}x!a_type>
+!bT_broadcast_tensor_type = tensor<?x{{n}}x{{k}}x!bT_type>
 
-module {{
+module {
 
-util.func private @sharktank_mmtfp_3d_{n}_{k}_{a_type}{bT_type}{accum_type}(
+util.func private @sharktank_mmtfp_3d_{{n}}_{{k}}_{{a_type}}{{bT_type}}{{accum_type}}(
     %a: !a_tensor_type, %bT: !bT_tensor_type)
-    -> !c_tensor_type {{
+    -> !c_tensor_type {
   %zero = arith.constant 0.000000e+00 : !accum_type
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %b0 = tensor.dim %a, %c0 : !a_tensor_type
   %m = tensor.dim %a, %c1 : !a_tensor_type
   %bT_broadcast_empty = tensor.empty(%b0) : !bT_broadcast_tensor_type
-  %bT_broadcast = linalg.generic {{
+  %bT_broadcast = linalg.generic {
       indexing_maps = [
         affine_map<(d0, d1, d2) -> (d1, d2)>,
         affine_map<(d0, d1, d2) -> (d0, d1, d2)>
       ],
-      iterator_types = ["parallel", "parallel", "parallel"] }}
+      iterator_types = ["parallel", "parallel", "parallel"] }
     ins(%bT: !bT_tensor_type)
-    outs(%bT_broadcast_empty: !bT_broadcast_tensor_type) {{
+    outs(%bT_broadcast_empty: !bT_broadcast_tensor_type) {
       ^bb0(%in: !bT_type, %out: !bT_type):
         linalg.yield %in : !bT_type
-    }} -> !bT_broadcast_tensor_type
+    } -> !bT_broadcast_tensor_type
   %result_empty = tensor.empty(%b0, %m) : !accum_tensor_type
   %result_init = linalg.fill
     ins(%zero : !accum_type)
@@ -47,6 +47,6 @@ util.func private @sharktank_mmtfp_3d_{n}_{k}_{a_type}{bT_type}{accum_type}(
     ins(%result_accum : !accum_tensor_type)
     outs(%result_cast_empty : !c_tensor_type) -> !c_tensor_type
   util.return %result_cast : !c_tensor_type
-}}
+}
 
-}}
+}

--- a/sharktank/tests/ops/mmt_block_scaled_offset_q4_test.py
+++ b/sharktank/tests/ops/mmt_block_scaled_offset_q4_test.py
@@ -40,9 +40,7 @@ class mmt_block_scaled_offset_q4_unsigned_test(unittest.TestCase):
         # Tolerances are empirical and results are not expected to match exactly.
         qs_i8 = layout_utils.promote_linear_i4_block_to_i8(qs)
         b = (d.to(ref_dtype) * qs_i8.to(ref_dtype) + m.to(ref_dtype)).flatten(1)
-        print(b)
         ref = torch.matmul(a.to(ref_dtype), b.T.to(ref_dtype))
-        print(ref)
         torch.testing.assert_close(result.to(ref_dtype), ref, atol=atol, rtol=rtol)
 
     def testExportDynamicDims(self):

--- a/sharktank/tests/ops/mmt_block_scaled_offset_q4_test.py
+++ b/sharktank/tests/ops/mmt_block_scaled_offset_q4_test.py
@@ -9,6 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 import unittest
+from parameterized import parameterized
 
 import torch
 
@@ -21,18 +22,28 @@ class mmt_block_scaled_offset_q4_unsigned_test(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)
 
-    def test_basic(self):
-        a = torch.rand([4, 16, 3200], dtype=torch.float32)
-        d = torch.rand([3200, 100, 1], dtype=torch.float16)
-        qs = (torch.rand([3200, 100, 16], dtype=torch.float32) * 32).to(torch.uint8)
-        m = torch.rand([3200, 100, 1], dtype=torch.float16)
+    @parameterized.expand(
+        [
+            (torch.float32, torch.float32, torch.float32, 1e-2, 1e-3),
+            (torch.float32, torch.float16, torch.float32, 1e-2, 1e-3),
+            (torch.float16, torch.float16, torch.float32, 1e-2, 1e-3),
+        ]
+    )
+    def test_basic(self, a_dtype, d_dtype, ref_dtype, atol, rtol):
+        a = torch.rand([4, 16, 3200], dtype=a_dtype) / 256.0
+        d = torch.rand([3200, 100, 1], dtype=d_dtype) / 256.0
+        qs = (torch.rand([3200, 100, 16], dtype=ref_dtype) * 255.0).to(torch.uint8)
+        m = torch.rand([3200, 100, 1], dtype=d_dtype) + 16.0
         result = ops.mmt_block_scaled_offset_q4_unsigned(a, d, qs, m)
 
         # Dequantize and test with normal matmul.
         # Tolerances are empirical and results are not expected to match exactly.
         qs_i8 = layout_utils.promote_linear_i4_block_to_i8(qs)
-        b = (d.to(torch.float32) * qs_i8.to(torch.float32) + m).flatten(1)
-        torch.testing.assert_close(result, torch.matmul(a, b.T), atol=1e-1, rtol=1e-5)
+        b = (d.to(ref_dtype) * qs_i8.to(ref_dtype) + m.to(ref_dtype)).flatten(1)
+        print(b)
+        ref = torch.matmul(a.to(ref_dtype), b.T.to(ref_dtype))
+        print(ref)
+        torch.testing.assert_close(result.to(ref_dtype), ref, atol=atol, rtol=rtol)
 
     def testExportDynamicDims(self):
         class MyModule(torch.nn.Module):

--- a/sharktank/tests/ops/mmtfp_test.py
+++ b/sharktank/tests/ops/mmtfp_test.py
@@ -9,6 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 import unittest
+from parameterized import parameterized
 
 import torch
 
@@ -20,17 +21,35 @@ class mmtfp_test(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)
 
-    def test2DF32(self):
-        a = torch.rand([128, 32], dtype=torch.float32)
-        b = torch.rand([256, 32], dtype=torch.float32)
+    @parameterized.expand(
+        [
+            (torch.float32, torch.float32, torch.float32),
+            (torch.float16, torch.float16, torch.float16),
+            (torch.float16, torch.float32, torch.float16),
+            (torch.float32, torch.float16, torch.float32),
+        ]
+    )
+    def test2D(self, a_dtype, b_dtype, ref_dtype):
+        a = torch.rand([128, 32], dtype=a_dtype)
+        b = torch.rand([256, 32], dtype=b_dtype)
         result = ops.mmtfp(a, b)
-        torch.testing.assert_close(result, torch.matmul(a, b.T))
+        ref = torch.matmul(a.to(ref_dtype), b.T.to(ref_dtype)).to(a_dtype)
+        torch.testing.assert_close(result, ref)
 
-    def test3DF32(self):
-        a = torch.rand([4, 128, 32], dtype=torch.float32)
-        b = torch.rand([256, 32], dtype=torch.float32)
+    @parameterized.expand(
+        [
+            (torch.float32, torch.float32, torch.float32),
+            (torch.float16, torch.float16, torch.float16),
+            (torch.float16, torch.float32, torch.float16),
+            (torch.float32, torch.float16, torch.float32),
+        ]
+    )
+    def test3DF(self, a_dtype, b_dtype, ref_dtype):
+        a = torch.rand([4, 128, 32], dtype=a_dtype)
+        b = torch.rand([256, 32], dtype=b_dtype)
         result = ops.mmtfp(a, b)
-        torch.testing.assert_close(result, torch.matmul(a, b.T))
+        ref = torch.matmul(a.to(ref_dtype), b.T.to(ref_dtype)).to(a_dtype)
+        torch.testing.assert_close(result, ref)
 
     def testExportDynamicDims(self):
         class MyModule(torch.nn.Module):


### PR DESCRIPTION
* Reworks all layers to respect declared activation/attention dtypes.
* Defaults normalization layers to promote to f32.
* Reworks all custom kernels to support mixed data types.
  * Adds parameterized tests for dtype combinations.
  * Switches template engine from str.format to jinja2 (this has been planned from the get-go and it was needed to handle switchiness due to dtype changes).
* Verified that inference works with `--activation-dtype float16`.

New deps added: parameterized, jinja2