### PR TITLE
Add support for tensor parallel sharding of datasets.

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -21,16 +21,14 @@ def main():
     from ..utils import cli
 
     parser = cli.create_parser()
-    cli.add_gguf_dataset_options(parser)
+    cli.add_input_dataset_options(parser)
     parser.add_argument(
         "--output",
         help="Output file path for exported MLIR file",
         default="/tmp/batch_llama_v1.mlir",
     )
     args = cli.parse(parser)
-
-    data_files = cli.get_gguf_data_files(args)
-    dataset = Dataset.load(data_files["gguf"])
+    dataset = cli.get_input_dataset(args)
 
     hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
     model = PagedLlamaModelV1(dataset.root_theta, LlamaModelConfig(hp))

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -213,16 +213,15 @@ def main():
         help="DType to use for activations in the model",
         default="float32",
     )
-    cli.add_gguf_dataset_options(parser)
+    cli.add_input_dataset_options(parser)
     cli.add_tokenizer_options(parser)
     args = cli.parse(parser)
 
     device = torch.device(args.device) if args.device else None
     activation_dtype = getattr(torch, args.activation_dtype)
     assert isinstance(activation_dtype, torch.dtype)
-    data_files = cli.get_gguf_data_files(args)
-    tokenizer = cli.get_tokenizer(args, data_files=data_files)
-    dataset = Dataset.load(data_files["gguf"], device=device)
+    dataset = cli.get_input_dataset(args)
+    tokenizer = cli.get_tokenizer(args)
     prompts = args.prompt
 
     config = LlamaModelConfig(

--- a/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
+++ b/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
@@ -10,73 +10,20 @@ This is an ad-hoc transformation which operates on the layer structure of
 weights of an LLM by converting the RHS of all eligible layers to a sharded
 form.
 """
-from typing import Optional, Union
-
-import re
-
+from ...transforms.dataset import MmtRHSShardingTransform
 from ...types import *
 
 
-# TODO: Remove this in favor of real logging once we have the setup right for CLI work.
-def _log(message, *args):
-    formatted = message % args
-    print(formatted)
-
-
-class MmtRHSShardingTransform:
-    def __init__(
-        self,
-        *patterns: Union[str, re.Pattern],
-        num_shards: int,
-        skip_on_unsupported: bool = True,
-    ):
-        self.patterns = patterns
-        self.num_shards = num_shards
-        self.skip_on_unsupported = skip_on_unsupported
-
-    def __call__(self, it: InferenceTensor):
-        name = it.name
-        if not any(re.match(p, name) for p in self.patterns):
-            return it
-        if isinstance(it, PrimitiveTensor):
-            sharded = self._shard_primitive_tensor(it)
-            if sharded is not None:
-                return sharded
-
-        if self.skip_on_unsupported:
-            _log("Skipping unsupported tensor: %r", it)
-            return it
-        else:
-            raise ValueError(f"Unsupporting sharding for tensor: {it}")
-
-    def _shard_primitive_tensor(
-        self, pt: PrimitiveTensor
-    ) -> Optional[list[PrimitiveTensor]]:
-        t = pt.as_torch()
-        shape = list(t.shape)
-        if len(shape) < 2:
-            return None
-        shard_dim = 1
-        shard_dim_size = shape[shard_dim]
-        if (shard_dim_size % self.num_shards) != 0:
-            return None
-        shard_split_size = shard_dim_size // self.num_shards
-        shard_ts = t.split(shard_split_size, dim=shard_dim)
-        st = ShardedPrimitiveTensor(pt.name, pt.shape, shard_dim, shard_ts)
-        _log("Sharding tensor %r -> %r", pt, st)
-        return st
-
-    def __repr__(self):
-        return f"ShardingTransform()"
-
-
-def main():
+def main(raw_args=None):
     from ...utils import cli
 
     parser = cli.create_parser()
     cli.add_input_dataset_options(parser)
     cli.add_output_dataset_options(parser)
-    args = cli.parse(parser)
+    parser.add_argument(
+        "--num-shards", type=int, required=True, help="Number of shards to split"
+    )
+    args = cli.parse(parser, args=raw_args)
     dataset = cli.get_input_dataset(args)
 
     tr = MmtRHSShardingTransform(

--- a/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
+++ b/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shards an LLM dataset.
+
+This is an ad-hoc transformation which operates on the layer structure of
+weights of an LLM by converting the RHS of all eligible layers to a sharded
+form.
+"""
+from typing import Optional, Union
+
+import re
+
+from ...types import *
+
+
+# TODO: Remove this in favor of real logging once we have the setup right for CLI work.
+def _log(message, *args):
+    formatted = message % args
+    print(formatted)
+
+
+class MmtRHSShardingTransform:
+    def __init__(
+        self,
+        *patterns: Union[str, re.Pattern],
+        num_shards: int,
+        skip_on_unsupported: bool = True,
+    ):
+        self.patterns = patterns
+        self.num_shards = num_shards
+        self.skip_on_unsupported = skip_on_unsupported
+
+    def __call__(self, it: InferenceTensor):
+        name = it.name
+        if not any(re.match(p, name) for p in self.patterns):
+            return it
+        if isinstance(it, PrimitiveTensor):
+            sharded = self._shard_primitive_tensor(it)
+            if sharded is not None:
+                return sharded
+
+        if self.skip_on_unsupported:
+            _log("Skipping unsupported tensor: %r", it)
+            return it
+        else:
+            raise ValueError(f"Unsupporting sharding for tensor: {it}")
+
+    def _shard_primitive_tensor(
+        self, pt: PrimitiveTensor
+    ) -> Optional[list[PrimitiveTensor]]:
+        t = pt.as_torch()
+        shape = list(t.shape)
+        if len(shape) < 2:
+            return None
+        shard_dim = 1
+        shard_dim_size = shape[shard_dim]
+        if (shard_dim_size % self.num_shards) != 0:
+            return None
+        shard_split_size = shard_dim_size // self.num_shards
+        shard_ts = t.split(shard_split_size, dim=shard_dim)
+        st = ShardedPrimitiveTensor(pt.name, pt.shape, shard_dim, shard_ts)
+        _log("Sharding tensor %r -> %r", pt, st)
+        return st
+
+    def __repr__(self):
+        return f"ShardingTransform()"
+
+
+def main():
+    from ...utils import cli
+
+    parser = cli.create_parser()
+    cli.add_input_dataset_options(parser)
+    cli.add_output_dataset_options(parser)
+    args = cli.parse(parser)
+    dataset = cli.get_input_dataset(args)
+
+    tr = MmtRHSShardingTransform(
+        r"^blk\.[0-9]+\.(attn_k|attn_q|attn_v|ffn_gate|ffn_up|ffn_down)\.weight$",
+        num_shards=8,
+    )
+    dataset.transform(tr)
+    dataset.save(args.output_irpa_file, io_report_callback=print)
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/sharktank/examples/validate_llama_ref_model.py
+++ b/sharktank/sharktank/examples/validate_llama_ref_model.py
@@ -19,11 +19,9 @@ def main(args: list[str]):
     torch.no_grad().__enter__()
 
     parser = cli.create_parser()
-    cli.add_gguf_dataset_options(parser)
+    cli.add_input_dataset_options(parser)
     args = cli.parse(parser)
-
-    data_files = cli.get_gguf_data_files(args)
-    config = Dataset.load(data_files["gguf"])
+    config = cli.get_input_dataset(args)
     hp = configs.LlamaHParams.from_gguf_props(config.properties)
     model = DirectCacheLlamaModelV1(config.root_theta, hp)
 

--- a/sharktank/sharktank/transforms/dataset/__init__.py
+++ b/sharktank/sharktank/transforms/dataset/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .sharding import *

--- a/sharktank/sharktank/transforms/dataset/sharding.py
+++ b/sharktank/sharktank/transforms/dataset/sharding.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional, Union
+
+import re
+
+from ...types import *
+from ...utils.logging import transform_logger as logger
+
+__all__ = [
+    "MmtRHSShardingTransform",
+]
+
+
+class MmtRHSShardingTransform:
+    """Shards tensors used as the RHS of a transposed matmul.
+
+    Tensors matching any of the patterns will be sharded, if supported, into
+    `num_shards`.
+    """
+
+    def __init__(
+        self,
+        *patterns: Union[str, re.Pattern],
+        num_shards: int,
+        skip_on_unsupported: bool = True,
+    ):
+        self.patterns = patterns
+        self.num_shards = num_shards
+        self.skip_on_unsupported = skip_on_unsupported
+
+    def __call__(self, it: InferenceTensor):
+        name = it.name
+        if not any(re.match(p, name) for p in self.patterns):
+            return it
+        if isinstance(it, PrimitiveTensor):
+            sharded = self._shard_primitive_tensor(it)
+            if sharded is not None:
+                return sharded
+
+        if self.skip_on_unsupported:
+            logger.debug("Skipping unsupported tensor: %r", it)
+            return it
+        else:
+            raise ValueError(f"Unsupporting sharding for tensor: {it}")
+
+    def _shard_primitive_tensor(
+        self, pt: PrimitiveTensor
+    ) -> Optional[list[PrimitiveTensor]]:
+        t = pt.as_torch()
+        shape = list(t.shape)
+        if len(shape) < 2:
+            return None
+        shard_dim = 1
+        shard_dim_size = shape[shard_dim]
+        if (shard_dim_size % self.num_shards) != 0:
+            return None
+        shard_split_size = shard_dim_size // self.num_shards
+        shard_ts = t.split(shard_split_size, dim=shard_dim)
+        st = ShardedPrimitiveTensor(pt.name, pt.shape, shard_dim, shard_ts)
+        logger.debug("Sharding tensor %r -> %r", pt, st)
+        return st
+
+    def __repr__(self):
+        return (
+            f"ShardingTransform(num_shards={self.num_shards}, patterns={self.patterns})"
+        )

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -498,11 +498,11 @@ class DatasetMetadata:
         # __SHARK_SHARD_RANKS__ list.
         if self.shard_ranks:
             shard_ranks_blob = json.dumps(self.shard_ranks)
-        if io_report_callback:
-            io_report_callback(
-                f"Add __SHARK_SHARD_RANKS__: {shard_ranks_blob.encode()}"
-            )
-        builder.add_blob("__SHARK_SHARD_RANKS__", shard_ranks_blob.encode())
+            if io_report_callback:
+                io_report_callback(
+                    f"Add __SHARK_SHARD_RANKS__: {shard_ranks_blob.encode()}"
+                )
+            builder.add_blob("__SHARK_SHARD_RANKS__", shard_ranks_blob.encode())
 
         # __SHARK_INFERENCE_TENSORS__ blob.
         try:

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -19,8 +19,9 @@ from shark_turbine.aot import (
     ExternalTensorTrait,
     ParameterArchive,
     ParameterArchiveEntry,
-    ParameterArchiveBuilder,
 )
+
+from ..utils.io import ShardedArchiveBuilder
 
 from .tensors import (
     InferenceTensor,
@@ -54,7 +55,9 @@ IOReportCallback = Callable[[str], None]
 # implementation for operating on the InferenceTensors.
 ################################################################################
 
-InferenceTensorTransform = Callable[[InferenceTensor], InferenceTensor]
+InferenceTensorTransform = Callable[
+    [InferenceTensor], Union[None, InferenceTensor, Sequence[InferenceTensor]]
+]
 
 
 class InferenceTensorTransforms:
@@ -103,12 +106,19 @@ class Theta:
         Returns a modified theta.
         """
         orig_flat_tensors = self.flatten().values()
-        tran_flat_tensors = []
-        for it in orig_flat_tensors:
-            for transform in transforms:
-                it = transform(it)
-            tran_flat_tensors.append(it)
-        return Theta(tran_flat_tensors)
+        for transform in transforms:
+            tran_flat_tensors = []
+            for it in orig_flat_tensors:
+                results = transform(it)
+                if results is None:
+                    continue
+                if isinstance(results, InferenceTensor):
+                    tran_flat_tensors.append(results)
+                else:
+                    tran_flat_tensors.extend(results)
+            orig_flat_tensors = tran_flat_tensors
+
+        return Theta(orig_flat_tensors)
 
     def to(self, *, device: Optional[Union[str, torch.device]] = None) -> "Theta":
         return self.transform(InferenceTensorTransforms.to_device(device))
@@ -163,7 +173,7 @@ class Theta:
 
     def add_tensors_to_archive(
         self,
-        irpa: ParameterArchiveBuilder,
+        irpa: "ShardedArchiveBuilder",
         inference_tensor_metas: dict[str, InferenceTensorMetadata],
         *,
         io_report_callback: Optional[IOReportCallback] = None,
@@ -456,10 +466,11 @@ class DatasetMetadata:
 
     properties: dict
     inference_tensors: dict[str, InferenceTensorMetadata]
+    shard_ranks: tuple[int] = ()
 
     def save(
         self,
-        builder: ParameterArchiveBuilder,
+        builder: ShardedArchiveBuilder,
         *,
         io_report_callback: Optional[IOReportCallback] = None,
     ):
@@ -484,6 +495,15 @@ class DatasetMetadata:
             )
         builder.add_blob("__SHARK_DATASET__", properties_json_blob.encode())
 
+        # __SHARK_SHARD_RANKS__ list.
+        if self.shard_ranks:
+            shard_ranks_blob = json.dumps(self.shard_ranks)
+        if io_report_callback:
+            io_report_callback(
+                f"Add __SHARK_SHARD_RANKS__: {shard_ranks_blob.encode()}"
+            )
+        builder.add_blob("__SHARK_SHARD_RANKS__", shard_ranks_blob.encode())
+
         # __SHARK_INFERENCE_TENSORS__ blob.
         try:
             inference_tensors_blob = json.dumps(inference_tensors_object, indent=2)
@@ -499,8 +519,7 @@ class DatasetMetadata:
             )
         builder.add_blob("__SHARK_INFERENCE_TENSORS__", inference_tensors_blob.encode())
 
-    @staticmethod
-    def load(entries: dict[str, ParameterArchiveEntry]) -> "DatasetMetadata":
+    def load_metadata(self, entries: dict[str, ParameterArchiveEntry]):
         # Load properties.
         try:
             properties_entry = entries["__SHARK_DATASET__"]
@@ -510,7 +529,18 @@ class DatasetMetadata:
             )
         properties_obj = json.loads(bytes(properties_entry.raw.file_view))
         assert isinstance(properties_obj, dict)
+        self.properties.update(properties_obj)
 
+        # __SHARK_SHARD_RANKS__
+        shard_ranks_entry = entries.get("__SHARK_SHARD_RANKS__")
+        if shard_ranks_entry is not None:
+            shark_ranks_obj = json.loads(bytes(shard_ranks_entry.raw.file_view))
+            assert isinstance(shark_ranks_obj, list) and all(
+                isinstance(i, int) for i in shark_ranks_obj
+            )
+            self.shard_ranks = tuple(shark_ranks_obj)
+
+    def load_tensors(self, entries: dict[str, ParameterArchiveEntry]):
         # Load inference tensors.
         try:
             inference_tensors_entry = entries["__SHARK_INFERENCE_TENSORS__"]
@@ -521,7 +551,7 @@ class DatasetMetadata:
         inference_tensors_obj = json.loads(bytes(inference_tensors_entry.raw.file_view))
         assert isinstance(inference_tensors_obj, dict)
 
-        inference_tensors: dict[str, InferenceTensorMetadata] = {}
+        inference_tensors = self.inference_tensors
         for tensor_name, tensor_meta_obj in inference_tensors_obj.items():
             tensor_meta = InferenceTensorMetadata.from_json(tensor_meta_obj)
             # Map the raw_tensors dict to tensors from the archive.
@@ -556,8 +586,6 @@ class DatasetMetadata:
             )
             inference_tensors[tensor_name] = inference_tensor
 
-        return DatasetMetadata(properties_obj, inference_tensors)
-
 
 def _dataset_save_helper(
     dataset: Dataset,
@@ -565,24 +593,22 @@ def _dataset_save_helper(
     *,
     io_report_callback: Optional[IOReportCallback] = None,
 ):
-    builder = ParameterArchiveBuilder()
+    builder = ShardedArchiveBuilder(Path(path))
     ds_meta = DatasetMetadata(dict(dataset.properties), {})
     # Add tensors.
-    # TODO: We need some form of streaming save upstream and then use that.
-    # For computed tensors, the memory overhead of this style is large
-    # because intermediates are retained until the `builder.save()`.
     dataset.root_theta.add_tensors_to_archive(
         builder,
         ds_meta.inference_tensors,
         io_report_callback=io_report_callback,
     )
+    ds_meta.shard_ranks = tuple(builder._rank_builders.keys())
 
-    # Serialize the metadata.
+    # Add metadata.
     ds_meta.save(builder, io_report_callback=io_report_callback)
 
     if io_report_callback:
         io_report_callback("Saving file")
-    builder.save(path)
+    builder.commit()
 
 
 def _dataset_load_helper(
@@ -606,9 +632,21 @@ def _dataset_load_helper(
 
 
 def _dataset_load_irpa(path: Path, mmap: bool) -> Dataset:
+    # Need to load in two phases: first read metadata from the root archive.
+    meta = DatasetMetadata(properties={}, inference_tensors={})
     archive = ParameterArchive(path, mmap=mmap)
-    # Note that there may be duplicates. Last wins.
     entries = {k: v for k, v in archive.items()}
-    meta = DatasetMetadata.load(entries)
+    meta.load_metadata(entries)
+
+    # Then we know what side-car rank archives should exist, so load those.
+    for rank in meta.shard_ranks:
+        rank_path = ShardedArchiveBuilder.path_for_rank(path, rank)
+        archive.load(rank_path, mmap=mmap)
+
+    # Finally, load all inference tensors.
+    entries = {k: v for k, v in archive.items()}
+    meta.load_tensors(entries)
+
+    # Note that there may be duplicates. Last wins.
     dataset = Dataset(meta.properties, Theta(meta.inference_tensors))
     return dataset

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -37,7 +37,7 @@ def parse(parser: argparse.ArgumentParser):
 def add_input_dataset_options(parser: argparse.ArgumentParser):
     """Adds options to load a GGUF dataset.
 
-    Either the `--hf-dataset` or `--gguf-file` argument can be present.
+    Either the `--hf-dataset`, `--gguf-file`, or `--irpa-file` argument can be present.
     """
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -9,7 +9,10 @@
 from typing import Dict, Optional
 
 import argparse
+import logging
 from pathlib import Path
+
+from ..types import Dataset
 
 from . import hf_datasets
 from . import tokenizer
@@ -22,16 +25,16 @@ def create_parser(
     description: Optional[str] = None,
 ) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog=prog, usage=usage, description=description)
-
     return parser
 
 
 def parse(parser: argparse.ArgumentParser):
     """Parses arguments and does any prescribed global process setup."""
-    return parser.parse_args()
+    args = parser.parse_args()
+    return args
 
 
-def add_gguf_dataset_options(parser: argparse.ArgumentParser):
+def add_input_dataset_options(parser: argparse.ArgumentParser):
     """Adds options to load a GGUF dataset.
 
     Either the `--hf-dataset` or `--gguf-file` argument can be present.
@@ -42,6 +45,20 @@ def add_gguf_dataset_options(parser: argparse.ArgumentParser):
         help=f"HF dataset to use (available: {list(hf_datasets.ALL_DATASETS.keys())})",
     )
     group.add_argument("--gguf-file", type=Path, help="GGUF file to load")
+    group.add_argument("--irpa-file", type=Path, help="IRPA file to load")
+
+
+def add_output_dataset_options(parser: argparse.ArgumentParser):
+    """Adds options to save a dataset.
+
+    This will result in the --output-irpa-file argument being added.
+    """
+    parser.add_argument(
+        "--output-irpa-file",
+        type=Path,
+        required=True,
+        help="IRPA file to save dataset to",
+    )
 
 
 def add_tokenizer_options(parser: argparse.ArgumentParser):
@@ -60,34 +77,46 @@ def add_tokenizer_options(parser: argparse.ArgumentParser):
     )
 
 
