### PR TITLE
[punet] Update quantizer to allow explicit mixed precision rescale.

### DIFF
--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -33,9 +33,9 @@ from ....types import *
 # at all.
 IMPORT_SMOOTHQUANT_PRESCALE = True
 
-# Optimized kernels can use a quantized bias, but this is an advanced case
-# that isn't working flawlessly yet.
-QUANTIZE_BIAS = False
+# Quantizing the bias can produce better fusions but puts more pressure on
+# datatype ranges.
+QUANTIZE_BIAS = True
 
 
 def _load_json(p: Path):
@@ -88,9 +88,9 @@ def apply_per_layer_quant(
             )
             updated_tensors[premul_input.name] = premul_input
 
-    input_scale = _get_json_tensor("input_scale", torch.float16)
+    input_scale = _get_json_tensor("input_scale", torch.float32)
     input_zp = _get_json_tensor("input_zp", torch.uint8)
-    weight_scale = _get_json_tensor("weight_scale", torch.float16)
+    weight_scale = _get_json_tensor("weight_scale", torch.float32)
     weight_zp = _get_json_tensor("weight_zp", torch.uint8)
 
     if (

--- a/sharktank/sharktank/ops/q_impls.py
+++ b/sharktank/sharktank/ops/q_impls.py
@@ -65,6 +65,7 @@ def qlinear_tensor_scaled_integer(
 
     # Alias components (d=scale, qs=quantized samples, m=offset)
     x_d = x_layout.d
+    x_dtype = x_layout.dtype
     x_qs = x_layout.qs
     x_m = x_layout.m
     weight_d = weight_layout.d
@@ -133,6 +134,7 @@ def qlinear_tensor_scaled_integer(
             shape=output_shape,
             d=rescale_d,
             qs=y_qs,
+            dtype=x_dtype,
         ),
     )
 

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -22,6 +22,8 @@ from .tensors import (
     register_quantized_layout,
     MetaDataValueType,
     QuantizedLayout,
+    _dtype_to_serialized_name,
+    _serialized_name_to_dtype,
 )
 
 from .layout_utils import (
@@ -57,6 +59,12 @@ class TensorScaledLayout(QuantizedLayout):
     If d/m are scalar tensors, then this implements whole tensor quantization.
     Otherwise, they must be broadcast to the axis along which scaling is
     performed.
+
+    If initialized with a dtype, the result of the conversion will be cast
+    to this dtype (unless if otherwise specified in dequant()). If dtype is
+    not specified in the constructor, it will default to the dtype of `d`.
+    For low precision fp types, it can be necessary to have a higher precision
+    `d` with high precision
     """
 
     def __init__(
@@ -66,11 +74,13 @@ class TensorScaledLayout(QuantizedLayout):
         d: torch.Tensor,
         qs: torch.Tensor,
         m: Optional[torch.Tensor] = None,
+        dtype: Optional[torch.dtype] = None,
     ):
         self._shape = shape
         self._d = d
         self._qs = qs
         self._m = m
+        self._dtype = dtype if dtype is not None else d.dtype
 
     @classmethod
     def serialized_name(cls) -> str:
@@ -84,7 +94,19 @@ class TensorScaledLayout(QuantizedLayout):
         planes: dict[str, torch.Tensor],
     ):
         m = planes.get("m")
-        return cls(shape=shape, d=planes["d"], qs=planes["qs"], m=m)
+        dtype_str = metadata.get("dtype")
+        if dtype_str is not None:
+            dtype = _serialized_name_to_dtype(dtype_str)
+        else:
+            # Backwards compat with old serialized. Emulate original behavior
+            # before mixed precision.
+            dtype = None
+        return cls(shape=shape, d=planes["d"], qs=planes["qs"], m=m, dtype=dtype)
+
+    @property
+    def metadata(self) -> Optional[dict[str, MetaDataValueType]]:
+        """Additional metadata needed to reconstruct a layout."""
+        return {"dtype": _dtype_to_serialized_name(self._dtype)}
 
     @property
     def planes(self) -> dict[str, torch.Tensor]:
@@ -100,6 +122,10 @@ class TensorScaledLayout(QuantizedLayout):
     def shape(self) -> list[int]:
         """The flattened shape of the logical (unblocked) result."""
         return self._shape
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
 
     @property
     def d(self) -> torch.Tensor:
@@ -123,16 +149,18 @@ class TensorScaledLayout(QuantizedLayout):
         d = self.d
         m = self.m
         qs = self.qs
-        if dtype is not None:
-            d = d.to(dtype)
-        else:
-            dtype = d.dtype
-        qs = qs.to(dtype=dtype)
+        if dtype is None:
+            dtype = self.dtype
+        rescale_dtype = d.dtype
+        qs = qs.to(dtype=rescale_dtype)
         if m is not None:
-            m = m.to(dtype)
-            return (qs - m) * d
+            m = m.to(rescale_dtype)
+            result = (qs - m) * d
         else:
-            return qs * d
+            result = qs * d
+        if result.dtype != dtype:
+            result = result.to(dtype=dtype)
+        return result
 
     def __repr__(self):
         r = (
@@ -141,6 +169,7 @@ class TensorScaledLayout(QuantizedLayout):
         )
         if self.m is not None:
             r += f", m({list(self.m.shape)}, dtype={self.m.dtype})"
+        r += f" -> {self.dtype}"
         return r
 
 

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -63,8 +63,8 @@ class TensorScaledLayout(QuantizedLayout):
     If initialized with a dtype, the result of the conversion will be cast
     to this dtype (unless if otherwise specified in dequant()). If dtype is
     not specified in the constructor, it will default to the dtype of `d`.
-    For low precision fp types, it can be necessary to have a higher precision
-    `d` with high precision
+    For low precision fp activation types, it can be necessary to have a higher
+    precision `d`.
     """
 
     def __init__(

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -158,6 +158,7 @@ class StaticScaledQuantizer(QuantizerTensor):
                     d=self._reciprocal_scale,
                     qs=qs,
                     m=self._offset,
+                    dtype=t.dtype,  # Original dtype.
                 ),
             )
         else:
@@ -194,6 +195,7 @@ class StaticScaledQuantizer(QuantizerTensor):
                     d=broadcast_reciprocal_scale,
                     qs=qs,
                     m=broadcast_offset,
+                    dtype=t.dtype,  # Original dtype.
                 ),
             )
 
