### PR TITLE
Export using "direct" kv_cache_type with batch size 1.

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Inference support for the PagedLLMV1 protocol of models."""
+"""Export support for the PagedLLMV1 protocol of models."""
 
 import json
 import torch
@@ -28,17 +28,25 @@ def main():
         help="Output file path for exported MLIR file",
         default="/tmp/batch_llama_v1.mlir",
     )
-
     parser.add_argument(
         "--output_config",
         help="Output file path for exported config file",
         default="/tmp/batch_llama_v1.json",
     )
+    parser.add_argument(
+        "--bs",
+        help="Comma-separated batch size(s) to generate, e.g. `4` or `2,4`",
+        type=lambda arg: [int(bs) for bs in arg.split(",")],
+        default="4",
+    )
+
     args = cli.parse(parser)
     dataset = cli.get_input_dataset(args)
 
     hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
-    model = PagedLlamaModelV1(dataset.root_theta, LlamaModelConfig(hp))
+    llama_config = LlamaModelConfig(hp)
+    llama_config.kv_cache_type = "direct" if args.bs == [1] else "paged"
+    model = PagedLlamaModelV1(dataset.root_theta, llama_config)
 
     def generate_params_json(hp, prefill_bs: list[int], decode_bs: list[int]):
         return {
@@ -65,15 +73,27 @@ def main():
         tokens = torch.empty(bs, 64, dtype=torch.int64)
         seq_lens = torch.empty(bs, dtype=torch.int64)
         seq_block_ids = torch.empty(bs, 4, dtype=torch.int64)
-        cache_state = model.cache.allocate(128)
         block_dim = torch.export.Dim("block", max=2047 // 16)
         sl_dim = 16 * block_dim
-        page_dim = torch.export.Dim("page")
+
+        if model.config.kv_cache_type == "paged":
+            cache_state = model.cache.allocate(page_count=128)
+            page_dim = torch.export.Dim("page")
+            cache_state_dynamic_shapes = [{0: page_dim}]
+        elif model.config.kv_cache_type == "direct":
+            cache_state = model.cache.allocate(bs=1)
+            # Direct cache dimensions:
+            #   2 * transformer_block_count of...
+            #   [bs, seq_length, attn_head_count, attn_head_dim]
+            cache_state_dynamic_shapes = (2 * hp.block_count) * [{}]
+        else:
+            raise NotImplementedError(f"Unsupported KV cache type: {type(model.cache)}")
+
         dynamic_shapes = {
             "tokens": {1: sl_dim},
             "seq_lens": {},
             "seq_block_ids": {1: block_dim},
-            "cache_state": [{0: page_dim}],
+            "cache_state": cache_state_dynamic_shapes,
         }
 
         print(f"Exporting prefill_bs{bs}")
@@ -100,15 +120,27 @@ def main():
         seq_lens = torch.ones(bs, dtype=torch.int64)
         start_positions = torch.ones(bs, dtype=torch.int64)
         seq_block_ids = torch.zeros(bs, 4, dtype=torch.int64)
-        cache_state = model.cache.allocate(128)
         block_dim = torch.export.Dim("block", max=2047 // 16)
-        page_dim = torch.export.Dim("page")
+
+        if model.config.kv_cache_type == "paged":
+            cache_state = model.cache.allocate(page_count=128)
+            page_dim = torch.export.Dim("page")
+            cache_state_dynamic_shapes = [{0: page_dim}]
+        elif model.config.kv_cache_type == "direct":
+            cache_state = model.cache.allocate(bs=1)
+            # Direct cache dimensions:
+            #   2 * transformer_block_count of...
+            #   [bs, seq_length, attn_head_count, attn_head_dim]
+            cache_state_dynamic_shapes = (2 * hp.block_count) * [{}]
+        else:
+            raise NotImplementedError(f"Unsupported KV cache type: {type(model.cache)}")
+
         dynamic_shapes = {
             "tokens": {},
             "seq_lens": {},
             "start_positions": {},
             "seq_block_ids": {1: block_dim},
-            "cache_state": [{0: page_dim}],
+            "cache_state": cache_state_dynamic_shapes,
         }
 
         print(f"Exporting decode_bs{bs}")
@@ -146,9 +178,7 @@ def main():
             return logits
 
     bsizes = []
-    for bs in [
-        4,
-    ]:
+    for bs in args.bs:
         generate_batch_prefill(bs)
         generate_batch_decode(bs)
         bsizes.append(bs)


### PR DESCRIPTION
It sounds like we'll end up with a bs1-only variant for client use and a bsN variant for serving with a couple of batch sizes compiled in that can be switched between dynamically to optimize for throughput.

* A new `--bs` argument can be used to specify batch sizes:

    flag | result
    -- | --
    --bs=1 | direct cache, batch size 1
    --bs=4 | paged cache, batch size 4
    --bs=1,4 | paged cache, batch sizes 1 and 4
    --bs=2,4,8 | paged cache, batch sizes 2, 4, and 8

* `prefill_bs1` exports successfully, with `generate_batch_decode(bs)` commented out and a command like

    ```
    python -m sharktank.examples.export_paged_llm_v1 \
        --hf-dataset=open_llama_3b_v2_f16_gguf \
        --output_mlir=/tmp/llama_prefill_bs1.mlir \
        --output_config=/tmp/llama_prefill_bs1.json \
        --bs=1
    ```

* `decode_bs1` fails during fx tracing, see the TODO in `transact_cache_direct()` to use index ops

---

TODO: 

- [ ] Resolve TODOs in `validate_direct_llama_model.py`, unless we don't want that script in the first place
- [ ] Update decode so it exports, by switching to using index ops