### PR TITLE
[shortfin] Add end-to-end cli for testing / executing prefill

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -93,8 +93,7 @@ def main():
                 seq_block_ids=seq_block_ids,
                 cache_state=cache_state,
             )
-            argmax = model.theta.ops.argmax(logits)
-            return argmax
+            return logits
 
     def generate_batch_decode(bs: int):
         tokens = torch.ones(bs, 1, dtype=torch.int64)

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -146,7 +146,9 @@ def main():
             return logits
 
     bsizes = []
-    for bs in [4,]:
+    for bs in [
+        4,
+    ]:
         generate_batch_prefill(bs)
         generate_batch_decode(bs)
         bsizes.append(bs)

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -93,7 +93,8 @@ def main():
                 seq_block_ids=seq_block_ids,
                 cache_state=cache_state,
             )
-            return logits
+            argmax = model.theta.ops.argmax(logits)
+            return argmax
 
     def generate_batch_decode(bs: int):
         tokens = torch.ones(bs, 1, dtype=torch.int64)
@@ -145,9 +146,12 @@ def main():
             )
             return logits
 
-    generate_batch_prefill(4)
-    generate_batch_decode(4)
-    config = generate_params_json(hp, [4], [4])
+    bsizes = []
+    for bs in [4,]:
+        generate_batch_prefill(bs)
+        generate_batch_decode(bs)
+        bsizes.append(bs)
+    config = generate_params_json(hp, bsizes, bsizes)
     print("GENERATED!")
 
     for name, ep in fxb.programs.items():
@@ -156,7 +160,7 @@ def main():
     print("Exporting")
     output = export(fxb)
     print(f"Saving to '{args.output_mlir}'")
-    output.save_mlir(args.output_config)
+    output.save_mlir(args.output_mlir)
     json.dump(config, open(args.output_config, "w"))
 
 

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -41,10 +41,10 @@ class LlamaModelConfig:
     device: Optional[torch.device] = None
 
     # Dtype to use for general FP activations not otherwise configured.
-    activation_dtype: torch.dtype = torch.float32
+    activation_dtype: torch.dtype = torch.float16
 
     # Dtype to use for attention.
-    attention_dtype: torch.dtype = torch.float32
+    attention_dtype: torch.dtype = torch.float16
 
     def create_kv_cache(self) -> BaseKVCache:
         hp = self.hp

--- a/shortfin/shortfin/framework/session.py
+++ b/shortfin/shortfin/framework/session.py
@@ -165,7 +165,6 @@ class ModuleSet:
 
     def add(self, *modules: VmModule):
         for module in modules:
-            print(module)
             self.modules.append(module)
 
     def load_vmfb(self, vmfb_path: str):

--- a/shortfin/shortfin/llm/impl/service_v1.py
+++ b/shortfin/shortfin/llm/impl/service_v1.py
@@ -90,7 +90,7 @@ class GenerateServiceV1(BatchGenerateService):
         max_sl = params.model.max_seq_len
         initial_inflight = EXPECTED_CONCURRENCY
 
-        # block_indices_pool: array([max_batch_size, max_attn_blocks], np.int16)
+        # block_indices_pool: array([max_batch_size, max_attn_blocks], np.int64)
         # Suitable to handle the sequence->block mapping for all steps.
         self.block_indices_pool = TransferBufferPool.shaped(
             self.session,
@@ -98,13 +98,13 @@ class GenerateServiceV1(BatchGenerateService):
                 max_bs,
                 max_sl // self.block_pos_stride,
             ],
-            HalElementType.INT_16,
+            HalElementType.SINT_64,
             initial_capacity=initial_inflight,
             growable=True,
             name="block_cache_indices",
         )
 
-        # Prefill tokens: array([max_batch_size, max_seq_len], np.int32)
+        # Prefill tokens: array([max_batch_size, max_seq_len], np.int64)
         # Tokens inputs to prefill.
         self.prefill_tokens_pool = TransferBufferPool.shaped(
             self.session,
@@ -112,43 +112,91 @@ class GenerateServiceV1(BatchGenerateService):
                 max_bs,
                 max_sl,
             ],
