### PR TITLE
Change signature of InferenceTensor constructors to be kwarg based.

### DIFF
--- a/sharktank/sharktank/transforms/dataset/sharding.py
+++ b/sharktank/sharktank/transforms/dataset/sharding.py
@@ -61,7 +61,9 @@ class MmtRHSShardingTransform:
             return None
         shard_split_size = shard_dim_size // self.num_shards
         shard_ts = t.split(shard_split_size, dim=shard_dim)
-        st = ShardedPrimitiveTensor(pt.name, pt.shape, shard_dim, shard_ts)
+        st = ShardedPrimitiveTensor(
+            name=pt.name, shape=pt.shape, shard_dim=shard_dim, ts=shard_ts
+        )
         logger.debug("Sharding tensor %r -> %r", pt, st)
         return st
 

--- a/sharktank/sharktank/types/gguf_interop/base.py
+++ b/sharktank/sharktank/types/gguf_interop/base.py
@@ -98,7 +98,7 @@ def _wrap_tensor(
     logical_shape = list(reversed(logical_shape))
     if type_name in ["F16", "F32", "F64"]:
         return DefaultPrimitiveTensor(
-            name, _externalize_tensor(name, data, logical_shape)
+            name=name, data=_externalize_tensor(name, data, logical_shape)
         )
 
     quantized_type = _quantized_types.get(type_name)

--- a/sharktank/sharktank/types/gguf_interop/layouts.py
+++ b/sharktank/sharktank/types/gguf_interop/layouts.py
@@ -8,6 +8,7 @@ import torch
 
 from ..tensors import (
     QuantizedTensor,
+    UnnamedTensorName,
 )
 
 from ..layouts import (
@@ -40,8 +41,10 @@ class Q8_0(QuantizedTensor[BlockScaledLayout]):
     https://github.com/ggerganov/llama.cpp/blob/f026f8120f97090d34a52b3dc023c82e0ede3f7d/ggml-opencl.cpp#L172-L180
     """
 
-    def __init__(self, *, name: str, raw: torch.Tensor, shape: list[int]):
-        super().__init__(name, shape=shape, layout_type=BlockScaledLayout)
+    def __init__(
+        self, *, raw: torch.Tensor, shape: list[int], name: str = UnnamedTensorName
+    ):
+        super().__init__(name=name, shape=shape, layout_type=BlockScaledLayout)
         assert raw.dtype == torch.uint8
         self.raw = raw
 
@@ -98,9 +101,11 @@ class Q4_K(QuantizedTensor[SuperBlockOffsetScaled_4_6_Layout]):
     which the compiler can do more with than a heavily interleaved format.
     """
 
-    def __init__(self, *, name: str, raw: torch.Tensor, shape: list[int]):
+    def __init__(
+        self, *, raw: torch.Tensor, shape: list[int], name: str = UnnamedTensorName
+    ):
         super().__init__(
-            name, shape=shape, layout_type=SuperBlockOffsetScaled_4_6_Layout
+            name=name, shape=shape, layout_type=SuperBlockOffsetScaled_4_6_Layout
         )
         self.raw = raw
 
@@ -215,8 +220,10 @@ def _unpack_gguf_i6_scale_mins(
 class Q5_K(QuantizedTensor[BlockScaledI4Layout]):
     """"""
 
-    def __init__(self, *, name: str, raw: torch.Tensor, shape: list[int]):
-        super().__init__(name, shape=shape, layout_type=BlockScaledI4Layout)
+    def __init__(
+        self, *, raw: torch.Tensor, shape: list[int], name: str = UnnamedTensorName
+    ):
+        super().__init__(name=name, shape=shape, layout_type=BlockScaledI4Layout)
         self.raw = raw
 
     def unpack(self) -> BlockScaledI4Layout:
@@ -233,8 +240,10 @@ class Q5_K(QuantizedTensor[BlockScaledI4Layout]):
 class Q6_K(QuantizedTensor[BlockScaledI4Layout]):
     """"""
 
-    def __init__(self, *, name: str, raw: torch.Tensor, shape: list[int]):
-        super().__init__(name, shape=shape, layout_type=BlockScaledI4Layout)
+    def __init__(
+        self, *, raw: torch.Tensor, shape: list[int], name: str = UnnamedTensorName
+    ):
+        super().__init__(name=name, shape=shape, layout_type=BlockScaledI4Layout)
         self.raw = raw
 
     def unpack(self) -> BlockScaledI4Layout:
@@ -267,8 +276,10 @@ class Q4_1(QuantizedTensor[BlockScaledI4Layout]):
     * `m` is pre-scaled by `delta`.
     """
 
-    def __init__(self, *, name: str, raw: torch.Tensor, shape: list[int]):
-        super().__init__(name, shape=shape, layout_type=BlockScaledI4Layout)
+    def __init__(
+        self, *, raw: torch.Tensor, shape: list[int], name: str = UnnamedTensorName
+    ):
+        super().__init__(name=name, shape=shape, layout_type=BlockScaledI4Layout)
         self.raw = raw
 
     def unpack(self) -> BlockScaledI4Layout:

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -167,9 +167,8 @@ class TestOpExport(unittest.TestCase):
         class MyModule(torch.nn.Module):
             def forward(self, a, d, qs, m):
                 rhs_pqt = PlanarQuantizedTensor(
-                    "",
-                    [3200, 3200],
-                    BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
+                    shape=[3200, 3200],
+                    layout=BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
                 )
                 result = ops.matmul(a, rhs_pqt)
                 return result

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -31,7 +31,7 @@ class EmbeddingLookupTest(unittest.TestCase):
     def testPrimitiveTensorRhs(self):
         t1 = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]])
         t2 = torch.rand(10, 3, dtype=torch.float16)
-        t2_pt = DefaultPrimitiveTensor("", t2)
+        t2_pt = DefaultPrimitiveTensor(data=t2)
         result = ops.embedding_lookup(t1, t2_pt, torch.float32)
         expected = F.embedding(t1, t2.to(torch.float32))
         torch.testing.assert_close(result, expected)
@@ -76,7 +76,7 @@ class MatmulTest(unittest.TestCase):
     def testTorchImplTransposedPrimitiveRHS(self):
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
-        t2_pt = DefaultPrimitiveTensor("", t2)
+        t2_pt = DefaultPrimitiveTensor(data=t2)
         result = ops.matmul(t1, t2_pt)
         expected = torch.matmul(t1, t2.T.to(torch.float32))
         torch.testing.assert_close(result, expected)
@@ -93,7 +93,7 @@ class MatmulTest(unittest.TestCase):
         d = torch.rand([3200, 100, 1], dtype=d_dtype) * 64
         qs = (torch.rand([3200, 100, 32], dtype=ref_dtype) * 32.0).to(torch.int8)
         rhs_pqt = PlanarQuantizedTensor(
-            "", [3200, 3200], BlockScaledLayout([3200, 3200], d, qs)
+            shape=[3200, 3200], layout=BlockScaledLayout([3200, 3200], d, qs)
         )
         result = ops.matmul(a, rhs_pqt)
         # Just verifying dispatch. Numerics are tested at the kernel level.
@@ -111,9 +111,8 @@ class MatmulTest(unittest.TestCase):
         qs = (torch.rand([3200, 100, 16], dtype=ref_dtype) * 255.0).to(torch.uint8)
         m = torch.rand([3200, 100, 1], dtype=d_dtype) + 16.0
         rhs_pqt = PlanarQuantizedTensor(
-            "",
-            [3200, 3200],
-            BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
+            shape=[3200, 3200],
+            layout=BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
         )
         result = ops.matmul(a, rhs_pqt)
         # Just verifying dispatch. Numerics are tested at the kernel level.
@@ -142,7 +141,7 @@ class RmsNormTest(unittest.TestCase):
     def testTorchPrimitiveWeightImpl(self):
         t1 = torch.rand(16, 128, dtype=torch.float32)
         t2 = torch.rand(16, 128, dtype=torch.float32)
-        t2_pt = DefaultPrimitiveTensor("", t2)
+        t2_pt = DefaultPrimitiveTensor(data=t2)
         result = ops.rms_norm(t1, t2_pt, epsilon=1e-10)
         actual = self._ref(t1, t2, epsilon=1e-10)
         torch.testing.assert_close(actual, result)

--- a/sharktank/tests/transforms/dataset_transforms_test.py
+++ b/sharktank/tests/transforms/dataset_transforms_test.py
@@ -41,9 +41,13 @@ class TransformTestBase(unittest.TestCase):
 class MmtRHSShardingTransformTest(TransformTestBase):
     def testPrimitive(self):
         orig_pts = [
-            DefaultPrimitiveTensor("blk.1.attn_k.weight", torch.randn([32, 128])),
-            DefaultPrimitiveTensor("blk.2.attn_q.weight", torch.randn([48, 64])),
-            DefaultPrimitiveTensor("other", torch.randn([2, 2])),
+            DefaultPrimitiveTensor(
+                name="blk.1.attn_k.weight", data=torch.randn([32, 128])
+            ),
+            DefaultPrimitiveTensor(
+                name="blk.2.attn_q.weight", data=torch.randn([48, 64])
+            ),
+            DefaultPrimitiveTensor(name="other", data=torch.randn([2, 2])),
         ]
         ds_orig = Dataset({}, Theta(orig_pts))
         input_path = self.save_dataset(ds_orig, "input")

--- a/sharktank/tests/types/dataset_test.py
+++ b/sharktank/tests/types/dataset_test.py
@@ -16,7 +16,7 @@ from sharktank.types import *
 
 
 def _t(name: str, *dims: int):
-    return DefaultPrimitiveTensor(name, torch.empty(*dims))
+    return DefaultPrimitiveTensor(name=name, data=torch.empty(*dims))
 
 
 def _flat_t_dict(*ts):
@@ -141,7 +141,9 @@ class DatasetTest(unittest.TestCase):
 
     def testRoundtripPlanarQuantizedTensor(self):
         layout_in = self._createTestLayout()
-        t_orig = PlanarQuantizedTensor("a.b.c", shape=layout_in.shape, layout=layout_in)
+        t_orig = PlanarQuantizedTensor(
+            name="a.b.c", shape=layout_in.shape, layout=layout_in
+        )
         self.assertIs(t_orig, t_orig.to_planar())
         ds_orig = Dataset({}, Theta({t_orig.name: t_orig}))
         ds_orig.save(self.temp_dir / "myds.irpa")

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -26,7 +26,9 @@ def _createTestLayout():
 
 class PlanarQuantizedTensorTest(unittest.TestCase):
     def testTransform(self):
-        pqt1 = PlanarQuantizedTensor("t1", [128, 1024], _createTestLayout())
+        pqt1 = PlanarQuantizedTensor(
+            name="t1", shape=[128, 1024], layout=_createTestLayout()
+        )
 
         def transform1(d):
             new_d = {}


### PR DESCRIPTION
This was bugging me for a while. Practically, it lets us make the `name` optional, which makes sense for activations and such.