### PR TITLE
Implement explicit sharded arithmetic operations using duck typing.

### DIFF
--- a/sharktank/sharktank/kernels/mmtfp.py
+++ b/sharktank/sharktank/kernels/mmtfp.py
@@ -37,11 +37,12 @@ class mmtfp(CustomOp):
             lambda: f"mmtfp arg 'a': Expected 2d or 3d tensor (got {a_desc.t.shape})",
         )
         torch._check(
-            not rest, f"mmtfp arg 'bT': Expected 2d tensor (got {bT_desc.t.shape})"
+            not rest,
+            lambda: f"mmtfp arg 'bT': Expected 2d tensor (got {bT_desc.t.shape})",
         )
         torch._check(
             a_k == bT_k,
-            f"mmtfp arg 'bT': Expected matching K dimension ({a_k} vs {bT_k})",
+            lambda: f"mmtfp arg 'bT': Expected matching K dimension ({a_k} vs {bT_k})",
         )
 
         # Specialize on the k and n dims.

--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -22,3 +22,4 @@ from .signatures import *
 # Ensure that implementations are registered.
 from . import default_impls
 from . import custom_impls
+from . import sharded_impls

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -12,52 +12,54 @@ from torch import Tensor, dtype
 import torch.nn.functional as F
 
 from ..types import InferenceTensor, PrimitiveTensor, QuantizedTensor
+from ._registry import unbox_tensor
 from .signatures import *
+
+# Elementwise
+@elementwise.override(Tensor)
+def elementwise_unary(operator, x):
+    x = unbox_tensor(x)
+    return operator(x)
+
+
+@elementwise.override(Tensor, Tensor)
+def elementwise_binary(operator, x, y):
+    x = unbox_tensor(x)
+    y = unbox_tensor(y)
+    return operator(x, y)
 
 
 # Embedding Lookup
 
 
 @embedding_lookup.override(Tensor, Tensor)
-def embedding_lookup_default(input: Tensor, embedding_matrix: Tensor, dtype: dtype):
-    return F.embedding(input, embedding_matrix.to(dtype))
-
-
-@embedding_lookup.override(Tensor, PrimitiveTensor)
-def embedding_lookup_Tensor_PrimitiveTensor(
-    input: Tensor, embedding_matrix: PrimitiveTensor, dtype: dtype
-):
-    return F.embedding(input, embedding_matrix.as_torch(dtype=dtype))
+def embedding_lookup_default(input, embedding_matrix, dtype: dtype):
+    return F.embedding(unbox_tensor(input), unbox_tensor(embedding_matrix).to(dtype))
 
 
 @embedding_lookup.override(Tensor, QuantizedTensor)
 def embedding_lookup_Tensor_QuantizedTensor(
-    input: Tensor, embedding_matrix: QuantizedTensor, dtype: dtype
+    input, embedding_matrix: QuantizedTensor, dtype: dtype
 ):
     dequant = embedding_matrix.unpack().dequant(dtype=dtype)
-    return F.embedding(input, dequant)
+    return F.embedding(unbox_tensor(input), dequant)
 
 
 # Matmul
 @matmul.override(Tensor, Tensor)
-def matmul_default(lhs: Tensor, rhs: Tensor, *, transpose_rhs: bool) -> Tensor:
+def matmul_default(lhs, rhs, *, transpose_rhs: bool) -> Tensor:
+    lhs = unbox_tensor(lhs)
+    rhs = unbox_tensor(rhs)
     if transpose_rhs:
         rhs = rhs.T
     return torch.matmul(lhs, rhs.to(lhs.dtype))
 
 
-@matmul.override(Tensor, PrimitiveTensor)
-def matmul_Tensor_PrimitiveTensor(
-    lhs: Tensor, rhs: PrimitiveTensor, *, transpose_rhs: bool
-) -> Tensor:
-    rhs_torch = rhs.as_torch(dtype=lhs.dtype)
-    return matmul_default(lhs, rhs_torch, transpose_rhs=transpose_rhs)
-
-
 @matmul.override(Tensor, QuantizedTensor)
