### PR TITLE
Allow files with multiple suffixes in dataset loading helper.

### DIFF
--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -597,7 +597,7 @@ def _dataset_load_helper(
         from . import gguf_interop
 
         return gguf_interop.load_file(path)
-    elif file_type == "irpa" or suffixes == [".irpa"]:
+    elif file_type == "irpa" or suffixes[-1] == ".irpa":
         return _dataset_load_irpa(path, mmap=mmap)
     else:
         raise IOError(

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -593,7 +593,7 @@ def _dataset_load_helper(
 ) -> Dataset:
     path = Path(path)
     suffixes = path.suffixes
-    if file_type == "gguf" or suffixes == [".gguf"]:
+    if file_type == "gguf" or suffixes[-1] == ".gguf":
         from . import gguf_interop
 
         return gguf_interop.load_file(path)


### PR DESCRIPTION
Some GGUF files have names like [`mistral-7b-v0.1.Q8_0.gguf`](https://huggingface.co/TheBloke/Mistral-7B-v0.1-GGUF/tree/main). for which `Path.suffixes` returns a list like `['.1', '.Q8_0', '.gguf']`. We can check the last element of the suffix list to support both `foo.gguf` and `foo.bar.baz.gguf`.