@@ -352,7 +354,7 @@ class DynamicScaledQuantizer(QuantizerTensor):
             reciprocal_scale = 1 / scale
             qs = saturate_cast(t * scale, self.dtype, round_int=True)
         else:
-            eps = 1e-4
+            eps = 1e-6
             iinfo = torch.iinfo(dtype)
             scale = iinfo.max / amax.clamp(eps)
             reciprocal_scale = 1.0 / scale
@@ -362,9 +364,7 @@ class DynamicScaledQuantizer(QuantizerTensor):
             shape=shape,
             name=name,
             layout=TensorScaledLayout(
-                shape=shape,
-                d=reciprocal_scale,
-                qs=qs,
+                shape=shape, d=reciprocal_scale, qs=qs, dtype=t.dtype  # Original dtype.
             ),
         )
 

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -481,12 +481,7 @@ class PlanarQuantizedTensor(QuantizedTensor):
         )
 
     def __repr__(self):
-        def _shape_dtype_repr(t: torch.Tensor):
-            shape_repr = ", ".join(str(d) for d in t.shape)
-            return f"{shape_repr}, dtype={t.dtype}"
-
-        planes_repr = [f"{k}[{_shape_dtype_repr(t)}]" for k, t in self.globals.items()]
-        return f"PlanarQuantized({self.name}, {self.shape}, planes={planes_repr})"
+        return f"PlanarQuantized({self.name}, {self.shape}, layout={self.layout})"
 
 
 ########################################################################################

--- a/sharktank/tests/types/quantizers_test.py
+++ b/sharktank/tests/types/quantizers_test.py
@@ -41,8 +41,9 @@ class StaticScaledQuantizerTest(TempDirTestBase):
             scale=torch.tensor(2.0, dtype=torch.float32), dtype=torch.uint8
         )
         ssq = self._roundtrip(ssq)
-        orig_value = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32)
+        orig_value = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float16)
         qt_value = ssq.quantize(orig_value)
+        qt_value = self._roundtrip(qt_value)
         layout = qt_value.unpack()
         dequant_value = layout.dequant()
         torch.testing.assert_close(orig_value, dequant_value, atol=1e-3, rtol=1e-3)
@@ -54,8 +55,9 @@ class StaticScaledQuantizerTest(TempDirTestBase):
             dtype=torch.int8,
         )
         ssq = self._roundtrip(ssq)
-        orig_value = torch.tensor([9.0, 10.0, 11.0, 12.0], dtype=torch.float32)
+        orig_value = torch.tensor([9.0, 10.0, 11.0, 12.0], dtype=torch.float16)
         qt_value = ssq.quantize(orig_value)
+        qt_value = self._roundtrip(qt_value)
         layout = qt_value.unpack()
         dequant_value = layout.dequant()
         torch.testing.assert_close(orig_value, dequant_value, atol=1e-3, rtol=1e-3)
@@ -84,7 +86,9 @@ class StaticScaledQuantizerTest(TempDirTestBase):
             dtype=torch.int8,
         )
         ssq = self._roundtrip(ssq)
-        orig_value = torch.tensor([[1.0, -2.0, 3.0], [10.0, -20.0, 60.0]])
+        orig_value = torch.tensor(
+            [[1.0, -2.0, 3.0], [10.0, -20.0, 60.0]], dtype=torch.float16
+        )
         qt_value = ssq.quantize(orig_value)
         layout = qt_value.unpack()
         qs = layout.planes["qs"]
@@ -102,7 +106,9 @@ class StaticScaledQuantizerTest(TempDirTestBase):
             dtype=torch.uint8,
         )
         ssq = self._roundtrip(ssq)
-        orig_value = torch.tensor([[9.0, -11.0, 13.0], [18.0, -29.0, 40.0]])
+        orig_value = torch.tensor(
+            [[9.0, -11.0, 13.0], [18.0, -29.0, 40.0]], dtype=torch.float16
+        )
         qt_value = ssq.quantize(orig_value)
         layout = qt_value.unpack()
         qs = layout.planes["qs"]


### PR DESCRIPTION
Previously, the dtype of the scale dictated the output dtype after dequant. This makes it impossible to execute in low-p (i.e. fp16) while preserving rescale computation in high-p (i.e. fp32). The latter is needed to avoid integer->float overflow after integer arithmetic. (There are other ways to factor this to avoid higher precision scales but this is simple/standard)

Also enables quantized bias, since this avoids the overflow and fixes an unnecessarily large eps.