### PR TITLE
Migrate dep from SHARK-Turbine to iree-turbine git repo.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
+            -e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
       - name: Run sharktank tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"
+            -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
       - name: Run sharktank tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/nod-ai/SHARK-Turbine.git#egg=SHARK-Turbine&subdirectory=core"
+            -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
       - name: Run sharktank tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -r pytorch-rocm-requirements.txt
 ```
 # Clone and install editable iree-turbine dep in deps/
 pip install -f https://iree.dev/pip-release-links.html --src deps \
-  -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
+  -e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"
 
 # Install editable local projects.
 pip install -r requirements.txt -e sharktank/ shortfin/

--- a/README.md
+++ b/README.md
@@ -42,16 +42,13 @@ pip install -r pytorch-rocm-requirements.txt
 
 ### Install Development Packages
 
-This assumes you have `SHARK-Turbine` checked out adjacent (note that for the
-moment we rely on pre-release versions, so installation is a bit harder).
-
 ```
-# Clone and install editable SHARK-Turbine dep in deps/
+# Clone and install editable iree-turbine dep in deps/
 pip install -f https://iree.dev/pip-release-links.html --src deps \
-  -e "git+https://github.com/nod-ai/SHARK-Turbine.git#egg=SHARK-Turbine&subdirectory=core"
+  -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
 
 # Install editable local projects.
-pip install -r requirements -e sharktank/ shortfin/
+pip install -r requirements.txt -e sharktank/ shortfin/
 ```
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -r pytorch-rocm-requirements.txt
 ```
 # Clone and install editable iree-turbine dep in deps/
 pip install -f https://iree.dev/pip-release-links.html --src deps \
-  -e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"
+  -e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
 
 # Install editable local projects.
 pip install -r requirements.txt -e sharktank/ shortfin/

--- a/sharktank/setup.py
+++ b/sharktank/setup.py
@@ -92,7 +92,7 @@ setup(
     packages=packages,
     package_data={"sharktank": ["py.typed"]},
     install_requires=[
-        "shark-turbine",
+        "iree-turbine",
     ],
     extras_require={
         "testing": [

--- a/sharktank/setup.py
+++ b/sharktank/setup.py
@@ -92,7 +92,7 @@ setup(
     packages=packages,
     package_data={"sharktank": ["py.typed"]},
     install_requires=[
-        "iree-turbine",
+        "shark-turbine",
     ],
     extras_require={
         "testing": [

--- a/turbine-requirements.txt
+++ b/turbine-requirements.txt
@@ -1,1 +1,1 @@
--e "git+https://github.com/nod-ai/SHARK-Turbine.git#egg=SHARK-Turbine&subdirectory=core"
+-e "git+https://github.com/nod-ai/iree-turbine.git#egg=SHARK-Turbine"

--- a/turbine-requirements.txt
+++ b/turbine-requirements.txt
@@ -1,1 +1,1 @@
--e "git+https://github.com/nod-ai/iree-turbine.git#egg=SHARK-Turbine"
+-e "git+https://github.com/nod-ai/iree-turbine.git#egg=shark-turbine"

--- a/turbine-requirements.txt
+++ b/turbine-requirements.txt
@@ -1,1 +1,1 @@
--e "git+https://github.com/nod-ai/iree-turbine.git#egg=SHARK-Turbine"
+-e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"

--- a/turbine-requirements.txt
+++ b/turbine-requirements.txt
@@ -1,1 +1,1 @@
--e "git+https://github.com/iree-org/iree-turbine.git#egg=SHARK-Turbine"
+-e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"

--- a/turbine-requirements.txt
+++ b/turbine-requirements.txt
@@ -1,1 +1,1 @@
--e "git+https://github.com/nod-ai/iree-turbine.git#egg=shark-turbine"
+-e "git+https://github.com/nod-ai/iree-turbine.git#egg=SHARK-Turbine"


### PR DESCRIPTION
The main project moved from https://github.com/nod-ai/SHARK-Turbine/ to https://github.com/iree-org/iree-turbine. Some package names and import paths still need to be migrated.

The package name is still "shark-turbine", even when using the "iree-turbine" repo.