-def get_gguf_data_files(args) -> Dict[str, Path]:
-    """Gets the path to the gguf file for the dataset."""
+def get_input_data_files(args) -> Optional[dict[str, Path]]:
+    """Gets data files given the input arguments.
+
+    Keys may contain:
+      * tokenizer_config.json
+      * gguf
+      * irpa
+    """
     if args.hf_dataset is not None:
         dataset = hf_datasets.get_dataset(args.hf_dataset).download()
-        if "gguf" not in dataset:
-            raise ValueError(
-                f"Argument --hf-dataset refers to a dataset that does not contain a "
-                f"gguf file ({dataset})"
-            )
         return dataset
-    else:
+    elif args.gguf_file is not None:
         return {"gguf": args.gguf_file}
+    elif args.irpa_file is not None:
+        return {"irpa": args.irpa_file}
 
 
-def get_tokenizer(
-    args, *, data_files: Optional[Dict[str, Path]] = None
-) -> tokenizer.InferenceTokenizer:
+def get_input_dataset(args) -> Dataset:
+    """Loads and returns a dataset from the given args.
+
+    Presumes that the arg parser was initialized with |add_input_dataset|.
+    """
+    data_files = get_input_data_files(args)
+    if "gguf" in data_files:
+        return Dataset.load(data_files["gguf"], file_type="gguf")
+
+    if "irpa" in data_files:
+        return Dataset.load(data_files["irpa"], file_type="irpa")
+
+
+def get_tokenizer(args) -> tokenizer.InferenceTokenizer:
     """Gets a tokenizer based on arguments.
 
     If the data_files= dict is present and explicit tokenizer options are not
     set, we will try to infer a tokenizer from the data files.
     """
