### PR TITLE
Bump kernels for `tensor.expand_shape` update

### DIFF
--- a/sharktank/sharktank/kernels/templates/mmt_block_scaled_offset_q4_unsigned.mlir
+++ b/sharktank/sharktank/kernels/templates/mmt_block_scaled_offset_q4_unsigned.mlir
@@ -61,7 +61,7 @@ util.func private @sharktank_mmt_block_scaled_offset_q4_unsigned_3d_{{n}}_{{k}}_
   } -> !b_grouped_tensor_type
 
   // Expand %a to have the same blocked reduction structure.
-  %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] : !a_tensor_type into !aexp_tensor_type
+  %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] output_shape [%batch0_dim,%m_dim,{{group0}},{{bs}}] : !a_tensor_type into !aexp_tensor_type
 
   // Grouped, batch mm.
   %result_empty = tensor.empty(%batch0_dim, %m_dim) : !accum_tensor_type

--- a/sharktank/sharktank/kernels/templates/mmt_block_scaled_q8_3d.mlir
+++ b/sharktank/sharktank/kernels/templates/mmt_block_scaled_q8_3d.mlir
@@ -52,7 +52,7 @@ util.func private @sharktank_mmt_block_scaled_q8_3d_{{n}}_{{k}}_{{bs}}_{{a_type}
   } -> !b_grouped_tensor_type
 
   // Expand %a to have the same blocked reduction structure.
-  %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] : !a_tensor_type into !aexp_tensor_type
+  %aexp = tensor.expand_shape %a [[0], [1], [2, 3]] output_shape [%batch0,%m,{{group0}},{{bs}}] : !a_tensor_type into !aexp_tensor_type
 
   // Grouped, batch mm.
   %result_empty = tensor.empty(%batch0, %m) : !accum_tensor_type

--- a/sharktank/sharktank/kernels/templates/mmt_super_block_scaled_offset_q4_unsigned_3d.mlir
+++ b/sharktank/sharktank/kernels/templates/mmt_super_block_scaled_offset_q4_unsigned_3d.mlir
@@ -106,7 +106,7 @@ util.func private @mmt_super_block_scaled_offset_q4_unsigned_3d_{{n}}_{{k}}_{{su
   } -> !b_grouped_tensor_type
 
   // Expand %a to have the same blocked reduction structure (sup, sub, block).
-  %aexp = tensor.expand_shape %a [[0], [1], [2, 3, 4]] : !a_tensor_type into !aexp_tensor_type
+  %aexp = tensor.expand_shape %a [[0], [1], [2, 3, 4]] output_shape [%batch0_dim,%m_dim,{{sup_count}},{{sub_count}},{{bs}}] : !a_tensor_type into !aexp_tensor_type
 
   // Grouped, batch mm.
   %result_empty = tensor.empty(%batch0_dim, %m_dim) : !accum_tensor_type


### PR DESCRIPTION
`tensor.expand_shape` has been updated for supporting between dynamic dimensions.