### PR TITLE
Add `--output` argument to `export_paged_llm_v1.py`.

### DIFF
--- a/sharktank/README.md
+++ b/sharktank/README.md
@@ -29,7 +29,9 @@ python -m sharktank.examples.paged_llm_v1 \
 ### Export an IREE compilable batched LLM for serving:
 
 ```shell
-python -m sharktank.examples.export_paged_llm_v1 --hf-dataset=open_llama_3b_v2_f16_gguf
+python -m sharktank.examples.export_paged_llm_v1 \
+  --hf-dataset=open_llama_3b_v2_f16_gguf \
+  --output=/tmp/open_llama_3b_v2_f16.mlir
 ```
 
 ### Dump parsed information about a model from a gguf file:

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -22,6 +22,11 @@ def main():
 
     parser = cli.create_parser()
     cli.add_gguf_dataset_options(parser)
+    parser.add_argument(
+        "--output",
+        help="Output file path for exported MLIR file",
+        default="/tmp/batch_llama_v1.mlir",
+    )
     args = cli.parse(parser)
 
     data_files = cli.get_gguf_data_files(args)
@@ -132,8 +137,8 @@ def main():
 
     print("Exporting")
     output = export(fxb)
-    print("Saving")
-    output.save_mlir("/tmp/batch_llama_v1.mlir")
+    print(f"Saving to '{args.output}'")
+    output.save_mlir(args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This helps when changing the script, exporting multiple versions, or using different inputs (via the `--hf-dataset` or `--gguf-file` input flags).