### PR TITLE
Implement quantization import for punet model.

### DIFF
--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .base import BaseLayer, ThetaLayer
+from .conv import Conv2DLayer
 from .kv_cache import BaseKVCache, DirectKVCache, PagedKVCache
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer

--- a/sharktank/sharktank/layers/conv.py
+++ b/sharktank/sharktank/layers/conv.py
@@ -1,0 +1,197 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional, Tuple
+
+import torch
+
+from .. import ops
+from ..types import *
+
+from .base import Theta, ThetaLayer
+
+
+__all__ = [
+    "Conv2DLayer",
+]
+
+
+class Conv2DLayer(ThetaLayer):
+    """Theta based conv2d layer. This assumes weight/bias naming as per the nn.Conv2D
+    module ("weight", "bias").
+
+    This layer is being adapted for quantization. See LinearLayer for full docs
+    while this is being worked out.
+    """
+
+    def __init__(
+        self, theta: Theta, padding: Optional[Tuple[int, int]] = None, stride: int = 1
+    ):
+        super().__init__(theta)
+        assert padding is None or len(padding) == 2
+        self.padding = padding
+        self.stride = stride
+        self.dilation = 1
+        self.groups = 1
+
+        self.weight = self.theta.tensor("weight")
+        self.bias = self.theta.optional_tensor("bias")
+
+        # Input premultiplier.
+        self.premul_input = theta.optional_tensor("premul_input")
+
+        # Get mode specific tensors.
+        self.mode: Optional[str] = None
+        self.fq_input: Optional[QuantizerTensor] = theta.optional_tensor("fq_input")
+        self.fq_output: Optional[QuantizerTensor] = theta.optional_tensor("fq_output")
+        self.q_input: Optional[QuantizerTensor] = theta.optional_tensor("q_input")
+        self.q_output: Optional[QuantizerTensor] = theta.optional_tensor("q_output")
+        self.dq_output: Optional[QuantizerTensor] = theta.optional_tensor("dq_output")
+
+        if self.fq_input is not None:
+            assert self.mode is None, f"Cannot enable fq mode and {self.mode}"
+            self.mode = "fq"
+            self._validate_fake_quant_mode()
+
+        if (
+            self.q_input is not None
+            or self.q_output is not None
+            or self.dq_output is not None
+        ):
+            assert self.mode is None, f"Cannot enable native quant mode and {self.mode}"
+            self.mode = "native_quant"
+            self._validate_native_quant_mode()
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        mode = self.mode
+        x = input
+        weight = self.weight
+        bias = self.bias
+
+        if self.premul_input is not None:
+            x = ops.elementwise(torch.mul, x, self.premul_input)
+
+        # Regular or fakequant mode.
+        if mode is None or mode == "fq":
+            # Input conditioning.
+            if self.mode == "fq":
+                orig_weight_layout = weight.unpack()
+                weight = orig_weight_layout.dequant()
+                x = self.fq_input.quantize(x)
+                orig_x_layout = x.unpack()
+                x = orig_x_layout.dequant()
+                if isinstance(bias, QuantizedTensor):
+                    bias = bias.unpack().dequant()
+
+            # Primary computation.
+            y = ops.conv2d(
+                x,
+                weight=weight,
+                bias=bias,
+                stride=self.stride,
+                padding=self.padding,
+                dilation=self.dilation,
+                groups=self.groups,
+            )
+
+            # Output conditioning.
+            if self.mode == "fq":
+                fq_output = self.fq_output
+                if fq_output is not None:
+                    # Static output quantization.
+                    y = fq_output.quantize(y).unpack().dequant()
+            return y
+
+        # Native quant mode.
+        # TODO: This needs to be completely replumbed into a couple of different
+        # fused ops. For the moment, though, we skate by with simulating it
+        # via normal ops.
+        if mode == "native_quant":
+            q_input = self.q_input
+            q_output = self.q_output
+            dq_output = self.dq_output
+            if q_input is not None:
+                x = q_input.quantize(x)
+
+            # TODO: We should be calling an explicit qmatmul that can take
+            # the output quantizer. For the moment, we ignore dq_output
+            # entirely and only act on a q_output.
+            # Primary computation.
+            y = ops.conv2d(
+                x,
+                weight=weight,
+                bias=bias,
+                stride=self.stride,
+                padding=self.padding,
+                dilation=self.dilation,
+                groups=self.groups,
+            )
+
+            if dq_output is not None and not isinstance(
+                dq_output, DynamicScaledQuantizer
+            ):
+                y = dq_output.quantize(y).unpack().dequant()
+
+            if q_output is not None:
+                y = q_output.quantize(y)
+
+            return y
+
+        raise AssertionError(f"Conv2DLayer unhandled mode '{mode}'")
+
+    def _validate_fake_quant_mode(self):
+        fq_input = self.fq_input
+        fq_output = self.fq_output
+        weight = self.weight
+        if not isinstance(fq_input, QuantizerTensor):
+            raise (
+                f"Conv2DLayer requires fq_input to be a QuantizerTensor, "
+                f"but got: {fq_input}"
+            )
+        if fq_output is not None:
+            if not isinstance(fq_output, QuantizerTensor):
+                raise (
+                    f"Conv2DLayer requires fq_output to be a QuantizerTensor, "
+                    f"but got: {fq_output}"
+                )
+        else:
+            # Dynamic quant mode requires a *ScaledQuantizer for the input
+            # and a TensorScaledLayout weight tensor.
+            if not isinstance(
+                fq_input, (StaticScaledQuantizer, DynamicScaledQuantizer)
+            ):
+                raise AssertionError(
+                    f"Conv2DLayer with a fq_output=None requires a "
+                    f"[Static|Dynamic]ScaledQuantizer for fq_input, but got: "
+                    f"{repr(fq_input)}"
+                )
+            if not isinstance(weight, QuantizedTensor):
+                raise AssertionError(
+                    f"Conv2DLayer with a fq_output=None requires a weight "
+                    f"of type QuantizedTensor, but got: {repr(weight)}"
+                )
+            if not issubclass(weight.layout_type, TensorScaledLayout):
+                raise AssertionError(
+                    f"Conv2DLayer with a fq_output=None requires a QuantizedTensor "
+                    f"weight with TensorScaledLayout, but got: {weight.layout_type}"
+                )
+
+    def _validate_native_quant_mode(self):
+        q_input = self.q_input
+        q_output = self.q_output
+        dq_output = self.dq_output
+
+        if q_output is None and dq_output is None:
+            raise AssertionError(
+                f"One of q_output or dq_output must be specified in native "
+                f"quantized mode for Conv2DLayer"
+            )
+
+        if q_output is not None and dq_output is not None:
+            raise AssertionError(
+                f"Only one of q_output or dq_output can be specified for a "
+                f"Conv2DLayer but got both."
+            )

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -4,21 +4,103 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from typing import Optional
+
 import torch
 
 from .. import ops
 from .base import Theta, ThetaLayer
