### PR TITLE
Fix validate_*_model.py scripts, plumb dtype in llama_ref.

### DIFF
--- a/sharktank/sharktank/examples/validate_llama_ref_model.py
+++ b/sharktank/sharktank/examples/validate_llama_ref_model.py
@@ -21,9 +21,12 @@ def main(args: list[str]):
     parser = cli.create_parser()
     cli.add_input_dataset_options(parser)
     args = cli.parse(parser)
-    config = cli.get_input_dataset(args)
-    hp = configs.LlamaHParams.from_gguf_props(config.properties)
-    model = DirectCacheLlamaModelV1(config.root_theta, hp)
+
+    dataset = cli.get_input_dataset(args)
+    hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
+    ref_llama_config = RefLlamaModelConfig(hp)
+    ref_llama_config.activation_dtype = torch.float16
+    model = DirectCacheLlamaModelV1(dataset.root_theta, ref_llama_config)
 
     kv_cache = model.create_cache(bs=1)
     start_index = 0

--- a/sharktank/sharktank/examples/validate_paged_llama_model.py
+++ b/sharktank/sharktank/examples/validate_paged_llama_model.py
@@ -14,12 +14,20 @@ from sharktank.models.llama.llama import *
 
 
 def main(args: list[str]):
+    from ..utils import cli
+
     torch.no_grad().__enter__()
-    config = Dataset.load(args[0])
-    hp = configs.LlamaHParams.from_gguf_props(config.properties)
+
+    parser = cli.create_parser()
+    cli.add_input_dataset_options(parser)
+    args = cli.parse(parser)
+
+    dataset = cli.get_input_dataset(args)
+    hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
     llama_config = LlamaModelConfig(hp)
     llama_config.activation_dtype = torch.float16
-    model = PagedLlamaModelV1(config.root_theta, llama_config)
+    model = PagedLlamaModelV1(dataset.root_theta, llama_config)
+
     cache_state = model.cache.paged.allocate(128)
     start_index = 0
     next_batch = torch.tensor(


### PR DESCRIPTION
Both of these commands work now:

```bash
python -m sharktank.examples.validate_paged_llama_model --hf-dataset=open_llama_3b_v2_f16_gguf
python -m sharktank.examples.validate_llama_ref_model --hf-dataset=open_llama_3b_v2_f16_gguf
```

Changes:

* Fixed these scripts to use the latest dataset utilities, avoiding errors about flag parsing:

    ```
    (sharktank) λ python -m sharktank.examples.validate_paged_llama_model --hf-dataset=open_llama_3b_v2_f16_gguf
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "D:\dev\projects\sharktank\sharktank\sharktank\examples\validate_paged_llama_model.py", line 184, in <module>
        sys.exit(main(sys.argv[1:]))
                 ^^^^^^^^^^^^^^^^^^
      File "D:\dev\projects\sharktank\sharktank\sharktank\examples\validate_paged_llama_model.py", line 25, in main
        dataset = Dataset.load(args[0])
                               ~~~~^^^
    TypeError: 'Namespace' object is not subscriptable
    ```

* Plumbed `activation_dtype` through the ref model, fixing:

    ```
    (sharktank) λ python -m sharktank.examples.validate_llama_ref_model --hf-dataset=open_llama_3b_v2_f16_gguf
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "D:\dev\projects\sharktank\sharktank\sharktank\examples\validate_llama_ref_model.py", line 46, in <module>
        sys.exit(main(sys.argv[1:]))
                 ^^^^^^^^^^^^^^^^^^
      File "D:\dev\projects\sharktank\sharktank\sharktank\examples\validate_llama_ref_model.py", line 27, in main
        model = DirectCacheLlamaModelV1(dataset.root_theta, hp)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "D:\dev\projects\sharktank\sharktank\sharktank\models\llama\llama_ref.py", line 35, in __init__
        TokenEmbeddingLayer(theta("token_embd"), dtype=hp.activation_dtype),
                                                       ^^^^^^^^^^^^^^^^^^^
    AttributeError: 'LlamaHParams' object has no attribute 'activation_dtype'
    ```