-            HalElementType.INT_32,
+            HalElementType.SINT_64,
             initial_capacity=initial_inflight,
             growable=True,
             name="prefill_tokens",
         )
 
-        # Prefill sequence lengths: array([max_batch_size], np.int16)
+        # Prefill sequence lengths: array([max_batch_size], np.int64)
         # Sequence lengths of input tokens.
         self.prefill_seq_lens_pool = TransferBufferPool.shaped(
             self.session,
             [max_bs],
-            HalElementType.INT_16,
+            HalElementType.SINT_64,
             initial_capacity=initial_inflight,
             growable=True,
             name="prefill_seq_lens",
         )
 
+        # Decode tokens: array([max_batch_size], np.int64)
+        # Tokens to perform a decode step with.
+        self.decode_tokens_pool = TransferBufferPool.shaped(
+            self.session,
+            [max_bs, 1],
+            HalElementType.SINT_64,
+            initial_capacity=initial_inflight,
+            growable=True,
+            name="decode_tokens",
+        )
+
+        # Decode seq lengths: array([max_batch_size], np.int64)
+        # Decoder seq length for this step
+        self.decode_seq_lens_pool = TransferBufferPool.shaped(
+            self.session,
+            [max_bs],
+            HalElementType.SINT_64,
+            initial_capacity=initial_inflight,
+            growable=True,
+            name="decode_seq_len",
+        )
+
+        # Decode start positions: array([max_batch_size], np.int64)
+        # Tokens to perform a decode step with.
+        self.decode_start_pos_pool = TransferBufferPool.shaped(
+            self.session,
+            [max_bs],
+            HalElementType.SINT_64,
+            initial_capacity=initial_inflight,
+            growable=True,
+            name="decode_start_pos",
+        )
+
     def start(self) -> "GenerateState":
         return GenerateState(self)
+    
+    def shutdown(self):
+        self.session.shutdown()
 
 
 class _Sequence:
     __slots__ = [
         "attn_blocks",
         "attn_blocks_needed",
-        "prefill_token_ids",
+        "current_token_ids",
+        "decode_token_ids",
         "request",
         "seq_length",
     ]
 
-    prefill_token_ids: list[int]
+    current_token_ids: list[int]
+    decode_token_ids: list[int]
 
     def __init__(self, request: GenerateRequest):
         self.request = request
         self.seq_length: int = 0
         self.attn_blocks: list[AttnBlockCacheEntry] = []
         self.attn_blocks_needed: int = 0
+        self.decode_token_ids = []
+        self.current_token_ids = []
+
+    def attn_blocks_available(self):
+        return len(self.attn_blocks)
+
+    def resize_attention(self, new_size):
+        old_size = self.attn_blocks_needed
+        self.attn_blocks_needed = new_size
+        return new_size - old_size
 
 
 class GenerateState(BatchGenerateState):
@@ -174,12 +222,13 @@ class GenerateState(BatchGenerateState):
     async def recycle(self):
         """Recycles or releases all resources consumed by this instance."""
         cache = self._service.cache
-        await self._batch_queue.sync(self.host_context)
+        self._batch_queue.sync(self.host_context)
         self._resources.recycle()
         all_blocks = []
         for seq in self._sequences:
             all_blocks.extend(seq.attn_blocks)
             seq.attn_blocks.clear()
+        self._sequences = []
         await cache.release_attn_blocks(all_blocks)
 
     async def set_sequences(self, requests: list[GenerateRequest]):
@@ -202,8 +251,8 @@ class GenerateState(BatchGenerateState):
             bs += 1
             seq = _Sequence(req)
             sequences.append(seq)
-            seq.prefill_token_ids = prefill_token_ids = req.required_prompt_token_ids
-            seq_length = len(prefill_token_ids)
+            seq.current_token_ids = req.required_prompt_token_ids
+            seq_length = len(seq.current_token_ids)
             seq.seq_length = seq_length
             max_seq_length = max(max_seq_length, seq_length)
             initial_block_count = seq_length // block_pos_stride + 1