+from ..types.layout_utils import saturate_cast
+from ..types import (
+    DynamicScaledQuantizer,
+    QuantizedTensor,
+    QuantizerTensor,
+    StaticScaledQuantizer,
+    TensorScaledLayout,
+)
+
+__all__ = [
+    "LinearLayer",
+]
 
 
 class LinearLayer(ThetaLayer):
     """Linear layer which computes:
 
     ```
-    matmul(x, weight.T)
+    matmul(x, weight.T) + bias
     ```
 
     Whether the weight is transposed as part of the calculation can be
     controlled with `transpose_weight=` (default true).
+
+    This layer will operate in one of several modes based on the presence
+    of additional tensors in theta:
+
+    Weight-Only Quant Mode:
+    -----------------------
+    In this mode, the weight and/or bias is a QuantizedTensor but there is
+    no activation quantization information (unless if the input happens to
+    have already come in from a previous layer as a QuantizedTensor). In this
+    case, the default behavior of the matmul op depends on the exact form of
+    weight quantization. If a kernel exists to fuse the computation in some
+    way, it will be used. Otherwise, the fallback logic will dequantize the
+    weight and perform normal FP math. The compiler may still do some fusion
+    on this, depending on many things.
+
+    FakeQuant Mode:
+    ---------------
+    FakeQuant mode is activated if 'fq_input' and 'fq_output' are present.
+    If present, they are expected to be of type `QuantizerTensor`. In this mode:
+
+      * Weight and bias will be dequantized if appropriate (typically, these
+        will be stored as some form of QuantizedTensor).
+      * The input will be quantized and then dequantized according to the
+        'fq_input' quantizer.
+      * If there is no 'fq_output' quantizer, we fall back to
+        "dynamic quantization"
+        mode, where we will dynamically compute an estimated output quantizer
+        by multiplying the input scale by the weight scale. This only works
+        for TensorScaledLayouts and is meant to simulate the fused dynamic
+        quantization mode.
+      * The output of the linear computation is quantized and then dequantized
+        by the 'fq_output' quantizer (whether explicit or computed).
+
+    While this mode is not particularly interesting for production deployments,
+    it duplicates closely the fake_quant logic typically used in simulators and
+    can help identify bugs and mismatches that can arise from more aggressive
+    techniques.
+
+    Native Quant Mode:
+    ------------------
+    In native quant mode, the goal is to perform quantized arithmetic. The types
+    of the inputs/weight/bias and an output quantizer dictate the precise
+    parameters of that arithmetic. The only required tensor in this mode is
+    either a 'q_output' or a 'dq_output':
+
+    * 'q_output' is used to specify output quantization parameters, and the
+      resulting QuantizedTensor is returned directly from the layer. This
+      means that any subsequent layer or operations must be prepared to handle
+      inputs with the exact quantization output from here.
+    * 'dq_output' is used to specify output quantization parameters and signal
+      the layer to dequantize back to a high precision tensor for return.
+      Downstream consumers will only see the high precision tensor.
+
+    There can also be an optional 'q_input' which specifies that the input to
+    the layer should be quantized according to this quantizer. If ommitted,
+    then the input to the layer *must* already be a QuantizedTensor (i.e. from
+    a producer).
+
+    Any of these quantizers may be a `DynamicScaledQuantizer`:
+
+    * For input quantizers, quantization parameters will be derived dynamically
+      based on the actual activation values.
+    * For output quantizers, quantization parameters will be estimated
+      dynamically based on the input/weight/bias quantizer/type.
+
+    The bias tensor is expected to be either a `QuantizedTensor` with the
+    same scaling as the output or a primitive tensor that will be dynamically
+    quantized to the output scale for accumulation.
     """
 
     def __init__(
@@ -36,8 +118,104 @@ class LinearLayer(ThetaLayer):
             self.bias = self.theta_tensor(bias_name)
         self.transpose_weight = transpose_weight
 
-    def forward(self, x: torch.Tensor):
-        x = ops.matmul(x, self.weight, transpose_rhs=self.transpose_weight)
-        if self.bias is not None:
-            x = ops.elementwise(torch.add, x, self.bias)
-        return x
+        # Get mode specific tensors.
+        self.mode: Optional[str] = None
+        self.fq_input: QuantizerTensor = theta.optional_tensor("fq_input")
+        self.fq_output: QuantizerTensor = theta.optional_tensor("fq_output")
+
+        if self.fq_input is not None:
+            assert self.mode is None, f"Cannot enable fq mode and {self.mode}"
+            self.mode = "fq"
+            self._validate_fake_quant_mode()
+
+    def forward(self, x):
+        mode = self.mode
+        weight = self.weight
+        bias = self.bias
+
+        # TODO: Implement native quant mode.
+
+        # Regular or fakequant mode.
+        if mode is None or mode == "fq":
+            # Input conditioning.
+            if self.mode == "fq":
+                orig_weight_layout = weight.unpack()
+                weight = orig_weight_layout.dequant()
+                x = self.fq_input.quantize(x)
+                orig_x_layout = x.unpack()
+                x = orig_x_layout.dequant()
+                if isinstance(bias, QuantizedTensor):
+                    bias = bias.unpack().dequant()
+
+            # Primary computation.
+            y = ops.matmul(x, weight, transpose_rhs=self.transpose_weight)
+            if bias is not None:
+                y = ops.elementwise(torch.add, y, bias)
+
+            # Output conditioning.
+            if self.mode == "fq":
+                fq_output = self.fq_output
+                if fq_output is None:
+                    # Dynamic output quantization.
+                    # TODO: With a bit of work, we could create a Quantizer
+                    # and use the normal arithmetic flow vs faking it here.
+                    # Dynamically compute output quant and simulate.
+                    # TODO: Better estimate of the output dynamic quant.
+                    reciprocal_scale = orig_weight_layout.d + orig_x_layout.d
+                    scale = 1.0 / reciprocal_scale
+                    offset = orig_weight_layout.m
+                    # Simulate quant.
+                    if offset is not None:
+                        qs = (y - offset) * scale
+                    else:
+                        qs = y * scale
+                    output_quant_dtype = orig_x_layout.qs.dtype
+                    qs = saturate_cast(qs, output_quant_dtype)
+                    # Dequant.
+                    output_dequant = reciprocal_scale * qs.to(y.dtype)
+                    if offset is not None:
+                        output_dequant = output_dequant + offset
+                    y = output_dequant
+                else:
+                    # Static output quantization.
+                    y = fq_output.quantize(y).unpack().dequant()
+            return y
+
+        raise AssertionError(f"LinearLayer unhandled mode")
+
+    def _validate_fake_quant_mode(self):
+        fq_input = self.fq_input
+        fq_output = self.fq_output
+        weight = self.weight
+        if not isinstance(fq_input, QuantizerTensor):
+            raise (
+                f"LinearLayer requires fq_input to be a QuantizerTensor, "
+                f"but got: {fq_input}"
+            )
+        if fq_output is not None:
+            if not isinstance(fq_output, QuantizerTensor):
+                raise (
+                    f"LinearLayer requires fq_output to be a QuantizerTensor, "
+                    f"but got: {fq_output}"
+                )
+        else:
+            # Dynamic quant mode requires a *ScaledQuantizer for the input
+            # and a TensorScaledLayout weight tensor.
+            if not isinstance(
+                fq_input, (StaticScaledQuantizer, DynamicScaledQuantizer)
+            ):
+                raise AssertionError(
+                    f"LinearLayer with a fq_output=None requires a "
+                    f"[Static|Dynamic]ScaledQuantizer for fq_input, but got: "
+                    f"{repr(fq_input)}"
+                )
+            if not isinstance(weight, QuantizedTensor):
+                raise AssertionError(
+                    f"LinearLayer with a fq_output=None requires a weight "
+                    f"of type QuantizedTensor, but got: {repr(weight)}"
+                )
+            if not issubclass(weight.layout_type, TensorScaledLayout):
+                raise AssertionError(
+                    f"LinearLayer with a fq_output=None requires a QuantizedTensor "
+                    f"weight with TensorScaledLayout, but got: {weight.layout_type}"
+                )

--- a/sharktank/sharktank/models/punet/layers.py
+++ b/sharktank/sharktank/models/punet/layers.py
@@ -18,7 +18,6 @@ from .config import *
 
 __all__ = [
     "ACTIVATION_FUNCTIONS",
-    "Conv2DLayer",
     "CrossAttnUpDownBlock2D",
     "GroupNormLayer",
     "TimestepEmbedding",
@@ -606,39 +605,6 @@ class TimestepProjection(nn.Module):
 ################################################################################
 # Layers that need to be made common once stable.
 ################################################################################
-
-
-class Conv2DLayer(ThetaLayer):
-    """Theta based conv2d layer. This assumes weight/bias naming as per the nn.Conv2D
-    module ("weight", "bias").
-
-    """
-
-    def __init__(
-        self, theta: Theta, padding: Optional[Tuple[int, int]] = None, stride: int = 1
-    ):
-        super().__init__(theta)
-        assert padding is None or len(padding) == 2
-        self.padding = padding
-        self.stride = stride
-        self.dilation = 1
-        self.groups = 1
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        weight = self.theta.tensor("weight")
-        if "bias" in self.theta.keys:
-            bias = self.theta.tensor("bias")
-        else:
-            bias = None
-        return ops.conv2d(
-            input,
-            weight=weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=self.dilation,
-            groups=self.groups,
-        )
 
 
 class GroupNormLayer(ThetaLayer):

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -4,12 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Imports huggingface config and params into a Dataset.
-
-This tool simply imports tensors and config with no transformation given a
-config.json and a safetensors file. Once sharding configurations are worked
-out, this should be replaced with a more general tool that can source from
-either HF or an existing IRPA file and transform/save in one step.
+"""Imports Brevitas pre-processed weights and quantization config into a 
+Dataset.
 
 Usage:
   python -m sharktank.models.punet.import_hf_dataset \
@@ -19,6 +15,9 @@ Usage:
 The resulting dataset has all tensors as nested in the original model.
 Properties are separated into a "meta" dict (for "_" prefixed props) and an
 "hparams" dict.
+
+Default flag values assume that there is a quant_param.json and 
+params.safetensors adjacent to the HF config.json file.
 """
 from typing import Optional
 

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -67,9 +67,9 @@ def apply_per_layer_quant(
         shape = qp[f"{name}_shape"]
         return torch.tensor(data_1d, dtype=dtype).reshape(shape)
 
-    input_scale = _get_json_tensor("input_scale", torch.float32)
+    input_scale = _get_json_tensor("input_scale", torch.float16)
     input_zp = _get_json_tensor("input_zp", torch.uint8)
-    weight_scale = _get_json_tensor("weight_scale", torch.float32)
+    weight_scale = _get_json_tensor("weight_scale", torch.float16)
     weight_zp = _get_json_tensor("weight_zp", torch.uint8)
     assert (
         weight_scale is not None and weight_zp is not None
@@ -116,11 +116,9 @@ def apply_per_layer_quant(
     updated_tensors[input_quantizer.name] = input_quantizer
 
     # Output dequant back to high precision.
-    output_scale = input_quantizer.scale * weight_quantizer.scale
-    output_quantizer = StaticScaledQuantizer(
+    # TODO: We are still working out output quantizer and how it interplays.
+    output_quantizer = DynamicScaledQuantizer(
         name=f"{layer_name}.dq_output",
-        scale=output_scale,
-        axis=0,
         dtype=weight_dtype,
     )
     updated_tensors[output_quantizer.name] = output_quantizer

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Imports Brevitas pre-processed weights and quantization config into a 
+"""Imports Brevitas pre-processed weights and quantization config into a
 Dataset.
 
 Usage:
@@ -16,7 +16,7 @@ The resulting dataset has all tensors as nested in the original model.
 Properties are separated into a "meta" dict (for "_" prefixed props) and an
 "hparams" dict.
 
-Default flag values assume that there is a quant_param.json and 
+Default flag values assume that there is a quant_param.json and
 params.safetensors adjacent to the HF config.json file.
 """
 from typing import Optional

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -1,0 +1,160 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Imports huggingface config and params into a Dataset.
+
+This tool simply imports tensors and config with no transformation given a
+config.json and a safetensors file. Once sharding configurations are worked
+out, this should be replaced with a more general tool that can source from
+either HF or an existing IRPA file and transform/save in one step.
+
+Usage:
+  python -m sharktank.models.punet.import_hf_dataset \
+    --output-irpa-file ~/models/punet/punet_fp16.irpa \
+    --config-json ~/models/stable-diffusion-xl-base-1.0/unet/config.json
+
+The resulting dataset has all tensors as nested in the original model.
+Properties are separated into a "meta" dict (for "_" prefixed props) and an
+"hparams" dict.
+"""
+from typing import Optional
+
+import json
+from pathlib import Path
+import safetensors
+import torch
+
+from ....types import *
+
+
+def _load_json(p: Path):
+    print(f"Loading {p}")
+    with open(p, "rb") as f:
+        return json.load(f)
+
+
+def _get_dataset_props(config_json_struct) -> dict:
+    # Separate meta parameters (prefixed with _) from hparams.
+    meta_params = {k: v for k, v in config_json_struct.items() if k.startswith("_")}
+    hparams = {k: v for k, v in config_json_struct.items() if not k.startswith("_")}
+    return {
+        "meta": meta_params,
+        "hparams": hparams,
+    }
+
+
+def _load_theta(st_source) -> Theta:
+    tensors = [
+        DefaultPrimitiveTensor(name=name, data=st_source.get_tensor(name))
+        for name in st_source.keys()
+    ]
+    return Theta(tensors)
+
+
+def apply_per_layer_quant(theta: Theta, qp):
+    # The config file has tensors as 1d and a _shape suffixed array with the
+    # concrete shape.
+    def _get_json_tensor(name: str, dtype: torch.dtype) -> Optional[torch.Tensor]:
+        data_1d = qp.get(name)
+        if data_1d is None:
+            return None
+        shape = qp[f"{name}_shape"]
+        return torch.tensor(data_1d, dtype=dtype).reshape(shape)
+
+    input_scale = _get_json_tensor("input_scale", torch.float32)
+    input_zp = _get_json_tensor("input_zp", torch.int32)
+    weight_scale = _get_json_tensor("weight_scale", torch.float32)
+    weight_zp = _get_json_tensor("weight_zp", torch.int32)
+    assert (
+        weight_scale is not None and weight_zp is not None
+    ), f"Could not find weight scale (in {qp.keys()})"
+
+    weight = theta.tensor("weight")
+    # TODO: There is ambiguity with respect to the axis of quantization and the
+    # shape of the scale. I think the intent was that the scale should have a
+    # broadcast ready shape, but they are all 1d. This model only does axis-0
+    # quantization, so we just assert that matches for now.
+    assert weight.shape[0] == weight_scale.shape[0], "Mismatched quantization axis"
+
+    # There is an implicit assumption that the weight is asym (uint8) quantized.
+    # Our quantizer uses scale/offset style:
+    #  round(t - offset) * scale)
+    #  round(t * scale - offset * scale)
+    # Whereas the params here are scale/zero-point:
+    #  round(t / scale + zp)
+    # We haven't used our infra for much asymmetric quant and may want to adapt
+    # zero point handling if rounding/precision is an issue.
+    quant_scale = 1.0 / weight_scale
+    quant_rscale = weight_scale
+    quant_offset = torch.neg(weight_zp * quant_rscale)
+    quantizer = StaticScaledQuantizer(
+        scale=quant_scale,
+        reciprocal_scale=quant_rscale,
+        axis=0,
+        offset=quant_offset,
+        dtype=torch.uint8,
+    )
+    weight_quant = quantizer.quantize(weight)
+    layout = weight_quant.unpack()
+    weight_dequant = layout.dequant()
+    print(f"ORIG:\n{weight.as_torch()[0]}")
+    print(f"DEQUANT:\n{weight_dequant[0]}")
+
+
+def main():
+    from ....utils import cli
+
+    parser = cli.create_parser()
+    cli.add_output_dataset_options(parser)
+    parser.add_argument(
+        "--config-json", type=Path, required=True, help="Path to the config.json file"
+    )
+    parser.add_argument(
+        "--params",
+        type=Path,
+        default=Path("params.safetensors"),
+        help="Parameter file name, relative to config.json",
+    )
+    parser.add_argument(
+        "--quant-params",
+        type=Path,
+        default=Path("quant_param.json"),
+        help="Quantization parameters",
+    )
+    args = cli.parse(parser)
+
+    config_json_path: Path = args.config_json
+    params_path: Path = args.params
+    quant_params_path: Path = args.quant_params
+    if not params_path.is_absolute():
+        params_path = config_json_path.parent / params_path
+    if not quant_params_path.is_absolute():
+        quant_params_path = config_json_path.parent / quant_params_path
+
+    # Construct the pre-transform dataset.
+    dataset_props = _get_dataset_props(_load_json(config_json_path))
+    quant_params_struct = _load_json(quant_params_path)
+    with safetensors.safe_open(params_path, framework="pt", device="cpu") as st:
+        theta = _load_theta(st)
+    ds = Dataset(dataset_props, theta)
+
+    # The quant_params_struct has quantization parameter structs keyed by full
+    # layer name. We process each of these in turn to produce a per-layer
+    # quantization scheme where no quantized tensors escape their layer.
+    for layer_name, qp in quant_params_struct.items():
+        print(f"Applying per-layer quants: {layer_name}")
+        layer_theta = theta(layer_name)
+        apply_per_layer_quant(layer_theta, qp)
+        break
+
+    # TODO: Post-process to introduce fused cross-layer connections.
+    return
+
+    dataset.save(args.output_irpa_file, io_report_callback=print)
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/sharktank/types/__init__.py
+++ b/sharktank/sharktank/types/__init__.py
@@ -7,5 +7,6 @@
 from .layouts import *
 from .tensors import *
 from .theta import *
+from .quantizers import *
 
 from . import gguf_interop

--- a/sharktank/sharktank/types/layout_utils.py
+++ b/sharktank/sharktank/types/layout_utils.py
@@ -13,6 +13,7 @@ __all__ = [
     "promote_linear_i2_block_to_i8",
     "promote_linear_i4_block_to_i8",
     "promote_linear_i6_block_to_i8",
+    "saturate_cast",
 ]
 
 
@@ -144,3 +145,14 @@ def _view_uint8_tensor(data: torch.Tensor) -> torch.Tensor:
         return data.view(torch.uint8)
     else:
         raise AssertionError(f"Expected tensor to by uint8 or int8. Got: {dtype}")
+
+
+def saturate_cast(t: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Does a saturating cast to the given dtype. For floating point
+    values, this is a simple cast. For integer types, it will saturate to the
+    min/max range.
+    """
+    if dtype.is_floating_point:
+        return t.to(dtype=dtype)
+    iinfo = torch.iinfo(dtype)
+    return t.clamp(iinfo.min, iinfo.max).to(dtype=dtype)

--- a/sharktank/sharktank/types/layout_utils.py
+++ b/sharktank/sharktank/types/layout_utils.py
@@ -147,7 +147,9 @@ def _view_uint8_tensor(data: torch.Tensor) -> torch.Tensor:
         raise AssertionError(f"Expected tensor to by uint8 or int8. Got: {dtype}")
 
 
-def saturate_cast(t: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+def saturate_cast(
+    t: torch.Tensor, dtype: torch.dtype, round_int: bool = True
+) -> torch.Tensor:
     """Does a saturating cast to the given dtype. For floating point
     values, this is a simple cast. For integer types, it will saturate to the
     min/max range.
@@ -155,4 +157,6 @@ def saturate_cast(t: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     if dtype.is_floating_point:
         return t.to(dtype=dtype)
     iinfo = torch.iinfo(dtype)
+    if round_int:
+        t = torch.round(t)
     return t.clamp(iinfo.min, iinfo.max).to(dtype=dtype)

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -84,7 +84,7 @@ class TensorScaledLayout(QuantizedLayout):
         planes: dict[str, torch.Tensor],
     ):
         m = planes.get("m")
-        return cls(shape, planes["d"], planes["qs"], m=m)
+        return cls(shape=shape, d=planes["d"], qs=planes["qs"], m=m)
 
     @property
     def planes(self) -> dict[str, torch.Tensor]:

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -33,13 +33,14 @@ __all__ = [
     "BlockScaledI4Layout",
     "BlockScaledLayout",
     "SuperBlockOffsetScaled_4_6_Layout",
+    "TensorScaledLayout",
 ]
 
 
 @register_quantized_layout
 class TensorScaledLayout(QuantizedLayout):
     """Quantized layout which combines some scalar scale (`d`) tensor with a
-    quantized sample (`qs`) tensor. An optional offset (`m`) scalar tensor
+    quantized sample (`qs`) tensor. An optional offset (`m`) tensor
     can be provided.
 
     The dequantization formula:
@@ -53,21 +54,17 @@ class TensorScaledLayout(QuantizedLayout):
     compatible to `d.dtype`. Generally, `qs` will be a lower precision
     floating point format or an integer dtype.
 
-    While it is rare to see such whole-tensor scaled layouts in modern work
-    on integer models (most such algorithms at least use per-axis, if not
-    some form of blocked), the resurgance of low precision floating point has
-    refreshed this approach and made it viable again. Since this is such a
-    common use that needs to be supported/switched on, we prefer to represent
-    this case as dedicated types vs trying to create a layout that can
-    also represent per-axis.
+    If d/m are scalar tensors, then this implements whole tensor quantization.
+    Otherwise, they must be broadcast to the axis along which scaling is
+    performed.
     """
 
     def __init__(
         self,
+        *,
         shape: list[int],
         d: torch.Tensor,
         qs: torch.Tensor,
-        *,
         m: Optional[torch.Tensor] = None,
     ):
         self._shape = shape

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -47,7 +47,7 @@ class TensorScaledLayout(QuantizedLayout):
 
     ```
     dtype = d.dtype
-    result = d.to(dtype) * qs + m
+    result = d.to(dtype) * (qs - m)
     ```
 
     If provided, `m` must be of the same dtype as `d`. `qs` must be cast
@@ -125,14 +125,14 @@ class TensorScaledLayout(QuantizedLayout):
         qs = self.qs
         if dtype is not None:
             d = d.to(dtype)
-            if m is not None:
-                m = m.to(dtype)
         else:
             dtype = d.dtype
-            assert m is None or m.dtype == d.dtype
-        scaled = d * qs.to(dtype)
-        shifted = scaled if m is None else scaled + m
-        return shifted
+        qs = qs.to(dtype=dtype)
+        if m is not None:
+            m = m.to(dtype)
+            return (qs - m) * d
+        else:
+            return qs * d
 
     def __repr__(self):
         r = (

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -277,6 +277,7 @@ class StaticScaledQuantizer(QuantizerTensor):
         return StaticScaledQuantizer(
             name=self.name,
             dtype=self.dtype,
+            axis=self.axis,
             scale=new_globals[f"{self.name}:scale"],
             reciprocal_scale=new_globals[f"{self.name}:rscale"],
             offset=new_globals.get(offset_name),

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -1,0 +1,269 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Quantizer Tensors
+These tensors contain quantization parameters that can be used to quantize some other
+tensor. These are typically stored in a dataset to signal a transformation into
+a quantized representation for some layer (typically for activations or other dynamic
+value) for which the underlying parameters themselves are fixed.
+
+Note that there is no need for a "DequantizerTensor" or a "dequantize" method on
+this class, since any `QuantizedTensor` already knows how to dequantize itself.
+"""
+
+from typing import Any, Optional
+
+from abc import abstractmethod
+
+import torch
+
+from ..utils.io import ShardedArchiveBuilder
+
+from .layouts import (
+    TensorScaledLayout,
+)
+
+from .tensors import (
+    InferenceTensor,
+    InferenceTensorMetadata,
+    PlanarQuantizedTensor,
+    PrimitiveTensor,
+    QuantizedTensor,
+    UnnamedTensorName,
+    register_inference_tensor,
+    _serialized_name_to_dtype,
+    _dtype_to_serialized_name,
+)
+
+__all__ = [
+    "DynamicScaledQuantizer",
+    "QuantizerTensor",
+    "StaticScaledQuantizer",
+]
+
+
+class QuantizerTensor(InferenceTensor):
+    """A tensor that knows how to quantize some other tensor."""
+
+    @abstractmethod
+    def quantize(self, t: PrimitiveTensor) -> QuantizedTensor:
+        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
+        ...
+
+
+@register_inference_tensor
+class StaticScaledQuantizer(QuantizerTensor):
+    """Quantizes to a `TensorScaledLayout` (per-tensor) or (TBD) for per-axis.
+
+    If `scale` is a scalar, it produces a PlanarQuantizedTensor of a
+    TensorScaledLayout where the `d` (scale) is the reciprocal of the scale
+    specified here.
+
+    An optional `offset` can be provided. If provided, when quantizing, this
+    will be subtracted from the value. Upon dequantizing, it will be added.
+    """
+
+    def __init__(
+        self,
+        *,
+        scale: torch.Tensor,
+        dtype: torch.dtype,
+        axis: Optional[int] = None,
+        reciprocal_scale: Optional[torch.Tensor] = None,
+        offset: Optional[torch.Tensor] = None,
+        name: str = UnnamedTensorName,
+    ):
+        super().__init__(shape=scale.shape, name=name)
+        assert axis is None or axis >= 0
+        self._scale = scale
+        if reciprocal_scale is None:
+            reciprocal_scale = 1.0 / scale
+        self._reciprocal_scale = reciprocal_scale
+        self._offset = offset
+        self._dtype = dtype
+        self._axis = axis
+        assert self._scale.shape == self._reciprocal_scale.shape
+        assert self._scale.dtype == self._reciprocal_scale.dtype
+        if self._offset is not None:
+            assert self._offset.shape == self._scale.shape
+            assert self._offset.dtype == self._scale.dtype
+        if self._axis is not None:
+            assert len(self._scale.shape) == 1, "Expected per-axis scale to be 1D"
+        else:
+            assert len(self._scale.shape) == 0, "Expected per-tensor scale to be 0D"
+
+    def quantize(self, t: PrimitiveTensor) -> QuantizedTensor:
+        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
+        shape = list(t.shape)
+        axis = self._axis
+        offset = self._offset
+        if axis is None:
+            # Per tensor.
+            if offset is None:
+                qs = (t * self._scale).to(dtype=self.dtype)
+            else:
+                qs = ((t - offset) * self._scale).to(dtype=self.dtype)
+            return PlanarQuantizedTensor(
+                shape=shape,
+                layout=TensorScaledLayout(
+                    shape=shape,
+                    d=self._reciprocal_scale,
+                    qs=qs,
+                    m=self._offset,
+                ),
+            )
+        else:
+            # Expand the scale/reciprocal to correspond to the broadcast axis.
+            scale = self._scale
+            reciprocal_scale = self._reciprocal_scale
+            offset = self._offset
+            assert axis >= 0 and axis < len(
+                shape
+            ), f"Per-axis scale {axis} out of bounds of shape {shape}"
+            scale_shape = [1] * len(shape)
+            scale_shape[axis] = scale.shape[0]
+            broadcast_scale = scale.reshape(scale_shape)
+            broadcast_reciprocal_scale = reciprocal_scale.reshape(scale_shape)
+            if offset is None:
+                broadcast_offset = None
+                qs = (t * broadcast_scale).to(dtype=self.dtype)
+            else:
+                broadcast_offset = offset.reshape(scale_shape)
+                qs = ((t - broadcast_offset) * broadcast_scale).to(dtype=self.dtype)
+            return PlanarQuantizedTensor(
+                shape=shape,
+                layout=TensorScaledLayout(
+                    shape=shape,
+                    d=broadcast_reciprocal_scale,
+                    qs=qs,
+                    m=broadcast_offset,
+                ),
+            )
+
+    @property
+    def axis(self) -> Optional[int]:
+        """Returns the axis that is scaled or None for whole tensor."""
+        return self._axis
+
+    @property
+    def offset(self) -> Optional[torch.Tensor]:
+        return self._offset
+
+    @property
+    def scale(self) -> torch.Tensor:
+        return self._scale
+
+    @property
+    def reciprocal_scale(self) -> torch.Tensor:
+        return self._reciprocal_scale
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @classmethod
+    def serialized_name(cls) -> str:
+        return "StaticScaledQuantizer"
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        raw_tensors: dict[str, torch.Tensor],
+        extra_properties: dict[str, Any],
+    ):
+        offset = None
+        try:
+            scale = raw_tensors["scale"]
+            reciprocal_scale = raw_tensors["rscale"]
+            if "offset" in raw_tensors:
+                offset = raw_tensors["offset"]
+        except KeyError as e:
+            raise IOError("Missing component tensor") from e
+        try:
+            dtype_name = extra_properties["dtype"]
+        except KeyError as e:
+            raise IOError("Missing property") from e
+        axis = int(extra_properties["axis"]) if "axis" in extra_properties else None
+        dtype = _serialized_name_to_dtype(dtype_name)
+        return cls(
+            name=name,
+            scale=scale,
+            offset=offset,
+            reciprocal_scale=reciprocal_scale,
+            dtype=dtype,
+            axis=axis,
+        )
+
+    @property
+    def globals(self) -> dict[str, torch.Tensor]:
+        d = {
+            f"{self.name}:scale": self._scale,
+            f"{self.name}:rscale": self._reciprocal_scale,
+        }
+        if self._offset is not None:
+            d[f"{self.name}:offset"] = self._offset
+        return d
+
+    def add_to_archive(self, builder: ShardedArchiveBuilder) -> InferenceTensorMetadata:
+        """Adds this tensor to the global archive."""
+        scale_name = f"{self.name}:scale"
+        rscale_name = f"{self.name}:rscale"
+        offset_name = f"{self.name}:offset"
+        extra_properties = {"dtype": _dtype_to_serialized_name(self._dtype)}
+        if self._axis is not None:
+            extra_properties["axis"] = self._axis
+        raw_tensors = {
+            "scale": scale_name,
+            "rscale": rscale_name,
+        }
+        builder.add_tensor(scale_name, self._scale)
+        builder.add_tensor(rscale_name, self._reciprocal_scale)
+        if self._offset is not None:
+            raw_tensors["offset"] = offset_name
+            builder.add_tensor(offset_name, self._offset)
+
+        return InferenceTensorMetadata(
+            self.serialized_name(),
+            raw_tensors=raw_tensors,
+            extra_properties=extra_properties,
+        )
+
+    def _clone_with_globals(
+        self, new_globals: dict[str, torch.Tensor]
+    ) -> "InferenceTensor":
+        offset_name = f"{self.name}:offset"
+        return StaticScaledQuantizer(
+            name=self.name,
+            dtype=self.dtype,
+            scale=new_globals[f"{self.name}:scale"],
+            reciprocal_scale=new_globals[f"{self.name}:rscale"],
+            offset=new_globals.get(offset_name),
+        )
+
+    def __repr__(self):
+        return (
+            f"StaticScaledQuantizer({self.name}, {self.shape}, "
+            f"scale=({self._scale.shape}, {self._scale.dtype}) along {self._axis}) "
+            f"offset={self._offset} "
+            f"-> dtype={self._dtype})"
+        )
+
+
+class DynamicScaledQuantizer(QuantizedTensor):
+    """Quantizer that produced a `TensorScaledLayout` (per-tensor) based on
+    computing the dynamic scale of the source tensor.
+
+    This is done via a computation like:
+
+    ```
+    finfo = torch.finfo(output_dtype)
+    amax = abs(max(x))
+    scale = finfo.max / amax.clamp(eps)
+    ```
+    """
+
+    ...

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -132,9 +132,11 @@ class StaticScaledQuantizer(QuantizerTensor):
         if axis is None:
             # Per tensor.
             if offset is None:
-                qs = saturate_cast(t * self._scale, self.dtype)
+                qs = saturate_cast(t * self._scale, self.dtype, round_int=True)
             else:
-                qs = saturate_cast((t - offset) * self._scale, dtype=self.dtype)
+                qs = saturate_cast(
+                    (t - offset) * self._scale, dtype=self.dtype, round_int=True
+                )
             return PlanarQuantizedTensor(
                 shape=shape,
                 name=name,
@@ -321,13 +323,13 @@ class DynamicScaledQuantizer(QuantizerTensor):
             finfo = torch.finfo(dtype)
             scale = finfo.max / amax.clamp(finfo.eps)
             reciprocal_scale = 1 / scale
-            qs = saturate_cast(t * scale, self.dtype)
+            qs = saturate_cast(t * scale, self.dtype, round_int=True)
         else:
             eps = 1e-4
             iinfo = torch.iinfo(dtype)
             scale = iinfo.max / amax.clamp(eps)
             reciprocal_scale = 1.0 / scale
-            qs = saturate_cast(t * scale, self.dtype)
+            qs = saturate_cast(t * scale, self.dtype, round_int=True)
         shape = list(t.shape)
         return PlanarQuantizedTensor(
             shape=shape,

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -486,53 +486,6 @@ class PlanarQuantizedTensor(QuantizedTensor):
 
 
 ########################################################################################
-# Quantizer Tensors
-# These tensors contain quantization parameters that can be used to quantize some other
-# tensor. These are typically stored in a dataset to signal a transformation into
-# a quantized representation for some layer (typically for activations or other dynamic
-# value) for which the underlying parameters themselves are fixed.
-#
-# Note that there is no need for a "DequantizerTensor" or a "dequantize" method on
-# this class, since any `QuantizedTensor` already knows how to dequantize itself.
-########################################################################################
-
-
-class QuantizerTensor(InferenceTensor):
-    """A tensor that knows how to quantize some other tensor."""
-
-    @abstractmethod
-    def quantize(self, t: PrimitiveTensor) -> QuantizedTensor:
-        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
-        ...
-
-
-class StaticScaledQuantizer(QuantizedTensor):
-    """Quantizes to a `TensorScaledLayout` (per-tensor) or (TBD) for per-axis.
-
-    It produces a PlanarQuantizedTensor of a TensorScaledLayout where the `d`
-    (scale) is the reciprocal of the scale specified here.
-    """
-
-    ...
-
-
-class DynamicScaledQuantizer(QuantizedTensor):
-    """Quantizer that produced a `TensorScaledLayout` (per-tensor) based on
-    computing the dynamic scale of the source tensor.
-
-    This is done via a computation like:
-
-    ```
-    finfo = torch.finfo(output_dtype)
-    amax = abs(max(x))
-    scale = finfo.max / amax.clamp(eps)
-    ```
-    """
-
-    ...
-
-
-########################################################################################
 # Sharded tensors
 ########################################################################################
 
@@ -668,3 +621,69 @@ class ShardedPrimitiveTensor(ShardedTensor):
             f"shard_dim={self.shard_dim}, shard_count={len(self._shards)} "
             f"of {self.shards[0].shape})"
         )
+
+
+########################################################################################
+# Serialization helpers
+########################################################################################
+
+
+def _dtype_to_serialized_name(dtype: torch.dtype) -> str:
+    try:
+        return _DTYPE_TO_NAME[dtype]
+    except KeyError as e:
+        raise KeyError(
+            f"Missing mapping for dtype {dtype}. Please add to the _NAME_TO_DTYPE dict"
+        ) from e
+
+
+def _serialized_name_to_dtype(dtype_name: str) -> torch.dtype:
+    try:
+        return _NAME_TO_DTYPE[dtype_name]
+    except KeyError as e:
+        raise KeyError(
+            f"Missing mapping for dtype '{dtype_name}'. Please add to the _NAME_TO_DTYPE dict"
+        ) from e
+
+
+_NAME_TO_DTYPE: dict[str, torch.dtype] = {
+    "float32": torch.float32,
+    "float64": torch.float64,
+    "complex64": torch.complex64,
+    "complex128": torch.complex128,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "uint8": torch.uint8,
+    "int8": torch.int8,
+    "int16": torch.int16,
+    "int32": torch.int32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+
+
+def _maybe_dtype(*names: str):
+    for name in names:
+        try:
+            cls = getattr(torch, name)
+        except AttributeError:
+            pass
+        else:
+            _NAME_TO_DTYPE[name] = cls
+
+
+_maybe_dtype(
+    "float8_e4m3fn",
+    "float8_e4m3fnuz",
+    "float8_e5m2",
+    "float8_e5m2fnuz",
+    "uint1",
+    "uint2",
+    "uint3",
+    "uint4",
+    "uint5",
+    "uint6",
+    "uint7",
+)
+
+_DTYPE_TO_NAME: dict[torch.dtype, str] = {v: k for k, v in _NAME_TO_DTYPE.items()}

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -486,6 +486,53 @@ class PlanarQuantizedTensor(QuantizedTensor):
 
 
 ########################################################################################
+# Quantizer Tensors
+# These tensors contain quantization parameters that can be used to quantize some other
+# tensor. These are typically stored in a dataset to signal a transformation into
+# a quantized representation for some layer (typically for activations or other dynamic
+# value) for which the underlying parameters themselves are fixed.
+#
+# Note that there is no need for a "DequantizerTensor" or a "dequantize" method on
+# this class, since any `QuantizedTensor` already knows how to dequantize itself.
+########################################################################################
+
+
+class QuantizerTensor(InferenceTensor):
+    """A tensor that knows how to quantize some other tensor."""
+
+    @abstractmethod
+    def quantize(self, t: PrimitiveTensor) -> QuantizedTensor:
+        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
+        ...
+
+
+class StaticScaledQuantizer(QuantizedTensor):
+    """Quantizes to a `TensorScaledLayout` (per-tensor) or (TBD) for per-axis.
+
+    It produces a PlanarQuantizedTensor of a TensorScaledLayout where the `d`
+    (scale) is the reciprocal of the scale specified here.
+    """
+
+    ...
+
+
+class DynamicScaledQuantizer(QuantizedTensor):
+    """Quantizer that produced a `TensorScaledLayout` (per-tensor) based on
+    computing the dynamic scale of the source tensor.
+
+    This is done via a computation like:
+
+    ```
+    finfo = torch.finfo(output_dtype)
+    amax = abs(max(x))
+    scale = finfo.max / amax.clamp(eps)
+    ```
+    """
+
+    ...
+
+
+########################################################################################
 # Sharded tensors
 ########################################################################################
 

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -124,6 +124,7 @@ class Theta:
         return results
 
     def tensor(self, *name_path: str | int) -> InferenceTensor:
+        name_path = _norm_name_path(name_path)
         t = self.optional_tensor(*name_path)
         if t is None:
             raise KeyError(
@@ -132,6 +133,7 @@ class Theta:
         return t
 
     def optional_tensor(self, *name_path: str | int) -> Optional[InferenceTensor]:
+        name_path = _norm_name_path(name_path)
         try:
             current_ts = self._tensors
             for part in name_path[0:-1]:
@@ -153,7 +155,8 @@ class Theta:
     def tensors(self) -> Collection[InferenceTensor]:
         return [v for v in self._tensors.values() if isinstance(v, InferenceTensor)]
 
-    def __call__(self, *name_path: Union[str, int]) -> "Theta":
+    def __call__(self, *name_path: str | int) -> "Theta":
+        name_path = _norm_name_path(name_path)
         current_ts = self._tensors
         try:
             for part in name_path:
@@ -207,6 +210,14 @@ def _flat_to_nested_dict(flat: dict[str, Any]) -> dict[str, Any]:
     for name, value in flat.items():
         add_to_dict(name, value)
     return nested
+
+
+def _norm_name_path(name_parts) -> list[str]:
+    accum = []
+    for part in name_parts:
+        part = str(part)
+        accum.extend(part.split("."))
+    return accum
 
 
 ################################################################################

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -123,18 +123,26 @@ class Theta:
         accum("", self._tensors)
         return results
 
-    def tensor(self, *name_path: Union[str, int]) -> InferenceTensor:
-        current_ts = self._tensors
+    def tensor(self, *name_path: str | int) -> InferenceTensor:
+        t = self.optional_tensor(*name_path)
+        if t is None:
+            raise KeyError(
+                f"Could not find tensor {name_path[-1]} in theta {name_path[0:-1]}"
+            )
+        return t
+
+    def optional_tensor(self, *name_path: str | int) -> Optional[InferenceTensor]:
         try:
+            current_ts = self._tensors
             for part in name_path[0:-1]:
                 current_ts = current_ts[str(part)]
             last = name_path[-1]
-            t = current_ts[str(last)]
         except KeyError:
             raise KeyError(
                 f"Unknown parameter {name_path} (in Theta object "
                 f"containing {self.keys})"
             )
+        t = current_ts.get(str(last))
         return t
 
     @property

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -13,14 +13,16 @@ import unittest
 from ..types import *
 
 
-class MainRunnerTestBase(unittest.TestCase):
-    """Performs an in-process test of a `main(args)` func."""
-
+class TempDirTestBase(unittest.TestCase):
     def setUp(self):
         self._temp_dir = Path(tempfile.mkdtemp(type(self).__qualname__))
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+
+class MainRunnerTestBase(TempDirTestBase):
+    """Performs an in-process test of a `main(args)` func."""
 
     def get_file_path(self, name: str) -> Path:
         return self._temp_dir / name

--- a/sharktank/tests/layers/linear_test.py
+++ b/sharktank/tests/layers/linear_test.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.layers import *
+from sharktank.types import *
+
+
+class LinearQuantTest(unittest.TestCase):
+    def testFakeQuantPerTensorDynamic(self):
+        # TODO: Testing matmuls on unscaled random data like this produces
+        # mis-behaving numerics due to outliers. Makes it hard to have a
+        # sanity check.
+        weight_raw = torch.randn(10, 20, dtype=torch.float32)
+        weight = DynamicScaledQuantizer(dtype=torch.int8).quantize(
+            weight_raw, name="weight"
+        )
+        theta = Theta(
+            [
+                DynamicScaledQuantizer(dtype=torch.int8, name="fq_input"),
+                weight,
+            ]
+        )
+        linear = LinearLayer(theta)
+
+        self.assertEqual(linear.mode, "fq")
+        x = torch.randn(5, 20, dtype=torch.float32)
+        y = linear(x)
+        y_ref = torch.matmul(x, weight_raw.t())
+        print("Y:", y)
+        print("Y_REF:", y_ref)
+
+    def testFakeQuantPerTensorStatic(self):
+        # TODO: Testing matmuls on unscaled random data like this produces
+        # mis-behaving numerics due to outliers. Makes it hard to have a
+        # sanity check.
+        weight_raw = torch.randn(10, 20, dtype=torch.float32)
+        weight = DynamicScaledQuantizer(dtype=torch.int8).quantize(
+            weight_raw, name="weight"
+        )
+        theta = Theta(
+            [
+                StaticScaledQuantizer(
+                    dtype=torch.int8, name="fq_input", scale=torch.tensor(25.6)
+                ),
+                StaticScaledQuantizer(
+                    dtype=torch.int8, name="fq_output", scale=torch.tensor(20.6)
+                ),
+                weight,
+            ]
+        )
+        linear = LinearLayer(theta)
+
+        self.assertEqual(linear.mode, "fq")
+        x = torch.randn(5, 20, dtype=torch.float32)
+        y = linear(x)
+        y_ref = torch.matmul(x, weight_raw.t())
+        print("Y:", y)
+        print("Y_REF:", y_ref)
+
+    # TODO: Test bias.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/types/layouts_test.py
+++ b/sharktank/tests/types/layouts_test.py
@@ -115,13 +115,13 @@ class TensorScaledLayoutTest(unittest.TestCase):
         )
         d = l.dequant()
         torch.testing.assert_close(
-            d, torch.tensor([9.0, 11.0, 13.0], dtype=torch.float32)
+            d, torch.tensor([-6.0, -4.0, -2.0], dtype=torch.float32)
         )
 
         l_new = TensorScaledLayout.create(l.shape, l.metadata, l.planes)
         d = l_new.dequant()
         torch.testing.assert_close(
-            d, torch.tensor([9.0, 11.0, 13.0], dtype=torch.float32)
+            d, torch.tensor([-6.0, -4.0, -2.0], dtype=torch.float32)
         )
 
 

--- a/sharktank/tests/types/layouts_test.py
+++ b/sharktank/tests/types/layouts_test.py
@@ -81,7 +81,7 @@ class SuperBlockOffsetScaled_4_6_LayoutTest(unittest.TestCase):
         bs = 32
 
         l = SuperBlockOffsetScaled_4_6_Layout(
-            [n, k],
+            shape=[n, k],
             d=torch.empty(n, sup, 1, dtype=torch.float32),
             dmin=torch.empty(n, sup, 1, dtype=torch.float32),
             sb_scales_high=torch.empty(n, sup, sub // 4, dtype=torch.uint8),
@@ -108,7 +108,7 @@ class TensorScaledLayoutTest(unittest.TestCase):
         n = 128
         k = 2560
         l = TensorScaledLayout(
-            [n, k],
+            shape=[n, k],
             d=torch.tensor(2.0, dtype=torch.float32),
             qs=torch.tensor([2.0, 3.0, 4.0], dtype=torch.float16),
             m=torch.tensor(5.0, dtype=torch.float32),

--- a/sharktank/tests/types/layouts_test.py
+++ b/sharktank/tests/types/layouts_test.py
@@ -97,5 +97,33 @@ class SuperBlockOffsetScaled_4_6_LayoutTest(unittest.TestCase):
         self.assertEqual(l.metadata, l_new.metadata)
 
 
+class TensorScaledLayoutTest(unittest.TestCase):
+    def testRegistered(self):
+        self.assertIs(
+            TensorScaledLayout,
+            REGISTERED_LAYOUT_CLASSES[TensorScaledLayout.serialized_name()],
+        )
+
+    def testRoundtripWithOffset(self):
+        n = 128
+        k = 2560
+        l = TensorScaledLayout(
+            [n, k],
+            d=torch.tensor(2.0, dtype=torch.float32),
+            qs=torch.tensor([2.0, 3.0, 4.0], dtype=torch.float16),
+            m=torch.tensor(5.0, dtype=torch.float32),
+        )
+        d = l.dequant()
+        torch.testing.assert_close(
+            d, torch.tensor([9.0, 11.0, 13.0], dtype=torch.float32)
+        )
+
+        l_new = TensorScaledLayout.create(l.shape, l.metadata, l.planes)
+        d = l_new.dequant()
+        torch.testing.assert_close(
+            d, torch.tensor([9.0, 11.0, 13.0], dtype=torch.float32)
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sharktank/tests/types/quantizer_test.py
+++ b/sharktank/tests/types/quantizer_test.py
@@ -121,5 +121,68 @@ class StaticScaledQuantizerTest(TempDirTestBase):
         torch.testing.assert_close(dequant_value, orig_value, atol=1e-3, rtol=1e-3)
 
 
+class DynamicScaledQuantizerTest(TempDirTestBase):
+    def _roundtrip(self, it):
+        dataset_path = self._temp_dir / "poodoo.irpa"
+        theta = Theta([it])
+        Dataset({}, theta).save(dataset_path)
+        ds = Dataset.load(dataset_path)
+        return ds.root_theta.tensor(it.name)
+
+    def testQuantDequantInt(self):
+        qr = DynamicScaledQuantizer(dtype=torch.int8)
+        qr = self._roundtrip(qr)
+        orig_value = torch.tensor([-5.0, -2.0, 3.0, 4.5], dtype=torch.float32)
+        qt_value = qr.quantize(orig_value)
+        layout = qt_value.unpack()
+        expected_quant_value = torch.tensor([-127, -50, 76, 114], dtype=torch.int8)
+        qs = layout.planes["qs"]
+        dequant_value = layout.dequant()
+        print("i8 QS:", qs)
+        print("i8 DQ:", dequant_value)
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-1, rtol=1e-3)
+        torch.testing.assert_close(qs, expected_quant_value)
+
+    def testQuantDequantf16(self):
+        qr = DynamicScaledQuantizer(dtype=torch.float16)
+        qr = self._roundtrip(qr)
+        orig_value = torch.tensor([-5.0, -2.0, 3.0, 4.5], dtype=torch.float32)
+        qt_value = qr.quantize(orig_value)
+        layout = qt_value.unpack()
+        expected_quant_value = torch.tensor(
+            [-65504.0, -26208.0, 39296.0, 58944.0], dtype=torch.float16
+        )
+        qs = layout.planes["qs"]
+        dequant_value = layout.dequant()
+        print("f16 QS:", qs)
+        print("f16 DQ:", dequant_value)
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-1, rtol=1e-3)
+        torch.testing.assert_close(qs, expected_quant_value)
+
+    def testQuantDequantf8fn(self):
+        qr = DynamicScaledQuantizer(dtype=torch.float8_e4m3fn)
+        qr = self._roundtrip(qr)
+        orig_value = torch.tensor([-5.0, -2.0, 3.0, 4.5], dtype=torch.float32)
+        qt_value = qr.quantize(orig_value)
+        layout = qt_value.unpack()
+        qs = layout.planes["qs"]
+        dequant_value = layout.dequant()
+        print("f8fn QS:", qs)
+        print("f8fn DQ:", dequant_value)
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-1, rtol=1e-1)
+
+    def testQuantDequantf8fnuz(self):
+        qr = DynamicScaledQuantizer(dtype=torch.float8_e4m3fnuz)
+        qr = self._roundtrip(qr)
+        orig_value = torch.tensor([-5.0, -2.0, 3.0, 4.5], dtype=torch.float32)
+        qt_value = qr.quantize(orig_value)
+        layout = qt_value.unpack()
+        qs = layout.planes["qs"]
+        dequant_value = layout.dequant()
+        print("f8fnuz QS:", qs)
+        print("f8fnuz DQ:", dequant_value)
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-1, rtol=1e-1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sharktank/tests/types/quantizer_test.py
+++ b/sharktank/tests/types/quantizer_test.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.types import *
+from sharktank.utils.testing import TempDirTestBase
+
+
+class StaticScaledQuantizerTest(TempDirTestBase):
+    def _roundtrip(self, it):
+        dataset_path = self._temp_dir / "poodoo.irpa"
+        theta = Theta([it])
+        Dataset({}, theta).save(dataset_path)
+        ds = Dataset.load(dataset_path)
+        return ds.root_theta.tensor(it.name)
+
+    def testPerTensorRoundtrip(self):
+        ssq = StaticScaledQuantizer(
+            name="poodoo",
+            scale=torch.tensor(0.2, dtype=torch.float32),
+            dtype=torch.float16,
+        )
+        ssq = self._roundtrip(ssq)
+        self.assertIs(ssq.axis, None)
+        self.assertEqual(ssq.scale, 0.2)
+        self.assertEqual(ssq.reciprocal_scale, 5.0)
+        self.assertIs(ssq.dtype, torch.float16)
+
+    def testPerTensorQuantDequant(self):
+        ssq = StaticScaledQuantizer(
+            scale=torch.tensor(0.2, dtype=torch.float32), dtype=torch.float16
+        )
+        ssq = self._roundtrip(ssq)
+
+        orig_value = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32)
+        qt_value = ssq.quantize(orig_value)
+        layout = qt_value.unpack()
+        expected_quant_value = torch.tensor([0.2, 0.4, 0.6, 0.8], dtype=torch.float16)
+        torch.testing.assert_close(layout.planes["qs"], expected_quant_value)
+        dequant_value = layout.dequant()
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-3, rtol=1e-3)
+
+    def testPerTensorOffsetQuantDequant(self):
+        ssq = StaticScaledQuantizer(
+            scale=torch.tensor(0.2, dtype=torch.float32),
+            offset=torch.tensor(8.0, dtype=torch.float32),
+            dtype=torch.float16,
+        )
+        ssq = self._roundtrip(ssq)
+        orig_value = torch.tensor([9.0, 10.0, 11.0, 12.0], dtype=torch.float32)
+        qt_value = ssq.quantize(orig_value)
+        layout = qt_value.unpack()
+        expected_quant_value = torch.tensor([0.2, 0.4, 0.6, 0.8], dtype=torch.float16)
+        qs = layout.planes["qs"]
+        torch.testing.assert_close(qs, expected_quant_value)
+        dequant_value = layout.dequant()
+        torch.testing.assert_close(orig_value, dequant_value, atol=1e-3, rtol=1e-3)
+
+    def testPerAxisRoundtrip(self):
+        ssq = StaticScaledQuantizer(
+            name="poodoo",
+            axis=1,
+            scale=torch.tensor([0.2, 0.4, 0.8], dtype=torch.float32),
+            dtype=torch.float16,
+        )
+        ssq = self._roundtrip(ssq)
+        self.assertEqual(ssq.axis, 1)
+        torch.testing.assert_close(ssq.scale, torch.tensor([0.2, 0.4, 0.8]))
+        torch.testing.assert_close(ssq.reciprocal_scale, torch.tensor([5.0, 2.5, 1.25]))
+        self.assertIs(ssq.dtype, torch.float16)
+
+    def testPerAxisQuantDequant(self):
+        ssq = StaticScaledQuantizer(
+            name="poodoo",
+            axis=1,
+            scale=torch.tensor([0.2, 0.4, 0.8], dtype=torch.float32),
+            dtype=torch.float16,
+        )
+        ssq = self._roundtrip(ssq)
+        orig_value = torch.tensor([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])
+        qt_value = ssq.quantize(orig_value)
+        layout = qt_value.unpack()
+        qs = layout.planes["qs"]
+        torch.testing.assert_close(
+            qs,
+            torch.tensor(
+                [[0.2000, 0.7998, 2.4004], [2.0000, 8.0000, 24.0000]],
+                dtype=torch.float16,
+            ),
+        )
+        dequant_value = layout.dequant()
+        torch.testing.assert_close(dequant_value, orig_value, atol=1e-3, rtol=1e-3)
+
+    def testPerAxisOffsetQuantDequant(self):
+        ssq = StaticScaledQuantizer(
+            name="poodoo",
+            axis=1,
+            scale=torch.tensor([0.2, 0.4, 0.8], dtype=torch.float32),
+            offset=torch.tensor([8.0, 9.0, 10.0], dtype=torch.float32),
+            dtype=torch.float16,
+        )
+        ssq = self._roundtrip(ssq)
+        orig_value = torch.tensor([[9.0, 11.0, 13.0], [18.0, 29.0, 40.0]])
+        qt_value = ssq.quantize(orig_value)
+        layout = qt_value.unpack()
+        qs = layout.planes["qs"]
+        torch.testing.assert_close(
+            qs,
+            torch.tensor(
+                [[0.2000, 0.7998, 2.4004], [2.0000, 8.0000, 24.0000]],
+                dtype=torch.float16,
+            ),
+        )
+        dequant_value = layout.dequant()
+        torch.testing.assert_close(dequant_value, orig_value, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a fairly substantial body of work that will be refined as we bring the model fully online. As of now, it runs and exports properly with the smoothquant int8 strategy and configuration we chose, but the results do not look correct. We will need to go through with a fine tooth comb and validate all of the numerics in conjunction with the quantization simulator that produced the parameters.

Key things added:

* Quantizer tensors for expressing the parameters needed in order to quantize from a higher precision to lower precision (tests both integer and fp8).
* First pass of teaching Linear and Conv layers how to work with quantized tensors and quantizers.
* Teach Linear and Conv layer how to handle high precision input pre multiplier (needed for SmoothQuant like strategies).
* Add a simple torch.export option to the interactive punet runner.
* Make custom op auto unboxing and auto dequant a regular feature that op implementations can enable with kwargs.
* Implement quantizers and QuantizedTensor types for the usual types of per-tensor and per-axis quant schemes.
* Add Theta.optional_tensor()
* Adds an import_brevitas_dataset.py which imports from a cooked (smoothquant folded) safetensors file and a JSON file containing calibration parameters, producing a quantized punet dataset.