### PR TITLE
[sharktank] Support exporting LLM configuration information

### DIFF
--- a/sharktank/README.md
+++ b/sharktank/README.md
@@ -31,7 +31,8 @@ python -m sharktank.examples.paged_llm_v1 \
 ```shell
 python -m sharktank.examples.export_paged_llm_v1 \
   --hf-dataset=open_llama_3b_v2_f16_gguf \
-  --output=/tmp/open_llama_3b_v2_f16.mlir
+  --output_mlir=/tmp/open_llama_3b_v2_f16.mlir
+  --output_config=/tmp/open_llama_3b_v2_f16.json
 ```
 
 ### Dump parsed information about a model from a gguf file:

--- a/sharktank/README.md
+++ b/sharktank/README.md
@@ -31,7 +31,7 @@ python -m sharktank.examples.paged_llm_v1 \
 ```shell
 python -m sharktank.examples.export_paged_llm_v1 \
   --hf-dataset=open_llama_3b_v2_f16_gguf \
-  --output_mlir=/tmp/open_llama_3b_v2_f16.mlir
+  --output_mlir=/tmp/open_llama_3b_v2_f16.mlir \
   --output_config=/tmp/open_llama_3b_v2_f16.json
 ```
 

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -158,7 +158,7 @@ def main():
     output = export(fxb)
     print(f"Saving to '{args.output_mlir}'")
     output.save_mlir(args.output_config)
-    json.dump(config, open("/tmp/batch_llama_v1.json", "w"))
+    json.dump(config, open(args.output_config, "w"))
 
 
 if __name__ == "__main__":

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -41,16 +41,16 @@ def main():
     model = PagedLlamaModelV1(dataset.root_theta, LlamaModelConfig(hp))
 
 
-    def generate_params_json(hp, prefill_bs:list[int], decode_bs:list[int]):
+    def generate_params_json(hp, prefill_bs: list[int], decode_bs: list[int]):
         return {
-            "module_name":"module",
-            "module_abi_version":1,
-            "max_seq_len" : hp.context_length,
-            "attn_head_count" : hp.attention_head_count,
-            "attn_head_dim" : hp.attn_head_dim,
-            "prefill_batch_sizes" : prefill_bs,
-            "decode_batch_sizes" : decode_bs,
-            "transformer_block_count" : hp.block_count,
+            "module_name": "module",
+            "module_abi_version": 1,
+            "max_seq_len": hp.context_length,
+            "attn_head_count": hp.attention_head_count,
+            "attn_head_dim": hp.attn_head_dim,
+            "prefill_batch_sizes": prefill_bs,
+            "decode_batch_sizes": decode_bs,
+            "transformer_block_count": hp.block_count,
         }
 
     # Unrolling cache updates by batch row makes dynamo sad without an

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -40,7 +40,6 @@ def main():
     hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
     model = PagedLlamaModelV1(dataset.root_theta, LlamaModelConfig(hp))
 
-
     def generate_params_json(hp, prefill_bs: list[int], decode_bs: list[int]):
         return {
             "module_name": "module",

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -24,9 +24,15 @@ def main():
     parser = cli.create_parser()
     cli.add_input_dataset_options(parser)
     parser.add_argument(
-        "--output",
+        "--output_mlir",
         help="Output file path for exported MLIR file",
         default="/tmp/batch_llama_v1.mlir",
+    )
+
+    parser.add_argument(
+        "--output_config",
+        help="Output file path for exported config file",
+        default="/tmp/batch_llama_v1.json",
     )
     args = cli.parse(parser)
     dataset = cli.get_input_dataset(args)
@@ -150,8 +156,8 @@ def main():
 
     print("Exporting")
     output = export(fxb)
-    print(f"Saving to '{args.output}'")
-    output.save_mlir(args.output)
+    print(f"Saving to '{args.output_mlir}'")
+    output.save_mlir(args.output_config)
     json.dump(config, open("/tmp/batch_llama_v1.json", "w"))
 
 

--- a/shortfin/shortfin/llm/config.py
+++ b/shortfin/shortfin/llm/config.py
@@ -62,6 +62,7 @@ from iree.runtime import (  # type: ignore
     HalElementType,
 )
 
+import json
 
 @dataclass
 class ModelParams:
@@ -114,6 +115,14 @@ class ModelParams:
     @property
     def max_batch_size(self):
         return max(self.max_prefill_batch_size, self.max_decode_batch_size)
+
+    @staticmethod
+    def load_json(path):
+        f = open(path)
+        j = json.load(f)
+        return ModelParams(
+            attn_dtype=HalElementType.FLOAT_16, **j)
+
 
 
 @dataclass

--- a/shortfin/shortfin/llm/config.py
+++ b/shortfin/shortfin/llm/config.py
@@ -64,6 +64,7 @@ from iree.runtime import (  # type: ignore
 
 import json
 
+
 @dataclass
 class ModelParams:
     """Parameters for a specific compiled model, sufficient to do cache planning and
@@ -120,9 +121,7 @@ class ModelParams:
     def load_json(path):
         f = open(path)
         j = json.load(f)
-        return ModelParams(
-            attn_dtype=HalElementType.FLOAT_16, **j)
-
+        return ModelParams(attn_dtype=HalElementType.FLOAT_16, **j)
 
 
 @dataclass


### PR DESCRIPTION
Beyond the exported `mlir` file additional configuration information is needed for inference, specifically the hyper parameters to allocating kv cache information along with maximum context length, etc.