@@ -258,14 +307,14 @@ class GenerateState(BatchGenerateState):
         # prefill_tokens: array([bs, max_seq_length], np.int32)
         prefill_tokens_host, prefill_tokens_device = resources.acquire_transfer_buffer(
             service.prefill_tokens_pool
-        ).h2d_array(cb, [bs, max_seq_length], HalElementType.INT_32, fill_value=0)
+        ).h2d_array(cb, [bs, max_seq_length], HalElementType.SINT_64, fill_value=0)
 
         # prefill_seq_lens: array([bs], np.int32)
         (
             prefill_seq_lens_host,
             prefill_seq_lens_device,
         ) = resources.acquire_transfer_buffer(service.prefill_seq_lens_pool).h2d_array(
-            cb, [bs], HalElementType.INT_32, fill_value=0
+            cb, [bs], HalElementType.SINT_64, fill_value=0
         )
 
         # attn_block_indices: array([bs, max_attn_blocks], np.in16)
@@ -273,16 +322,16 @@ class GenerateState(BatchGenerateState):
             prefill_attn_block_indices_host,
             prefill_attn_block_indices_device,
         ) = resources.acquire_transfer_buffer(service.block_indices_pool).h2d_array(
-            cb, [bs, max_attn_blocks_length], HalElementType.INT_16, fill_value=0
+            cb, [bs, max_attn_blocks_length], HalElementType.SINT_64, fill_value=0
         )
 
         # Populate host buffers for each sequence.
         for i in range(len(sequences)):
             seq = sequences[i]
             attn_blocks = seq.attn_blocks
-            prefill_token_ids = seq.prefill_token_ids
-            row_seq_len = len(prefill_token_ids)
-            prefill_tokens_host[i, 0:row_seq_len] = prefill_token_ids
+            current_token_ids = seq.current_token_ids
+            row_seq_len = len(current_token_ids)
+            prefill_tokens_host[i, 0:row_seq_len] = current_token_ids
             prefill_seq_lens_host[i] = row_seq_len
             for j in range(len(seq.attn_blocks)):
                 prefill_attn_block_indices_host[i, j] = attn_blocks[j].index
@@ -303,10 +352,7 @@ class GenerateState(BatchGenerateState):
         inputs.push_ref(prefill_tokens_device)
         inputs.push_ref(prefill_seq_lens_device)
         inputs.push_ref(prefill_attn_block_indices_device)
-
-        wait_fence, signal_fence = work_queue.step_fences()
-        inputs.push_ref(wait_fence)
-        inputs.push_ref(signal_fence)
+        inputs.push_ref(service.cache.attn_block_buffer_view)
 
         # Outputs:
         #   attn_block_buffer_view (tied output)
@@ -314,4 +360,140 @@ class GenerateState(BatchGenerateState):
         outputs = VmVariantList(1)
         # TODO: Async invoke.
         hc.vm_context.invoke(self._prefill_function, inputs, outputs)
