### PR TITLE
Remove repeated copyright header from validate_llama_ref_model.py.

### DIFF
--- a/sharktank/sharktank/examples/validate_llama_ref_model.py
+++ b/sharktank/sharktank/examples/validate_llama_ref_model.py
@@ -4,12 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Copyright 2024 Advanced Micro Devices, Inc
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 import sys
 
 import torch


### PR DESCRIPTION
This file had the copyright header twice.