### PR TITLE
Enable ci.yml tests on Windows.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{matrix.os}}
     env:
       PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,11 @@ jobs:
       matrix:
         version: [3.11]
         os: [ubuntu-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        shell: bash
     env:
       PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
     steps:


### PR DESCRIPTION
If we want this coverage (it would help me as I develop mainly on Windows).

The Linux job currently take ~1 minute, Windows take ~3 minutes (mostly extra take taken installing deps via pip).

~~There is one test failure at the moment, which https://github.com/nod-ai/sharktank/pull/34 will fix.~~