+        return work_queue.guard(outputs.get_as_ref(0).deref(HalBufferView))
+
+    async def set_decode_step(self, tokens):
+        """Initiates processing of a list of tokens to decode across each batch
+
+        This is async because it acquires resources which may not be available.
+        """
+        service = self._service
+        block_pos_stride = service.block_pos_stride
+
+        sequences = self._sequences
+        assert sequences, "set_sequences was not called yet"
+        assert len(sequences) == len(tokens), "expected token for each sequence"
+
+        max_attn_blocks_length = 0
+        max_seq_length = 0
+        attn_blocks_required = 0
+
+        for tok, seq in zip(tokens, self._sequences):
+            seq.decode_token_ids.append(tok)
+            seq.seq_length = seq.seq_length + 1
+
+            max_seq_length = max(max_seq_length, seq.seq_length)
+            block_count = seq.seq_length // block_pos_stride + 1
+
+            seq.attn_blocks_needed = block_count
+            attn_blocks_required += block_count - seq.attn_blocks_available()
+            max_attn_blocks_length = max(max_attn_blocks_length, block_count)
+
+        # Acquire the needed attention blocks in one batch so as to give the scheduler
+        # the most visibility into the need.
+        logger.debug("Acquire decode attn blocks: %s", attn_blocks_required)
+        all_attn_blocks: list[AttnBlockCacheEntry] = []
+        await service.cache.acquire_attn_blocks(attn_blocks_required, all_attn_blocks)
+        block_index = 0
+        for seq in sequences:
+            next_block_count = seq.attn_blocks_needed - seq.attn_blocks_available()
+            seq.attn_blocks.extend(
+                all_attn_blocks[block_index : block_index + next_block_count]
+            )
+            block_index += next_block_count
+
+        # Save state.
+        self._max_attn_blocks_length = max_attn_blocks_length
+        self._max_seq_length = max_seq_length
+
+
+    async def decode(self) -> TimelineGuarded[HalBufferView]:
+        hc = self.host_context
+        service = self._service
+        resources = self._resources
+        bs = self._bs
+        max_attn_blocks_length = self._max_attn_blocks_length
+        sequences = self._sequences
+        work_queue = self._batch_queue
+
+        # Record a command buffer for performing h2d transfers.
+        cb = HalCommandBuffer(hc.session.device)
+
+        # decode_tokens: array([bs, 1], np.int32)
+        (
+            decode_tokens_host,
+            decode_tokens_device,
+        ) = resources.acquire_transfer_buffer(service.decode_tokens_pool).h2d_array(
+            cb, [bs, 1], HalElementType.SINT_64, fill_value=0
+        )
+
+        # decode_seq_lens: array([bs], np.int32)
+        (
+            decode_seq_lens_host,
+            decode_seq_lens_device,
+        ) = resources.acquire_transfer_buffer(service.decode_seq_lens_pool).h2d_array(
+            cb, [bs], HalElementType.SINT_64, fill_value=0
+        )
+
+        # decode_start_pos: array([bs], np.int32)
+        (
+            decode_start_pos_host,
+            decode_start_pos_device,
+        ) = resources.acquire_transfer_buffer(service.decode_start_pos_pool).h2d_array(
+            cb, [bs], HalElementType.SINT_64, fill_value=0
+        )
+
+        # attn_block_indices: array([bs, max_attn_blocks], np.in16)
+        (
+            decode_attn_block_indices_host,
+            decode_attn_block_indices_device,
+        ) = resources.acquire_transfer_buffer(service.block_indices_pool).h2d_array(
+            cb, [bs, max_attn_blocks_length], HalElementType.SINT_64, fill_value=0
+        )
+
+        # Populate host buffers for each sequence.
+        for i in range(len(sequences)):
+            break
+            seq = sequences[i]
+            attn_blocks = seq.attn_blocks
+
+            tok = seq.decode_token_ids[0]
+            seq_len = len(seq.current_token_ids)
+            print(seq.current_token_ids)
+            seq.current_token_ids.append(tok)
+            seq.decode_token_ids = seq.decode_token_ids[1:]
+
+            decode_tokens_host[i, 0] = tok
+            decode_start_pos_host[i] = seq_len
+            decode_seq_lens_host[i] = seq_len
+            for j in range(len(seq.attn_blocks)):
+                decode_attn_block_indices_host[i, j] = attn_blocks[j].index
+
+        # Perform h2d transfers.
+        cb.end()
+        work_queue.execute_sequential([cb])
+
+        # Inputs:
+        #   token_ids
+        #   seq_lens
+        #   start_pos
+        #   attn_block_indices
+        #   attn_block_buffer_view (the entire slab passed as input)
+        #   wait, signal semaphores
+        #   tied attn_block_buffer (for input[4])
+        #   tied attn_block_buffer (for result[0])
+        inputs = VmVariantList(5)
+        inputs.push_ref(decode_tokens_device)
+        inputs.push_ref(decode_seq_lens_device)
+        inputs.push_ref(decode_start_pos_device)
+        inputs.push_ref(decode_attn_block_indices_device)
+        inputs.push_ref(service.cache.attn_block_buffer_view)
+
+        # Outputs:
+        #   attn_block_buffer_view (tied output)
+        #   decode_tokens
+        outputs = VmVariantList(1)
+        # TODO: Async invoke.
+        print("Invoking")
+        hc.vm_context.invoke(self._decode_function, inputs, outputs)
         return work_queue.guard(outputs.get_as_ref(0).deref(HalBufferView))

