### PR TITLE
Iterate on quantized linear and conv layers.

### DIFF
--- a/sharktank/sharktank/layers/conv.py
+++ b/sharktank/sharktank/layers/conv.py
@@ -22,9 +22,6 @@ __all__ = [
 class Conv2DLayer(ThetaLayer):
     """Theta based conv2d layer. This assumes weight/bias naming as per the nn.Conv2D
     module ("weight", "bias").
-
-    This layer is being adapted for quantization. See LinearLayer for full docs
-    while this is being worked out.
     """
 
     def __init__(
@@ -42,156 +39,34 @@ class Conv2DLayer(ThetaLayer):
 
         # Input premultiplier.
         self.premul_input = theta.optional_tensor("premul_input")
-
-        # Get mode specific tensors.
-        self.mode: Optional[str] = None
-        self.fq_input: Optional[QuantizerTensor] = theta.optional_tensor("fq_input")
-        self.fq_output: Optional[QuantizerTensor] = theta.optional_tensor("fq_output")
         self.q_input: Optional[QuantizerTensor] = theta.optional_tensor("q_input")
-        self.q_output: Optional[QuantizerTensor] = theta.optional_tensor("q_output")
-        self.dq_output: Optional[QuantizerTensor] = theta.optional_tensor("dq_output")
-
-        if self.fq_input is not None:
-            assert self.mode is None, f"Cannot enable fq mode and {self.mode}"
-            self.mode = "fq"
-            self._validate_fake_quant_mode()
-
-        if (
-            self.q_input is not None
-            or self.q_output is not None
-            or self.dq_output is not None
-        ):
-            assert self.mode is None, f"Cannot enable native quant mode and {self.mode}"
-            self.mode = "native_quant"
-            self._validate_native_quant_mode()
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        mode = self.mode
         x = input
+        q_input = self.q_input
         weight = self.weight
         bias = self.bias
 
         if self.premul_input is not None:
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
-        # Regular or fakequant mode.
-        if mode is None or mode == "fq":
-            # Input conditioning.
-            if self.mode == "fq":
-                orig_weight_layout = weight.unpack()
-                weight = orig_weight_layout.dequant()
-                x = self.fq_input.quantize(x)
-                orig_x_layout = x.unpack()
-                x = orig_x_layout.dequant()
-                if isinstance(bias, QuantizedTensor):
-                    bias = bias.unpack().dequant()
+        if q_input is not None:
+            x = q_input.quantize(x)
 
-            # Primary computation.
-            y = ops.conv2d(
-                x,
-                weight=weight,
-                bias=bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
+        # Primary computation.
+        y = ops.conv2d(
+            x,
+            weight=weight,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
 
-            # Output conditioning.
-            if self.mode == "fq":
-                fq_output = self.fq_output
-                if fq_output is not None:
-                    # Static output quantization.
-                    y = fq_output.quantize(y).unpack().dequant()
-            return y
-
-        # Native quant mode.
-        # TODO: This needs to be completely replumbed into a couple of different
-        # fused ops. For the moment, though, we skate by with simulating it
-        # via normal ops.
-        if mode == "native_quant":
-            q_input = self.q_input
-            q_output = self.q_output
-            dq_output = self.dq_output
-            if q_input is not None:
-                x = q_input.quantize(x)
-
-            # TODO: We should be calling an explicit qmatmul that can take
-            # the output quantizer. For the moment, we ignore dq_output
-            # entirely and only act on a q_output.
-            # Primary computation.
-            y = ops.conv2d(
-                x,
-                weight=weight,
-                bias=bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
-
-            if dq_output is not None and not isinstance(
-                dq_output, DynamicScaledQuantizer
-            ):
-                y = dq_output.quantize(y).unpack().dequant()
-
-            if q_output is not None:
-                y = q_output.quantize(y)
-
-            return y
-
-        raise AssertionError(f"Conv2DLayer unhandled mode '{mode}'")
-
-    def _validate_fake_quant_mode(self):
-        fq_input = self.fq_input
-        fq_output = self.fq_output
-        weight = self.weight
-        if not isinstance(fq_input, QuantizerTensor):
-            raise (
-                f"Conv2DLayer requires fq_input to be a QuantizerTensor, "
-                f"but got: {fq_input}"
-            )
-        if fq_output is not None:
-            if not isinstance(fq_output, QuantizerTensor):
-                raise (
-                    f"Conv2DLayer requires fq_output to be a QuantizerTensor, "
-                    f"but got: {fq_output}"
-                )
-        else:
-            # Dynamic quant mode requires a *ScaledQuantizer for the input
-            # and a TensorScaledLayout weight tensor.
-            if not isinstance(
-                fq_input, (StaticScaledQuantizer, DynamicScaledQuantizer)
-            ):
-                raise AssertionError(
-                    f"Conv2DLayer with a fq_output=None requires a "
-                    f"[Static|Dynamic]ScaledQuantizer for fq_input, but got: "
-                    f"{repr(fq_input)}"
-                )
-            if not isinstance(weight, QuantizedTensor):
-                raise AssertionError(
-                    f"Conv2DLayer with a fq_output=None requires a weight "
-                    f"of type QuantizedTensor, but got: {repr(weight)}"
-                )
-            if not issubclass(weight.layout_type, TensorScaledLayout):
-                raise AssertionError(
-                    f"Conv2DLayer with a fq_output=None requires a QuantizedTensor "
-                    f"weight with TensorScaledLayout, but got: {weight.layout_type}"
-                )
-
-    def _validate_native_quant_mode(self):
-        q_input = self.q_input
-        q_output = self.q_output
-        dq_output = self.dq_output
-
-        if q_output is None and dq_output is None:
-            raise AssertionError(
-                f"One of q_output or dq_output must be specified in native "
-                f"quantized mode for Conv2DLayer"
-            )
-
-        if q_output is not None and dq_output is not None:
-            raise AssertionError(
-                f"Only one of q_output or dq_output can be specified for a "
-                f"Conv2DLayer but got both."
-            )
+        # Unconditionally dequantize.
+        # TODO: Support a q_output specifier that signals the layer to let
+        # the QuantizedTensor escape.
+        if isinstance(y, QuantizedTensor):
+            y = y.unpack().dequant()
+        return y

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -53,12 +53,13 @@ class LinearLayer(ThetaLayer):
         self.q_input: Optional[QuantizerTensor] = theta.optional_tensor("q_input")
 
     def forward(self, x):
-        if self.premul_input is not None:
-            x = ops.elementwise(torch.mul, x, self.premul_input)
-
         weight = self.weight
         bias = self.bias
         q_input = self.q_input
+
+        if self.premul_input is not None:
+            x = ops.elementwise(torch.mul, x, self.premul_input)
+
         if q_input is not None:
             x = q_input.quantize(x)
         y = ops.linear(x, weight, bias)

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -32,77 +32,6 @@ class LinearLayer(ThetaLayer):
       x = x * premul_input
     matmul(x, weight.T) + bias
     ```
-
-    Whether the weight is transposed as part of the calculation can be
-    controlled with `transpose_weight=` (default true).
-
-    This layer will operate in one of several modes based on the presence
-    of additional tensors in theta:
-
-    Weight-Only Quant Mode:
-    -----------------------
-    In this mode, the weight and/or bias is a QuantizedTensor but there is
-    no activation quantization information (unless if the input happens to
-    have already come in from a previous layer as a QuantizedTensor). In this
-    case, the default behavior of the matmul op depends on the exact form of
-    weight quantization. If a kernel exists to fuse the computation in some
-    way, it will be used. Otherwise, the fallback logic will dequantize the
-    weight and perform normal FP math. The compiler may still do some fusion
-    on this, depending on many things.
-
-    FakeQuant Mode:
-    ---------------
-    FakeQuant mode is activated if 'fq_input' and 'fq_output' are present.
-    If present, they are expected to be of type `QuantizerTensor`. In this mode:
-
-      * Weight and bias will be dequantized if appropriate (typically, these
-        will be stored as some form of QuantizedTensor).
-      * The input will be quantized and then dequantized according to the
-        'fq_input' quantizer.
-      * If there is no 'fq_output' quantizer, we fall back to
-        "dynamic quantization"
-        mode, where we will dynamically compute an estimated output quantizer
-        by multiplying the input scale by the weight scale. This only works
-        for TensorScaledLayouts and is meant to simulate the fused dynamic
-        quantization mode.
-      * The output of the linear computation is quantized and then dequantized
-        by the 'fq_output' quantizer (whether explicit or computed).
-
-    While this mode is not particularly interesting for production deployments,
-    it duplicates closely the fake_quant logic typically used in simulators and
-    can help identify bugs and mismatches that can arise from more aggressive
-    techniques.
-
-    Native Quant Mode:
-    ------------------
-    In native quant mode, the goal is to perform quantized arithmetic. The types
-    of the inputs/weight/bias and an output quantizer dictate the precise
-    parameters of that arithmetic. The only required tensor in this mode is
-    either a 'q_output' or a 'dq_output':
-
-    * 'q_output' is used to specify output quantization parameters, and the
-      resulting QuantizedTensor is returned directly from the layer. This
-      means that any subsequent layer or operations must be prepared to handle
-      inputs with the exact quantization output from here.
-    * 'dq_output' is used to specify output quantization parameters and signal
-      the layer to dequantize back to a high precision tensor for return.
-      Downstream consumers will only see the high precision tensor.
-
-    There can also be an optional 'q_input' which specifies that the input to
-    the layer should be quantized according to this quantizer. If ommitted,
-    then the input to the layer *must* already be a QuantizedTensor (i.e. from
-    a producer).
-
-    Any of these quantizers may be a `DynamicScaledQuantizer`:
-
-    * For input quantizers, quantization parameters will be derived dynamically
-      based on the actual activation values.
-    * For output quantizers, custom fused kernels which internally estimate
-      their output scales will be used.
-
-    The bias tensor is expected to be either a `QuantizedTensor` with the
-    same scaling as the output or a primitive tensor that will be dynamically
-    quantized to the output scale for accumulation.
     """
 
     def __init__(
@@ -111,7 +40,6 @@ class LinearLayer(ThetaLayer):
         *,
         weight_name: str = "weight",
         bias_name: str = "bias",
-        transpose_weight: bool = True,
     ):
         super().__init__(theta)
         self._simulate_native_quant = True
@@ -119,129 +47,25 @@ class LinearLayer(ThetaLayer):
         self.bias = None
         if bias_name in self.theta.keys:
             self.bias = self.theta_tensor(bias_name)
-        self.transpose_weight = transpose_weight
 
         # Input premultiplier.
         self.premul_input = theta.optional_tensor("premul_input")
-
-        # Get mode specific tensors.
-        self.mode: Optional[str] = None
-        self.fq_input: Optional[QuantizerTensor] = theta.optional_tensor("fq_input")
-        self.fq_output: Optional[QuantizerTensor] = theta.optional_tensor("fq_output")
         self.q_input: Optional[QuantizerTensor] = theta.optional_tensor("q_input")
-        self.q_output: Optional[QuantizerTensor] = theta.optional_tensor("q_output")
-
-        if self.fq_input is not None:
-            assert self.mode is None, f"Cannot enable fq mode and {self.mode}"
-            self.mode = "fq"
-            self._validate_fake_quant_mode()
-
-        if self.q_input is not None or self.q_output is not None:
-            assert self.mode is None, f"Cannot enable native quant mode and {self.mode}"
-            self.mode = "native_quant"
-            self._validate_native_quant_mode()
 
     def forward(self, x):
-        mode = self.mode
         if self.premul_input is not None:
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
-        # Regular or fakequant mode.
-        if mode is None or mode == "fq":
-            return self._fake_quant(x)
-
-        # Native quant mode.
-        # TODO: This needs to be completely replumbed into a couple of different
-        # fused ops. For the moment, though, we skate by with simulating it
-        # via normal ops.
-        if mode == "native_quant":
-            if self._simulate_native_quant:
-                return self._native_quant(x)
-            else:
-                raise AssertionError(
-                    "LinearLayer does not yet support non-simulated native quant"
-                )
-
-        raise AssertionError(f"LinearLayer unhandled mode '{mode}'")
-
-    def _native_quant(self, x):
         weight = self.weight
         bias = self.bias
-        dequant_dtype = x.dtype  # TODO: unbox
         q_input = self.q_input
-        q_output = self.q_output
         if q_input is not None:
             x = q_input.quantize(x)
-        y = ops.qlinear_dequant(x, weight, bias)
+        y = ops.linear(x, weight, bias)
+
+        # Unconditionally dequantize.
+        # TODO: Support a q_output specifier that signals the layer to let
+        # the QuantizedTensor escape.
+        if isinstance(y, QuantizedTensor):
+            y = y.unpack().dequant()
         return y
-
-    def _fake_quant(self, x):
-        weight = self.weight
-        bias = self.bias
-        # Input conditioning.
-        if self.mode == "fq":
-            orig_weight_layout = weight.unpack()
-            weight = orig_weight_layout.dequant()
-            x = self.fq_input.quantize(x)
-            orig_x_layout = x.unpack()
-            x = orig_x_layout.dequant()
-            if isinstance(bias, QuantizedTensor):
-                bias = bias.unpack().dequant()
-
-        # Primary computation.
-        y = ops.matmul(x, weight, transpose_rhs=self.transpose_weight)
-        if bias is not None:
-            y = ops.elementwise(torch.add, y, bias)
-
-        # Output conditioning.
-        if self.mode == "fq":
-            fq_output = self.fq_output
-            if fq_output is not None:
-                # Static output quantization.
-                y = fq_output.quantize(y).unpack().dequant()
-        return y
-
-    def _validate_fake_quant_mode(self):
-        fq_input = self.fq_input
-        fq_output = self.fq_output
-        weight = self.weight
-        if not isinstance(fq_input, QuantizerTensor):
-            raise (
-                f"LinearLayer requires fq_input to be a QuantizerTensor, "
-                f"but got: {fq_input}"
-            )
-        if fq_output is not None:
-            if not isinstance(fq_output, QuantizerTensor):
-                raise (
-                    f"LinearLayer requires fq_output to be a QuantizerTensor, "
-                    f"but got: {fq_output}"
-                )
-        else:
-            # Dynamic quant mode requires a *ScaledQuantizer for the input
-            # and a TensorScaledLayout weight tensor.
-            if not isinstance(
-                fq_input, (StaticScaledQuantizer, DynamicScaledQuantizer)
-            ):
-                raise AssertionError(
-                    f"LinearLayer with a fq_output=None requires a "
-                    f"[Static|Dynamic]ScaledQuantizer for fq_input, but got: "
-                    f"{repr(fq_input)}"
-                )
-            if not isinstance(weight, QuantizedTensor):
-                raise AssertionError(
-                    f"LinearLayer with a fq_output=None requires a weight "
-                    f"of type QuantizedTensor, but got: {repr(weight)}"
-                )
-            if not issubclass(weight.layout_type, TensorScaledLayout):
-                raise AssertionError(
-                    f"LinearLayer with a fq_output=None requires a QuantizedTensor "
-                    f"weight with TensorScaledLayout, but got: {weight.layout_type}"
-                )
-
-    def _validate_native_quant_mode(self):
-        q_input = self.q_input
-        q_output = self.q_output
-
-        assert self.transpose_weight, "Native quant requires transposed weight matrix"
-        if q_output is not None:
-            raise AssertionError("Quantized LinearLayer output not yet supported")

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -167,24 +167,14 @@ class LinearLayer(ThetaLayer):
     def _native_quant(self, x):
         weight = self.weight
         bias = self.bias
-        accum_dtype = x.dtype  # TODO: unbox
+        dequant_dtype = x.dtype  # TODO: unbox
         q_input = self.q_input
         q_output = self.q_output
         if q_input is not None:
             x = q_input.quantize(x)
 
         # Simulate quantization with per-axis accumulate/offset.
-        y = ops.qlinear_dequant_accum(x, weight, bias, accum_dtype=accum_dtype)
-
-        # TODO: We should be calling an explicit qmatmul that can take
-        # the output quantizer. For the moment, we ignore dq_output
-        # entirely and only act on a q_output.
-        # y = ops.matmul(x, weight, transpose_rhs=self.transpose_weight)
-        # if bias is not None:
-        #     y = ops.elementwise(torch.add, y, bias)
-        # if q_output is not None:
-        #     y = q_output.quantize(y)
-
+        y = ops.qlinear_dequant(x, weight, bias, dequant_dtype=dequant_dtype)
         return y
 
     def _fake_quant(self, x):

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -172,9 +172,7 @@ class LinearLayer(ThetaLayer):
         q_output = self.q_output
         if q_input is not None:
             x = q_input.quantize(x)
-
-        # Simulate quantization with per-axis accumulate/offset.
-        y = ops.qlinear_dequant(x, weight, bias, dequant_dtype=dequant_dtype)
+        y = ops.qlinear_dequant(x, weight, bias)
         return y
 
     def _fake_quant(self, x):

--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -92,7 +92,6 @@ def apply_per_layer_quant(
     weight_quantizer = StaticScaledQuantizer(
         scale=1.0 / weight_scale,
         reciprocal_scale=weight_scale,
-        axis=0,
         offset=None if torch.count_nonzero(weight_zp) == 0 else weight_zp,
         dtype=torch.uint8,
     )
@@ -108,7 +107,6 @@ def apply_per_layer_quant(
         bias_scale = input_scale * weight_scale
         bias_quantizer = StaticScaledQuantizer(
             scale=bias_scale,
-            axis=0 if len(bias_scale.shape) > 0 else None,
             dtype=torch.int32,
             disable_saturate=True,
         )

--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -20,6 +20,9 @@ from . import _registry
 from .signatures import *
 
 # Ensure that implementations are registered.
+# Note that delegation prefers matching ops defined later, so order here
+# can be important.
 from . import default_impls
 from . import custom_impls
 from . import sharded_impls
+from . import q_impls

--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -26,4 +26,5 @@ from . import default_impls
 from . import custom_impls
 from . import sharded_impls
 
+# Comment this out to completely disable optimized quantized implementations.
 from . import q_impls

--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -25,4 +25,5 @@ from .signatures import *
 from . import default_impls
 from . import custom_impls
 from . import sharded_impls
+
 from . import q_impls

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -7,6 +7,8 @@
 # This file contains overrides of the standard ops for normal torch and
 # generic primitive/quantized types.
 
+from typing import Optional
+
 import torch
 from torch import Tensor, dtype
 import torch.nn.functional as F
@@ -16,13 +18,22 @@ from ._registry import unbox_tensor
 from .signatures import *
 
 # conv2d
-@conv2d.override(Tensor, Tensor, Tensor, auto_dequant=True)
-def conv2d_with_bias(
-    input: Tensor, weight: Tensor, bias: Tensor, *, stride, padding, dilation, groups
+
+
+def conv2d_default(
+    input: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    *,
+    stride,
+    padding,
+    dilation,
+    groups
 ):
     input = unbox_tensor(input)
     weight = unbox_tensor(weight)
-    bias = unbox_tensor(bias)
+    if bias is not None:
+        bias = unbox_tensor(bias)
     if weight.dtype != input.dtype:
         weight = weight.to(input.dtype)
     if bias.dtype != input.dtype:
@@ -38,25 +49,8 @@ def conv2d_with_bias(
     )
 
 
-@conv2d.override(Tensor, Tensor, auto_dequant=True)
-def conv2d_no_bias(
-    input: Tensor, weight: Tensor, bias, *, stride, padding, dilation, groups
-):
-    assert bias is None
-    input = unbox_tensor(input)
-    weight = unbox_tensor(weight)
-    if weight.dtype != input.dtype:
-        weight = weight.to(input.dtype)
-    return F.conv2d(
-        input,
-        weight,
-        bias,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        groups=groups,
-    )
-
+conv2d.override(Tensor, Tensor, Tensor, auto_dequant=True)(conv2d_default)
+conv2d.override(Tensor, Tensor, auto_dequant=True)(conv2d_default)
 
 # Elementwise
 @elementwise.override(Tensor)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -105,6 +105,23 @@ def layer_norm_default(input, weight, bias, *, eps):
     )
 
 
+# Linear
+def linear_default(input, weight, bias, *, accum_dtype) -> Tensor:
+    input = unbox_tensor(input)
+    weight = unbox_tensor(weight)
+    bias = None if bias is None else unbox_tensor(bias)
+    if weight.dtype != input.dtype:
+        weight = weight.to(dtype=input.dtype)
+    result = torch.matmul(input, weight.T)
+    if bias is not None:
+        result = result + bias
+    return result
+
+
+linear.override(Tensor, Tensor, auto_dequant=True)(linear_default)
+linear.override(Tensor, Tensor, Tensor, auto_dequant=True)(linear_default)
+
+
 # Matmul
 @matmul.override(Tensor, Tensor, auto_dequant=True)
 def matmul_default(lhs, rhs, *, transpose_rhs: bool) -> Tensor:

--- a/sharktank/sharktank/ops/q_impls.py
+++ b/sharktank/sharktank/ops/q_impls.py
@@ -1,0 +1,92 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Implementations for the q* family of ops.
+
+Note that unlike the normal FP ops, these ops are only parameterized on
+distinct types that have a direct implementation in the system. They are
+non general (and do not fall back to generic unboxing/dequant). It is
+expected that layers which use them know specifically that they wish to
+perform some flavor of fully quantized arithmetic.
+
+This module does not contain op overrides that are merely *optimizations*
+of a more general algorithm. Practically, this means that auto-dequantizing
+ops (which includes weight-only quantizations) happen in custom_impls and
+fully quantized op implementations are defined here.
+"""
+
+from typing import Optional
+
+import torch
+
+from ..types import (
+    InferenceTensor,
+    PrimitiveTensor,
+    QuantizedTensor,
+    TensorScaledLayout,
+)
+
+from ._registry import unbox_tensor, AnyTensor
+from .signatures import *
+
+################################################################################
+# qlinear
+################################################################################
+
+
+def qlinear_dequant_accum_tensor_scaled(
+    x: QuantizedTensor,
+    weight: QuantizedTensor,
+    bias: Optional[AnyTensor],
+    *,
+    accum_dtype: torch.dtype
+) -> torch.Tensor:
+    if not issubclass(x.layout_type, TensorScaledLayout) or not issubclass(
+        weight.layout_type, TensorScaledLayout
+    ):
+        return NotImplemented
+
+    # Now we know that both the x/weight are TensorScaledLayout. There are still
+    # degrees of freedom:
+    #  * Either/both can be per-tensor or per-axis scaled (d is 0D or d is nd>0).
+    #  * Either/both can have offsets of not (m is not None).
+    x_layout: TensorScaledLayout = x.unpack()
+    weight_layout: TensorScaledLayout = weight.unpack()
+
+    # Alias components (d=scale, qs=quantized samples, m=offset)
+    x_d = x_layout.d
+    x_qs = x_layout.qs
+    x_m = x_layout.m
+    weight_d = weight_layout.d
+    weight_qs = weight_layout.qs
+    weight_m = weight_layout.m
+
+    # TODO: Handle permutation that we have a kernel for.
+
+    # Fall back to exact simulation using higher precision types.
+    x_qs = x_qs.to(accum_dtype)
+    weight_qs = weight_qs.to(accum_dtype)
+    y_qs = torch.matmul(x_qs, weight_qs.T)
+    print("Y_QS:", y_qs.shape)
+    print("X_D:", x_d.shape)
+    print("WEIGHT_D:", weight_d.shape)
+    y = (y_qs - weight_m.T) * (x_d * weight_d.T)
+
+    print("Y:", y.shape)
+    # In this variant, the bias is always full precision, not quantized.
+    bias = None if bias is None else unbox_tensor(bias)
+    if bias is not None:
+        y = y + bias
+    return y
+
+
+# Overrload for both bias and no bias.
+qlinear_dequant_accum.override(QuantizedTensor, QuantizedTensor)(
+    qlinear_dequant_accum_tensor_scaled
+)
+qlinear_dequant_accum.override(QuantizedTensor, QuantizedTensor, AnyTensor)(
+    qlinear_dequant_accum_tensor_scaled
+)

--- a/sharktank/sharktank/ops/q_impls.py
+++ b/sharktank/sharktank/ops/q_impls.py
@@ -42,7 +42,6 @@ def qlinear_dequant_tensor_scaled(
     weight: QuantizedTensor,
     bias: Optional[AnyTensor],
     *,
-    dequant_dtype: torch.dtype,
     accum_dtype: torch.dtype
 ) -> torch.Tensor:
     if not issubclass(x.layout_type, TensorScaledLayout) or not issubclass(
@@ -80,7 +79,8 @@ def qlinear_dequant_tensor_scaled(
         weight_qs = weight_qs - weight_m
     y_qs = torch.matmul(x_qs, weight_qs.T)
     # Output scale by the product of input and weight scale.
-    y = y_qs.to(dequant_dtype) * (x_d * weight_d.T)
+    rescale = x_d * weight_d.T
+    y = y_qs.to(rescale.dtype) * rescale
 
     # In this variant, the bias is always full precision, not quantized.
     bias = None if bias is None else unbox_tensor(bias)

--- a/sharktank/sharktank/ops/q_impls.py
+++ b/sharktank/sharktank/ops/q_impls.py
@@ -91,12 +91,18 @@ def qlinear_tensor_scaled_integer(
     # activation manipulation. Whereas if applied before, it either blocks
     # matmul fusion or fuses additional arithmetic into the O(n^3) operation.
     if x_m is not None:
+        # Apply offset correction for asymmetric x.
+        # At the time of writing this was not a common case.
         x_offset_fix = torch.sum(weight_qs, axis=0, keepdim=True) * x_m
         y_qs = y_qs - x_offset_fix
     if weight_m is not None:
+        # Apply offset correction for asymmetric weight.
+        # At the time of writing this was the common case.
         weight_offset_fix = torch.sum(x_qs, axis=-1, keepdim=True) * weight_m.T
         y_qs = y_qs - weight_offset_fix
     if x_m is not None and weight_m is not None:
+        # Apply joint offset correction if both x and weight are asymmetric.
+        # At the time of writing this was not a common case.
         xweight_offset_fix = x_m * weight_m.T * x_qs.shape[-1]
         y_qs = y_qs + xweight_offset_fix
 

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -231,7 +231,6 @@ def qlinear_dequant(
     weight: AnyTensor,
     bias: Optional[AnyTensor],
     *,
-    dequant_dtype: torch.dtype,
     accum_dtype: torch.dtype = torch.int32,
 ) -> torch.Tensor:
     """Quantized linear operator which dequantizes and accumulates the matmul
@@ -248,14 +247,11 @@ def _qlinear_dequant_accum_trampoline(
     weight: AnyTensor,
     bias: Optional[AnyTensor],
     *,
-    dequant_dtype: torch.dtype,
     accum_dtype: torch.dtype = torch.int32,
 ):
     tensors = (x, weight) if bias is None else (x, weight, bias)
     for override in d.find_overrides(tensors):
-        result = override(
-            x, weight, bias, dequant_dtype=dequant_dtype, accum_dtype=accum_dtype
-        )
+        result = override(x, weight, bias, accum_dtype=accum_dtype)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/layout_utils.py
+++ b/sharktank/sharktank/types/layout_utils.py
@@ -148,15 +148,23 @@ def _view_uint8_tensor(data: torch.Tensor) -> torch.Tensor:
 
 
 def saturate_cast(
-    t: torch.Tensor, dtype: torch.dtype, round_int: bool = True
+    t: torch.Tensor,
+    dtype: torch.dtype,
+    round_int: bool = True,
+    disable_saturate: bool = False,
 ) -> torch.Tensor:
     """Does a saturating cast to the given dtype. For floating point
     values, this is a simple cast. For integer types, it will saturate to the
-    min/max range.
+    min/max range. An argument disable_saturate= is provided to allow
+    saturation to be disabled by flag without changing caller code. This is
+    needed if (for example, trying to saturate a high precision integer
+    type like int32) with a low precision tensor.
     """
     if dtype.is_floating_point:
         return t.to(dtype=dtype)
     iinfo = torch.iinfo(dtype)
     if round_int:
         t = torch.round(t)
-    return t.clamp(iinfo.min, iinfo.max).to(dtype=dtype)
+    if not disable_saturate:
+        t = t.clamp(iinfo.min, iinfo.max)
+    return t.to(dtype=dtype)

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -431,26 +431,27 @@ def _norm_per_axis_param(
     If axis is None, then the case is inferred from the parameters.
     The normalized axis and parameters are returned.
     """
-    required_rank = None
-    results = []
-    for p in params:
-        if p is None:
-            continue
-        rank = len(p.shape)
-        if required_rank is None:
-            if rank == 0:
-                axis = None
-                required_rank = 0
+    # Infer based on shapes.
+    if axis is None:
+        required_rank = None
+        for p in params:
+            if p is None:
+                continue
+            rank = len(p.shape)
+            if required_rank is None:
+                if rank == 0:
+                    axis = None
+                    required_rank = 0
+                else:
+                    axis = _find_non_unit_axis(p)
+                    required_rank = rank
             else:
-                axis = _find_non_unit_axis(p)
-                required_rank = rank
-        else:
-            # Enforce.
-            if rank != required_rank:
-                raise AssertionError(
-                    f"Expected rank {required_rank} quant parameter but "
-                    f"got {rank}: {p}"
-                )
+                # Enforce.
+                if rank != required_rank:
+                    raise AssertionError(
+                        f"Expected rank {required_rank} quant parameter but "
+                        f"got {rank}: {p}"
+                    )
 
     if axis is None:
         return axis, params

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -480,9 +480,12 @@ class PlanarQuantizedTensor(QuantizedTensor):
         )
 
     def __repr__(self):
-        return (
-            f"PlanarQuantized({self.name}, {self.shape}, planes={self.globals.keys()})"
-        )
+        def _shape_dtype_repr(t: torch.Tensor):
+            shape_repr = ", ".join(str(d) for d in t.shape)
+            return f"{shape_repr}, dtype={t.dtype}"
+
+        planes_repr = [f"{k}[{_shape_dtype_repr(t)}]" for k, t in self.globals.items()]
+        return f"PlanarQuantized({self.name}, {self.shape}, planes={planes_repr})"
 
 
 ########################################################################################

--- a/sharktank/tests/layers/linear_test.py
+++ b/sharktank/tests/layers/linear_test.py
@@ -12,7 +12,79 @@ from sharktank.layers import *
 from sharktank.types import *
 
 
+def _randomize_per_axis(t: torch.Tensor, axis: int, offset_range: float = 0.0):
+    # Applies a randomized per-axis scale and offset to a tensor.
+    bcast_shape = [1] * len(t.shape)
+    bcast_shape[axis] = t.shape[axis]
+
+    rnd_mult = torch.rand(bcast_shape, dtype=torch.float32)
+    t = t * rnd_mult
+    rnd_offset = torch.rand(bcast_shape, dtype=torch.float32) * offset_range
+    return t + rnd_offset
+
+
+def _scale_offset_per_axis_ui8(t: torch.Tensor, reduce_dim: int):
+    mn, _ = torch.min(t, reduce_dim)
+    mx, _ = torch.max(t, reduce_dim)
+    scale = 255.0 / (mx - mn)
+    offset = torch.round(mn * scale)
+    return scale, offset.to(dtype=torch.uint8)
+
+
+def _scale_per_tensor_i8(t: torch.Tensor):
+    amax = torch.abs(torch.max(t))
+    scale = 127 / amax.clamp(1e-6)
+    return scale
+
+
 class LinearQuantTest(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(12345)
+
+    def testNativeQuant_SymPerTensor_AsymPerAxis0_Dynamic(self):
+        # Tests a linear layer that multiplies a per-tensor lhs with a
+        # per-axis(0) rhs to produce a dynamically scaled FP result as output.
+
+        # Generate random tensors that are then randomly scaled along axis-0.
+        # Bias the rhs slightly to induce more interesting zero points.
+        lhs = _randomize_per_axis(torch.rand(4, 8, 128, dtype=torch.float32), axis=0)
+        rhs = _randomize_per_axis(
+            torch.rand(16, 128, dtype=torch.float32), axis=0, offset_range=0.02
+        )
+        # bias = torch.rand(16, dtype=torch.float32) + 5.0
+        bias = torch.zeros(16, dtype=torch.float32)
+
+        lhs_scale = _scale_per_tensor_i8(lhs)
+        rhs_scale, rhs_offset = _scale_offset_per_axis_ui8(rhs, 1)
+
+        lhs_quantizer = StaticScaledQuantizer(
+            name="q_input", scale=lhs_scale, dtype=torch.int8
+        )
+        rhs_quantizer = StaticScaledQuantizer(
+            scale=rhs_scale, offset=rhs_offset, dtype=torch.uint8, axis=0
+        )
+        rhs_quant = rhs_quantizer.quantize(rhs, name="weight")
+
+        # Sanity check that dequant'ing the RHS is roughly the same.
+        rhs_dequant = rhs_quant.unpack().dequant()
+        print("RHS_DIFF:", torch.abs(rhs_dequant - rhs))
+        # print("RHS:", rhs)
+        # print("RHS_DEQUANT:", rhs_dequant)
+        torch.testing.assert_close(rhs_dequant, rhs, atol=1e-1, rtol=1e-2)
+
+        theta = Theta(
+            [
+                lhs_quantizer,
+                rhs_quant,
+                DefaultPrimitiveTensor(name="bias", data=bias),
+            ]
+        )
+        linear = LinearLayer(theta)
+
+        output = linear(lhs)
+        output_ref = torch.matmul(lhs, rhs.T) + bias
+        print(torch.abs(output - output_ref))
+
     def testFakeQuantPerTensorDynamic(self):
         # TODO: Testing matmuls on unscaled random data like this produces
         # mis-behaving numerics due to outliers. Makes it hard to have a

--- a/sharktank/tests/layers/linear_test.py
+++ b/sharktank/tests/layers/linear_test.py
@@ -51,8 +51,8 @@ class LinearQuantTest(unittest.TestCase):
         rhs = _randomize_per_axis(
             torch.rand(16, 128, dtype=torch.float32), axis=0, offset_range=0.02
         )
-        # bias = torch.rand(16, dtype=torch.float32) + 5.0
-        bias = torch.zeros(16, dtype=torch.float32)
+        bias = torch.rand(16, dtype=torch.float32) + 5.0
+        # bias = torch.zeros(16, dtype=torch.float32)
 
         lhs_scale = _scale_per_tensor_i8(lhs)
         rhs_scale, rhs_offset = _scale_offset_per_axis_ui8(rhs, 1)
@@ -66,11 +66,11 @@ class LinearQuantTest(unittest.TestCase):
         rhs_quant = rhs_quantizer.quantize(rhs, name="weight")
 
         # Sanity check that dequant'ing the RHS is roughly the same.
-        rhs_dequant = rhs_quant.unpack().dequant()
-        print("RHS_DIFF:", torch.abs(rhs_dequant - rhs))
+        # rhs_dequant = rhs_quant.unpack().dequant()
+        # print("RHS_DIFF:", torch.abs(rhs_dequant - rhs))
         # print("RHS:", rhs)
         # print("RHS_DEQUANT:", rhs_dequant)
-        torch.testing.assert_close(rhs_dequant, rhs, atol=1e-1, rtol=1e-2)
+        # torch.testing.assert_close(rhs_dequant, rhs, atol=1e-1, rtol=1e-2)
 
         theta = Theta(
             [
@@ -84,6 +84,7 @@ class LinearQuantTest(unittest.TestCase):
         output = linear(lhs)
         output_ref = torch.matmul(lhs, rhs.T) + bias
         print(torch.abs(output - output_ref))
+        torch.testing.assert_close(output, output_ref, atol=1e-1, rtol=1e-1)
 
     def testFakeQuantPerTensorDynamic(self):
         # TODO: Testing matmuls on unscaled random data like this produces


### PR DESCRIPTION
Capturing a stable state from iterating with the quantization simulator.

Primary changes:

* Drastically simplify the way that linear and conv layers are configured. Now the primary knob is the presence of a `q_input` quantizer. If present, it will be used to quantize the activations prior to feeding to the underlying op.
* Add `qdq_input` tensor to linear and conv, which can be used to simulate quantization for testing/compare/goldens/etc.
* Implemented bias quantization (disabled for now because still tracking down numeric instability).
* Added an option to the brevitas importer to bootstrap from a base safetensors file, only using the primary one for quantized layers. Not clear it is meaningful but aided some debugging.
* Added an optimized quantized linear op override. This will get used for TensorScaled inputs and allows either an FP or TensorScaled bias. For the former, bias add will be done after dequant in FP. For the latter, it will be done prior to dequant and is responsible for providing the output scale.
* Added a dedicated `linear` op.
* Fixed `saturate_cast` to have an option to disable saturation (for int32 and such).
* Reworked StaticScaledQuantizer to infer the axis in the case when scales/zp come in pre-broadcast.