-def matmul_Tensor_PrimitiveTensor(
-    lhs: Tensor, rhs: QuantizedTensor, *, transpose_rhs: bool
+def matmul_Tensor_QuantizedTensor(
+    lhs, rhs: QuantizedTensor, *, transpose_rhs: bool
 ) -> Tensor:
+    lhs = unbox_tensor(lhs)
     rhs_torch = rhs.unpack().dequant(lhs.dtype)
     return matmul_default(lhs, rhs_torch, transpose_rhs=transpose_rhs)
 
@@ -66,24 +68,32 @@ def matmul_Tensor_PrimitiveTensor(
 
 
 @rms_norm.override(Tensor, Tensor)
-def rms_norm_default(x: Tensor, weight: Tensor, *, epsilon: float) -> Tensor:
+def rms_norm_default(x, weight, *, epsilon: float) -> Tensor:
+    x = unbox_tensor(x)
+    weight = unbox_tensor(weight)
     variance = x.pow(2).mean(-1, keepdim=True)
     output = x * torch.rsqrt(variance + epsilon)
     output = output * weight
     return output
 
 
-@rms_norm.override(Tensor, PrimitiveTensor)
-def rms_norm_Tensor_PrimitiveTensor(
-    x: Tensor, weight: PrimitiveTensor, *, epsilon: float
-) -> Tensor:
-    weight = weight.as_torch(dtype=x.dtype)
-    return rms_norm_default(x, weight, epsilon=epsilon)
-
-
 @rms_norm.override(Tensor, QuantizedTensor)
 def rms_norm_Tensor_QuantizedTensor(
-    x: Tensor, weight: PrimitiveTensor, *, epsilon: float
+    x, weight: PrimitiveTensor, *, epsilon: float
 ) -> Tensor:
+    x = unbox_tensor(x)
     weight = weight.unpack().dequant(x.dtype)
     return rms_norm_default(x, weight, epsilon=epsilon)
+
+
+# Sharded default impls (do nothing).
+
+
+@sharded_cat.override(Tensor)
+def sharded_cat_unsharded(maybe_sharded):
+    return unbox_tensor(maybe_sharded)
+
+
+@sharded_sum.override(Tensor)
+def sharded_sum_unsharded(maybe_sharded):
+    return unbox_tensor(maybe_sharded)

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from torch import Tensor, dtype
+import torch.nn.functional as F
+
+from ..types import InferenceTensor, ShardedPrimitiveTensor
+from ._registry import unbox_tensor
+from .signatures import *
+
+# Sharded elementwise.
+
+
+@elementwise.override(ShardedPrimitiveTensor)
+def sharded_elementwise_unary(operator, x: ShardedPrimitiveTensor):
+    partials = [operator(unbox_tensor(pt)) for pt in x.shards]
+    return ShardedPrimitiveTensor(shard_dim=x.shard_dim, shape=x.shape, ts=partials)
+
+
+@elementwise.override(ShardedPrimitiveTensor, ShardedPrimitiveTensor)
+def sharded_elementwise_binary(
+    operator, x: ShardedPrimitiveTensor, y: ShardedPrimitiveTensor
+):
+    assert x.shard_count == y.shard_count
+    assert x.shard_dim == y.shard_dim
+    pt_xs = [unbox_tensor(pt) for pt in x.shards]
+    pt_ys = [unbox_tensor(pt) for pt in y.shards]
+    partials = [operator(pt_x, pt_y) for pt_x, pt_y in zip(pt_xs, pt_ys)]
+    return ShardedPrimitiveTensor(shard_dim=x.shard_dim, shape=x.shape, ts=partials)
+
+
+# Sharded matmuls.
+
+
+@matmul.override(Tensor, ShardedPrimitiveTensor)
+def matmul_sharded_rhs(lhs, rhs: ShardedPrimitiveTensor, *, transpose_rhs: bool):
+    # When multiplying (unsharded, sharded), the rhs must be sharded by column.
+    # In a transposed configuration, this is axis 0, otherwise 1.
+    # This will result in a ShardedTensor, sharded by column.
+    lhs = unbox_tensor(lhs)
+    rhs_shard_dim = rhs.shard_dim
+    if transpose_rhs:
+        assert (
+            rhs_shard_dim == 0
+        ), f"matmul[sharded, transposed rhs] must be sharded on dim 0 but is {rhs_shard_dim}"
+    else:
+        assert (
+            rhs_shard_dim == 1
+        ), f"matmul[sharded rhs] must be sharded on dim 1 but is {rhs_shard_dim}"
+    partials = [
+        matmul(lhs, partial_rhs, transpose_rhs=transpose_rhs)
+        for partial_rhs in rhs.shards
+    ]
+    # The partial is sharded columnwise (last dim).
+    return ShardedPrimitiveTensor(shard_dim=len(lhs.shape) - 1, ts=partials)
+
+
+@matmul.override(ShardedPrimitiveTensor, ShardedPrimitiveTensor)
+def matmul_sharded(
+    lhs: ShardedPrimitiveTensor, rhs: ShardedPrimitiveTensor, *, transpose_rhs: bool
+):
+    if lhs.shard_count != rhs.shard_count:
+        raise ValueError(
+            f"Cannot matmul sharded tensors of different shard_count: "
+            f"({lhs.shard_count} vs {rhs.shard_count})"
+        )
+    partials = [
+        matmul(partial_lhs, partial_rhs, transpose_rhs=transpose_rhs)
+        for partial_lhs, partial_rhs in zip(lhs.shards, rhs.shards)
+    ]
+    return ShardedPrimitiveTensor(shard_dim=lhs.shard_dim, ts=partials)
+
+
+# Sharded sum.
+
+
+@sharded_cat.override(ShardedPrimitiveTensor)
+def sharded_cat_unsharded(maybe_sharded: ShardedPrimitiveTensor):
+    shard_ts = [t.as_torch() for t in maybe_sharded.shards]
+    return torch.cat(shard_ts, dim=maybe_sharded.shard_dim)
+
+
+@sharded_sum.override(ShardedPrimitiveTensor)
+def sharded_sum_sharded(maybe_sharded: ShardedPrimitiveTensor):
+    # TODO: Should implement as an all reduce.
+    shards = maybe_sharded.shards
+    accum = shards[0].as_torch()
+    for shard in shards[1:]:
+        accum = torch.add(accum, shard.as_torch())
+    return accum

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -82,7 +82,7 @@ class MatmulTest(unittest.TestCase):
         torch.testing.assert_close(result, expected)
         self.assertIs(
             ops._registry._TEST_LAST_OP_DISPATCH,
-            ops.custom_impls.matmul_mmtfp_tensor_primitive_tensor,
+            ops.custom_impls.matmul_mmtfp_tensor_tensor,
         )
 
     def testTorchImplTransposedQuantizedRHS_BlockScaledLayout(self):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1,0 +1,104 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank import ops
+from sharktank.types import *
+
+
+class MatmulTest(unittest.TestCase):
+    def testTorchRHSColumnShardedTransposed(self):
+        t1 = torch.rand(4, 32, 16, dtype=torch.float32)
+        t2 = torch.rand(48, 16, dtype=torch.float16)
+        # RHS is transposed, so dim0 is the "column". Shard into 12.
+        t2_sharded = ShardedPrimitiveTensor(shard_dim=0, ts=t2.split(4, dim=0))
+        sharded_result = ops.matmul(t1, t2_sharded)
+        expected_result = ops.matmul(t1, t2)
+        unsharded_result = ops.sharded_cat(sharded_result)
+        torch.testing.assert_close(unsharded_result, expected_result)
+
+    def testTorchRHSColumnSharded(self):
+        t1 = torch.rand(4, 32, 16, dtype=torch.float32)
+        t2 = torch.rand(16, 48, dtype=torch.float16)
+        t2_sharded = ShardedPrimitiveTensor(shard_dim=1, ts=t2.split(4, dim=1))
+        sharded_result = ops.matmul(t1, t2_sharded, transpose_rhs=False)
+        expected_result = ops.matmul(t1, t2, transpose_rhs=False)
+        unsharded_result = ops.sharded_cat(sharded_result)
+        torch.testing.assert_close(unsharded_result, expected_result)
+
+    def testShardedChainMatmulX2Transposed(self):
+        # Computes Z = (XA)B (sharded by 8).
+        X = torch.rand(4, 32, 16, dtype=torch.float32)
+        A = torch.rand(48, 16, dtype=torch.float16)
+        B = torch.rand(16, 48, dtype=torch.float16)
+        XA = ops.matmul(X, A)
+        Z = ops.matmul(XA, B)
+
+        # Columnwise sharding of A matrix (transposed).
+        A_sharded = ShardedPrimitiveTensor(shard_dim=0, ts=A.split(6, dim=0))
+        assert A_sharded.shard_count == 8
+        # Rowwise sharding of B matrix (transposed).
+        B_sharded = ShardedPrimitiveTensor(shard_dim=1, ts=B.split(6, dim=1))
+        assert B_sharded.shard_count == 8
+
+        XA_sharded = ops.matmul(X, A_sharded)
+        Z_sharded = ops.matmul(XA_sharded, B_sharded)
+        Z_unsharded = ops.sharded_sum(Z_sharded)
+        torch.testing.assert_close(Z_unsharded, Z)
+
+    def testShardedFFNTransposed(self):
+        input = torch.rand(4, 32, 64, dtype=torch.float32)
+        unsharded_ffn_gate_weight = torch.rand(128, 64, dtype=torch.float16)
+        unsharded_ffn_down_weight = torch.rand(64, 128, dtype=torch.float16)
+        unsharded_ffn_up_weight = torch.rand(128, 64, dtype=torch.float16)
+
+        def compute(input, ffn_gate_weight, ffn_down_weight, ffn_up_weight):
+            ffn_gate = ops.elementwise(
+                torch.nn.functional.silu, ops.matmul(input, ffn_gate_weight)
+            )
+            ffn_up = ops.matmul(input, ffn_up_weight)
+            ffn_down = ops.matmul(
+                ops.elementwise(torch.mul, ffn_gate, ffn_up), ffn_down_weight
+            )
+            summed = ops.sharded_sum(ffn_down)
+            return summed
+
+        Z_ref = compute(
+            input,
+            unsharded_ffn_gate_weight,
+            unsharded_ffn_down_weight,
+            unsharded_ffn_up_weight,
+        )
+
+        # Columnwise sharding of gate and up weight (transposed).
+        sharded_ffn_gate_weight = ShardedPrimitiveTensor(
+            shard_dim=0, ts=unsharded_ffn_gate_weight.split(16, dim=0)
+        )
+        sharded_ffn_up_weight = ShardedPrimitiveTensor(
+            shard_dim=0, ts=unsharded_ffn_up_weight.split(16, dim=0)
+        )
+        assert sharded_ffn_gate_weight.shard_count == 8
+        assert sharded_ffn_up_weight.shard_count == 8
+
+        # Rowwise sharding of down weight (transposed).
+        sharded_ffn_down_weight = ShardedPrimitiveTensor(
+            shard_dim=1, ts=unsharded_ffn_down_weight.split(16, dim=1)
+        )
+        assert sharded_ffn_down_weight.shard_count == 8
+        Z_sharded = compute(
+            input,
+            sharded_ffn_gate_weight,
+            sharded_ffn_down_weight,
+            sharded_ffn_up_weight,
+        )
+        torch.testing.assert_close(Z_sharded, Z_ref)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This level of math is aimed at the inner-most level of the device hierarchy, where it is assumed that the devices connected to a process are connected via high-speed links. By coding the model with explicit sharded arithmetic, we naturally get multi-device distribution by having a few points where we insert communication primitives. In this approach, the same math expressions run on either unary or nary-sharded tensor-parallel weight partitions. Using duck typing, the nary-sharded partitions are seen as a `ShardedTensor` and corresponding duplication of the math is undertaken. Unlike fully automatic solutions, this approach *requires* that the model author does some minimal coding for placement and distribution. In practice, this is unavoidable anyway, so by taking the layers of automation out of it, it is at least transparent, can be inspected eagerly, etc.

New ops:

* `elementwise`: Apply a sharded or unsharded unary/binary elementwise operator.
* `sharded_cat`: Concatenate across the sharding dimension or return an unsharded tensor as is.
* `sharded_sum`: Sum all shards or return unsharded tensor as is.

Adds implementation variants for:

* `matmul_sharded_rhs`: Matmul operating on a global lhs and a sharded rhs. This is typically the first layer in a multi step sequence. Returns a sharded tensor.
* `matmul_sharded`: Matmul operating on a sharded lhs and rhs. Performs partial matmuls on each shard, returning a sharded result tensor.

It is left to the user, based on the arrangement of the math to choose how to reduce a final result from a ShardedTensor to a unary one.

For now, not implemented on QuantizedTensors because additional infra will be needed for row-wise sharding.