### PR TITLE
Ignore errors in `shutil.rmtree`, fixing test failure on Windows.

### DIFF
--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -20,7 +20,7 @@ class MainRunnerTestBase(unittest.TestCase):
         self._temp_dir = Path(tempfile.mkdtemp(type(self).__qualname__))
 
     def tearDown(self):
-        shutil.rmtree(self._temp_dir)
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
 
     def get_file_path(self, name: str) -> Path:
         return self._temp_dir / name


### PR DESCRIPTION
This fixes errors during cleanup on Windows like:

```
============================================ FAILURES ============================================= _________________________________ ShardingTests.testExportFfnNet __________________________________

path = WindowsPath('C:/Users/Scott/AppData/Local/Temp/tmpi6mjj021ShardingTests')
onerror = <function onerror at 0x000001CE81C54FE0>

    def _rmtree_unsafe(path, onerror):
        try:
            with os.scandir(path) as scandir_it:
                entries = list(scandir_it)
        except OSError:
            onerror(os.scandir, path, sys.exc_info())
            entries = []
        for entry in entries:
            fullname = entry.path
            if _rmtree_isdir(entry):
                try:
                    if entry.is_symlink():
                        # This can only happen if someone replaces
                        # a directory with a symlink after the call to
                        # os.scandir or entry.is_dir above.
                        raise OSError("Cannot call rmtree on a symbolic link")
                except OSError:
                    onerror(os.path.islink, fullname, sys.exc_info())
                    continue
                _rmtree_unsafe(fullname, onerror)
            else:
                try:
>                   os.unlink(fullname)
E                   PermissionError: [WinError 5] Access is denied: 'C:\\Users\\Scott\\AppData\\Local\\Temp\\tmpi6mjj021ShardingTests\\ffn.rank0.irpa'

C:\Program Files\Python311\Lib\shutil.py:620: PermissionError

During handling of the above exception, another exception occurred:
sharktank\sharktank\utils\testing.py:44: in tearDown
    shutil.rmtree(self._temp_dir, onerror=onerror)
C:\Program Files\Python311\Lib\shutil.py:759: in rmtree
    return _rmtree_unsafe(path, onerror)
C:\Program Files\Python311\Lib\shutil.py:622: in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
```

The directory cleanup appears to succeed anyways, so ignoring errors on individual file operations in `tearDown` seems fine to me.