--- a/shortfin/shortfin/llm/impl/service_v1.py
+++ b/shortfin/shortfin/llm/impl/service_v1.py
@@ -164,7 +164,7 @@ class GenerateServiceV1(BatchGenerateService):
 
     def start(self) -> "GenerateState":
         return GenerateState(self)
-    
+
     def shutdown(self):
         self.session.shutdown()
 
@@ -406,7 +406,6 @@ class GenerateState(BatchGenerateState):
         self._max_attn_blocks_length = max_attn_blocks_length
         self._max_seq_length = max_seq_length
 
-
     async def decode(self) -> TimelineGuarded[HalBufferView]:
         hc = self.host_context
         service = self._service
@@ -420,12 +419,9 @@ class GenerateState(BatchGenerateState):
         cb = HalCommandBuffer(hc.session.device)
 
         # decode_tokens: array([bs, 1], np.int32)
-        (
-            decode_tokens_host,
-            decode_tokens_device,
-        ) = resources.acquire_transfer_buffer(service.decode_tokens_pool).h2d_array(
-            cb, [bs, 1], HalElementType.SINT_64, fill_value=0
-        )
+        (decode_tokens_host, decode_tokens_device,) = resources.acquire_transfer_buffer(
+            service.decode_tokens_pool
+        ).h2d_array(cb, [bs, 1], HalElementType.SINT_64, fill_value=0)
 
         # decode_seq_lens: array([bs], np.int32)
         (

--- a/shortfin/shortfin/llm/impl/service_v1.py
+++ b/shortfin/shortfin/llm/impl/service_v1.py
@@ -449,7 +449,6 @@ class GenerateState(BatchGenerateState):
 
         # Populate host buffers for each sequence.
         for i in range(len(sequences)):
-            break
             seq = sequences[i]
             attn_blocks = seq.attn_blocks
 

--- a/shortfin/shortfin/llm/impl/service_v1_cli.py
+++ b/shortfin/shortfin/llm/impl/service_v1_cli.py
@@ -9,7 +9,7 @@ import argparse
 import numpy
 import sys
 
-from transformers import LlamaTokenizer
+from transformers import LlamaTokenizer  # type: ignore
 
 from iree.runtime import (  # type: ignore
     HalElementType,

--- a/shortfin/shortfin/llm/impl/service_v1_cli.py
+++ b/shortfin/shortfin/llm/impl/service_v1_cli.py
@@ -1,0 +1,91 @@
+
+import asyncio
+import argparse
+import numpy
+import sys
+
+from transformers import LlamaTokenizer
+
+from iree.runtime import (  # type: ignore
+    HalElementType,
+)
+
+from shortfin.framework.session import DeviceSession
+
+from shortfin.llm.attn_block_cache import (
+    create_attn_block_cache_module,
+    AttnBlockCache,
+)
+
+from shortfin.llm.config import (
+    CacheParams,
+    ModelParams,
+    ServiceParams,
+)
+
+from shortfin.llm.impl.service_v1 import GenerateServiceV1
+from shortfin.llm.service import GenerateRequest
+
+def setup(vmfb_path, config_path, gguf_path):
+    from iree.runtime._binding import disable_leak_checker  # type: ignore
+    model_params = ModelParams.load_json(config_path)
+
+    cache_params = CacheParams(
+        model=model_params, device_block_count=128, block_pos_stride=16)
+
+    disable_leak_checker()
+    session = DeviceSession(uri="local-task", queue_count=2)
+    attn_block_cache = AttnBlockCache(session, cache_params)
+
+    lms = session.create_module_set(model_params.module_name, context_count=1)
+    lms.load_io_module(gguf_path)
+    lms.load_vmfb(vmfb_path)
+    lms.add(create_attn_block_cache_module(attn_block_cache))
+    lms.initialize()
+
+    params = ServiceParams(cache=cache_params, model=model_params)
+    service = GenerateServiceV1(session=session, params=params, cache=attn_block_cache)
+    return service
+
+def map_buffer(value):
+    mapped = value.map()
+    return mapped.asarray(
+        value.shape,
+        HalElementType.map_to_dtype(value.element_type))
+
+async def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokenizer")
+    parser.add_argument("--config")
+    parser.add_argument("--vmfb")
+    parser.add_argument("--gguf")
+    parsed = parser.parse_args(argv)
+
+    hf_path = parsed.tokenizer
+    config_path = parsed.config
+    vmfb_path = parsed.vmfb
+    gguf_path = parsed.gguf
+
+    service = setup(vmfb_path, config_path, gguf_path)
+    tokenizer = LlamaTokenizer.from_pretrained(hf_path)
+    state = service.start()
+
+    for line in ["one two three four"]:
+        prompt = line.strip()
+        if not prompt:
+            break
+
+        input_ids = tokenizer.encode(prompt, return_tensors="pt")[0].tolist()
+        print(input_ids)
+        request = GenerateRequest("request_id", prompt, input_ids)
+        await state.set_sequences([request])
+        logits = await state.prefill()
+
+        mapped_logits = map_buffer(logits.value)
+        print(mapped_logits)
+        await state.recycle()
+
+    service.shutdown()
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1:]))

