### PR TITLE
Add some features that make it easier to do A/B comparison on punet.

### DIFF
--- a/sharktank/sharktank/layers/base.py
+++ b/sharktank/sharktank/layers/base.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from typing import Dict
+
 import torch
 import torch.nn as nn
 
@@ -25,8 +27,26 @@ __all__ = [
 class BaseLayer(nn.Module):
     """Base class of all of our layers."""
 
-    def trace_tensor(self, key: str, t: torch.Tensor, *, values: bool = True):
-        debugging.trace_tensor(key, t, values=values)
+    def trace_tensor(
+        self, key: str, t: torch.Tensor, *, values: bool = True, golden: bool = False
+    ):
+        debugging.trace_tensor(key, t, values=values, golden=golden)
+
+    def trace_tensors(
+        self,
+        key: str,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        values: bool = True,
+        golden: bool = False,
+    ):
+        debugging.trace_tensors(key, tensors, values=values, golden=golden)
+
+    def trace_golden(self, key: str, t: torch.Tensor):
+        debugging.trace_tensor(key, t, golden=True)
+
+    def trace_goldens(self, key: str, tensors: Dict[str, torch.Tensor]):
+        debugging.trace_tensors(key, tensors, golden=True)
 
     def assert_not_nan(self, *ts: torch.Tensor):
         """Checks whether tensors have nan values in them.

--- a/sharktank/sharktank/models/punet/tools/run_punet.py
+++ b/sharktank/sharktank/models/punet/tools/run_punet.py
@@ -13,6 +13,41 @@ from shark_turbine import aot
 from ..model import Unet2DConditionModel, ClassifierFreeGuidanceUnetModel
 
 
+def get_random_inputs(dtype, device):
+    torch.random.manual_seed(42)
+    max_length = 64
+    height = 1024
+    width = 1024
+    bs = 1
+    return {
+        "sample": torch.rand(bs, 4, height // 8, width // 8, dtype=dtype).to(device),
+        "timestep": torch.zeros(1, dtype=torch.int32).to(device),
+        "encoder_hidden_states": torch.rand(2 * bs, max_length, 2048, dtype=dtype).to(
+            device
+        ),
+        "text_embeds": torch.rand(2 * bs, 1280, dtype=dtype).to(device),
+        "time_ids": torch.zeros(2 * bs, 6, dtype=dtype).to(device),
+        "guidance_scale": torch.tensor([7.5], dtype=dtype).to(device),
+    }
+
+
+def load_inputs(st_path: Path, dtype, device):
+    from safetensors import safe_open
+
+    with safe_open(st_path, framework="pt", device=device) as st:
+        random_inputs = get_random_inputs(dtype=dtype, device=device)
+        inputs = {}
+        for name, random_input in random_inputs.items():
+            if name in st.keys():
+                print(f"Using specified input for tensor {name}")
+                t = st.get_tensor(name)
+                inputs[name] = t
+            else:
+                print(f"Using default/random tensor for tensor {name}")
+                inputs[name] = random_input
+    return inputs
+
+
 def main():
     from ....utils import cli
 
@@ -21,6 +56,11 @@ def main():
     parser.add_argument("--device", default="cuda:0", help="Torch device to run on")
     parser.add_argument("--dtype", default="float16", help="DType to run in")
     parser.add_argument("--export", type=Path, help="Export to path (vs run)")
+    parser.add_argument(
+        "--inputs",
+        type=Path,
+        help="Safetensors file of inputs (or random if not given)",
+    )
     args = cli.parse(parser)
 
     device = args.device
@@ -33,41 +73,20 @@ def main():
     mdl = ClassifierFreeGuidanceUnetModel(cond_unet)
 
     # Run a step for debugging.
-    torch.random.manual_seed(42)
-    max_length = 64
-    height = 1024
-    width = 1024
-    bs = 1
-    sample = torch.rand(bs, 4, height // 8, width // 8, dtype=dtype).to(device)
-    timestep = torch.zeros(1, dtype=torch.int32).to(device)
-    prompt_embeds = torch.rand(2 * bs, max_length, 2048, dtype=dtype).to(device)
-    text_embeds = torch.rand(2 * bs, 1280, dtype=dtype).to(device)
-    time_ids = torch.zeros(2 * bs, 6, dtype=dtype).to(device)
-    guidance_scale = torch.tensor([7.5], dtype=dtype).to(device)
+    if args.inputs:
+        inputs = load_inputs(args.inputs, dtype=dtype, device=device)
+    else:
+        inputs = get_random_inputs(dtype=dtype, device=device)
 
     if args.export:
         # Temporary: Need a dedicated exporter.
         output = aot.export(
             mdl,
-            kwargs={
-                "sample": sample,
-                "timestep": timestep,
-                "encoder_hidden_states": prompt_embeds,
-                "text_embeds": text_embeds,
-                "time_ids": time_ids,
-                "guidance_scale": guidance_scale,
-            },
+            kwargs=inputs,
         )
         output.save_mlir(args.export)
     else:
-        results = mdl.forward(
-            sample=sample,
-            timestep=timestep,
-            encoder_hidden_states=prompt_embeds,
-            text_embeds=text_embeds,
-            time_ids=time_ids,
-            guidance_scale=guidance_scale,
-        )
+        results = mdl.forward(**inputs)
         print("1-step results:", results)
 
 

--- a/sharktank/sharktank/utils/debugging.py
+++ b/sharktank/sharktank/utils/debugging.py
@@ -5,10 +5,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Tools for debugging models."""
+from typing import Dict, Optional
 
 from dataclasses import dataclass
 import re
 import os
+from pathlib import Path
 from typing import Sequence
 
 import torch
@@ -27,6 +29,8 @@ SETTING_PART_PATTERN = re.compile(r"""^([\\+\\-])?([^=]+)(=(.*))?$""")
 class DebugFlags:
     enable_tensor_trace: bool = False
     enable_nan_checks: bool = False
+    save_goldens_path: Optional[Path] = None
+    golden_sequence_value: int = 0
 
     def set(self, part: str):
         m = re.match(SETTING_PART_PATTERN, part)
@@ -41,6 +45,8 @@ class DebugFlags:
             self.enable_tensor_trace = logical_sense
         elif name == "enable_nan_checks":
             self.enable_nan_checks = logical_sense
+        elif name == "save_goldens_path":
+            self.save_goldens_path = Path(value)
         else:
             logger.warn("Unrecognized %s flag: '%s'", FLAGS_ENV_NAME, name)
 
@@ -68,8 +74,40 @@ class DebugFlags:
 flags = DebugFlags.parse_from_env()
 
 
-def trace_tensor(key: str, t: torch.Tensor, *, values: bool = True):
+def trace_tensor(
+    key: str, t: torch.Tensor, *, values: bool = True, golden: bool = False
+):
+    trace_tensors(key, {"default": t}, values=values, golden=golden)
+
+
+def trace_tensors(
+    key: str,
+    tensors: Dict[str, torch.Tensor],
+    *,
+    values: bool = True,
+    golden: bool = False,
+):
+    if golden:
+        if flags.save_goldens_path:
+            _save_goldens(key, tensors)
+        return
     if not flags.enable_tensor_trace:
         return
-    values_repr = repr(t) if values else "...elided..."
-    print(f"::: TRACE {key}({list(t.shape), t.dtype}) =\n{values_repr}")
+    for name, t in tensors.items():
+        if t is not None:
+            values_repr = repr(t) if values else "...elided..."
+            print(f"::: TRACE {key}:{name}({list(t.shape), t.dtype}) =\n{values_repr}")
+
+
+def _save_goldens(key: str, tensors: Dict[str, torch.Tensor]):
+    next_sequence = flags.golden_sequence_value
+    flags.golden_sequence_value += 1
+    # Sanitize as path.
+    key = re.sub("[" + re.escape(r"""#~!@$%^&*()[]{}:;"'""") + "]", "", key)
+    from safetensors.torch import save_file
+
+    path: Path = flags.save_goldens_path / f"{next_sequence:04d}_{key}.safetensors"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"::: SAVE GOLDEN {path}")
+    non_none_tensors = {k: v.contiguous() for k, v in tensors.items() if v is not None}
+    save_file(non_none_tensors, path)


### PR DESCRIPTION
* run_punet.py gets a `--inputs` argument, where a safetensors file can be supplied to override random inputs.
* Added APIs for `trace_tensor(golden=True)` which is meant to be kept permanently at key points in the model (as opposed to normal trace_tensor which is meant as a debugging aid to be removed when done).
* Added `TURBINE_LLM_DEBUG=save_goldens_path=...some/path` env var setting. This dumps a sequenced list of safetensors files for every tensor traced with golden=True.
* Added golden traces at input/output/down/mid/up block boundaries in the punet model.
* Verified with an offline script that without our optimized linear layer, we are within the margin of error with stability unet, using Brevitas i8 quantization. The layer with optimized math enabled diverges slowly, causing a large deviation on the whole model level. This should be easy to track down with the additional instrumentation.