-    if data_files is None:
-        data_files = {}
-    else:
-        data_files = dict(data_files)
     if args.tokenizer_config_json is not None:
-        data_files["tokenizer_config.json"] = args.tokenizer_config_json
+        data_files = {"tokenizer_config.json", args.tokenizer_config_json}
+    else:
+        data_files = get_input_data_files(args)
 
     tokenizer_type = args.tokenizer_type
     if tokenizer_type is None:

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -6,7 +6,7 @@
 
 """Utilities for building command line tools."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 import argparse
 import logging
@@ -28,10 +28,10 @@ def create_parser(
     return parser
 
 
-def parse(parser: argparse.ArgumentParser):
+def parse(parser: argparse.ArgumentParser, *, args: Sequence[str] | None = None):
     """Parses arguments and does any prescribed global process setup."""
-    args = parser.parse_args()
-    return args
+    parsed_args = parser.parse_args(args)
+    return parsed_args
 
 
 def add_input_dataset_options(parser: argparse.ArgumentParser):

--- a/sharktank/sharktank/utils/io.py
+++ b/sharktank/sharktank/utils/io.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+
+from shark_turbine.aot import (
+    ParameterArchiveBuilder,
+)
+
+
+class ShardedArchiveBuilder(ParameterArchiveBuilder):
+    """A ParameterArchiveBuilder that can contain subordinate builders for each rank.
+
+    TODO: This currently collects all data in memory and commits at once. This
+    can be made much more memory efficient for computed datasets by exposing
+    a Python streaming save helper upstream and using that.
+    """
+
+    def __init__(self, save_path: Path):
+        super().__init__()
+        self.save_path = save_path
+        self._rank_builders: dict[int, ParameterArchiveBuilder] = {}
+
+    def for_rank(self, rank: int) -> ParameterArchiveBuilder:
+        """Returns a ParameterArchiveBuilder for"""
+        if rank in self._rank_builders:
+            return self._rank_builders[rank]
+        b = ParameterArchiveBuilder()
+        self._rank_builders[rank] = b
+        return b
+
+    def commit(self):
+        """Performs final commit of all builders to disk."""
+        self.save(self.save_path)
+        for i, rank_builder in self._rank_builders.items():
+            rank_builder.save(ShardedArchiveBuilder.path_for_rank(self.save_path, i))
+
+    @staticmethod
+    def path_for_rank(path: Path, rank: int):
+        """Returns a path to a file modified with a rank.
+
+        Example input:
+          /tmp/foobar.irpa
+
+        Example output:
+          /tmp/foobar.rank0.irpa
+        """
+        return path.with_suffix(f".rank{rank}{path.suffix}")

--- a/sharktank/sharktank/utils/io.py
+++ b/sharktank/sharktank/utils/io.py
@@ -25,7 +25,7 @@ class ShardedArchiveBuilder(ParameterArchiveBuilder):
         self._rank_builders: dict[int, ParameterArchiveBuilder] = {}
 
     def for_rank(self, rank: int) -> ParameterArchiveBuilder:
-        """Returns a ParameterArchiveBuilder for"""
+        """Returns a ParameterArchiveBuilder for tensors specific to the given rank."""
         if rank in self._rank_builders:
             return self._rank_builders[rank]
         b = ParameterArchiveBuilder()

--- a/sharktank/sharktank/utils/logging.py
+++ b/sharktank/sharktank/utils/logging.py
@@ -4,4 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
+
 from shark_turbine.support.logging import get_logger
+
+
+transform_logger: logging.Logger = get_logger("sharktank.transforms")

--- a/sharktank/tests/transforms/dataset_transforms_test.py
+++ b/sharktank/tests/transforms/dataset_transforms_test.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# For testing dataset transforms, we like to use an example CLI tool, invoked
+# programmatically to test the entire interaction. See examples under the
+# examples/ directory.
+
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+import torch
+
+from sharktank.types import *
+
+
+class TransformTestBase(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = Path(tempfile.mkdtemp("transform.test"))
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
+
+    def get_irpa_path(self, name: str) -> Path:
+        return self._temp_dir / f"{name}.irpa"
+
+    def save_dataset(self, ds: Dataset, name: str) -> Path:
+        p = self.get_irpa_path(name)
+        ds.save(p)
+        return p
+
+    def run_main(self, main_func, *args):
+        new_args = [str(arg) for arg in args]
+        main_func(new_args)
+
+
+class MmtRHSShardingTransformTest(TransformTestBase):
+    def testPrimitive(self):
+        orig_pts = [
+            DefaultPrimitiveTensor("blk.1.attn_k.weight", torch.randn([32, 128])),
+            DefaultPrimitiveTensor("blk.2.attn_q.weight", torch.randn([48, 64])),
+            DefaultPrimitiveTensor("other", torch.randn([2, 2])),
+        ]
+        ds_orig = Dataset({}, Theta(orig_pts))
+        input_path = self.save_dataset(ds_orig, "input")
+        output_path = self.get_irpa_path("output")
+        from sharktank.examples.sharding import shard_llm_dataset
+
+        self.run_main(
+            shard_llm_dataset.main,
+            "--irpa-file",
+            input_path,
+            "--output-irpa-file",
+            output_path,
+            "--num-shards",
+            8,
+        )
+        ds_tran = Dataset.load(output_path, mmap=False)
+
+        # Verify.
+        flat_sts = ds_tran.root_theta.flatten()
+        self.assertEqual(3, len(flat_sts))
+        st_1 = flat_sts["blk.1.attn_k.weight"]
+        st_2 = flat_sts["blk.2.attn_q.weight"]
+        pt_3 = flat_sts["other"]
+        self.assertIsInstance(st_1, ShardedPrimitiveTensor)
+        self.assertIsInstance(st_2, ShardedPrimitiveTensor)
+        self.assertIsInstance(pt_3, DefaultPrimitiveTensor)
+        self.assertListEqual(st_1.shape, [32, 128])
+        self.assertListEqual(st_2.shape, [48, 64])
+
+        # Verify component shapes for st_1.
+        self.assertEqual(8, len(st_1.shards))
+        self.assertTrue(all(pt.shape == [32, 16] for pt in st_1.shards))
+        self.assertTrue(
+            all(list(pt.as_torch().shape) == [32, 16] for pt in st_1.shards)
+        )
+
+        # Verify component shapes for st_2.
+        self.assertEqual(8, len(st_2.shards))
+        self.assertTrue(all(pt.shape == [48, 8] for pt in st_2.shards))
+        self.assertTrue(all(list(pt.as_torch().shape) == [48, 8] for pt in st_2.shards))
+
+        # Verify contents for one shard for sanity.
+        new_t = st_1.shards[0].as_torch()
+        torch.testing.assert_close(new_t, orig_pts[0].as_torch().split(16, dim=1)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Adds a new ShardedTensor and ShardedPrimitiveTensor (ShardedQuantizedTensor is TBI).
* Adds an example `shard_llm_dataset` tool which will shard most of the LLM MLP layers for standard models.
* Extends dataset saving and loading to save 'global' IRPA files by default, but if shards are present in the dataset, they will be written/read from dedicated `*.rank{n}.irpa` files. For serving, this will allow each rank to have a subset of only the parameters it needs in certain advanced topologies.
  * May make this optional in the future, also allowing to save a flat IRPA.
* Threads through some additional CLI handling niceties for dataset input/output tools.
* Next steps will add op support for these ShardedTensor cases by emitting appropriate device-affinity and reduction ops.