--- a/shortfin/shortfin/llm/impl/service_v1_cli.py
+++ b/shortfin/shortfin/llm/impl/service_v1_cli.py
@@ -1,4 +1,3 @@
-
 import asyncio
 import argparse
 import numpy
@@ -26,12 +25,15 @@ from shortfin.llm.config import (
 from shortfin.llm.impl.service_v1 import GenerateServiceV1
 from shortfin.llm.service import GenerateRequest
 
+
 def setup(vmfb_path, config_path, gguf_path):
     from iree.runtime._binding import disable_leak_checker  # type: ignore
+
     model_params = ModelParams.load_json(config_path)
 
     cache_params = CacheParams(
-        model=model_params, device_block_count=128, block_pos_stride=16)
+        model=model_params, device_block_count=128, block_pos_stride=16
+    )
 
     disable_leak_checker()
     session = DeviceSession(uri="local-task", queue_count=2)
@@ -47,11 +49,11 @@ def setup(vmfb_path, config_path, gguf_path):
     service = GenerateServiceV1(session=session, params=params, cache=attn_block_cache)
     return service
 
+
 def map_buffer(value):
     mapped = value.map()
-    return mapped.asarray(
-        value.shape,
-        HalElementType.map_to_dtype(value.element_type))
+    return mapped.asarray(value.shape, HalElementType.map_to_dtype(value.element_type))
+
 
 async def main(argv):
     parser = argparse.ArgumentParser()
@@ -86,6 +88,7 @@ async def main(argv):
         await state.recycle()
 
     service.shutdown()
+
 
 if __name__ == "__main__":
     asyncio.run(main(sys.argv[1:]))

--- a/shortfin/shortfin/llm/impl/service_v1_cli.py
+++ b/shortfin/shortfin/llm/impl/service_v1_cli.py
@@ -1,3 +1,9 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 import asyncio
 import argparse
 import numpy
@@ -57,10 +63,10 @@ def map_buffer(value):
 
 async def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--tokenizer")
-    parser.add_argument("--config")
-    parser.add_argument("--vmfb")
-    parser.add_argument("--gguf")
+    parser.add_argument("--tokenizer", help="name of hugginface tokenizer to use")
+    parser.add_argument("--config", help="json config file with hyperparameters")
+    parser.add_argument("--vmfb", help="vmfb with compiler LLM kernels")
+    parser.add_argument("--gguf", help="gguf file containing modle coefficients")
     parsed = parser.parse_args(argv)
 
     hf_path = parsed.tokenizer


### PR DESCRIPTION
Updated for what the outgoing prefill looks like. This included validation with llama 2 that a reasonable sequent (one two three four) correctly predicted preceding tokens.

This should support generic export / execution of gguf prefill however there still exists issues with the newly added decoder path.