### PR TITLE
Make matmul's transpose_rhs default to False and use linear instead

### DIFF
--- a/sharktank/sharktank/examples/sharding/export_ffn_net.py
+++ b/sharktank/sharktank/examples/sharding/export_ffn_net.py
@@ -51,10 +51,10 @@ class ShardedFFN(ThetaLayer):
         ffn_up_weight = self.theta.tensor("ffn_up", "weight")
         ffn_down_weight = self.theta.tensor("ffn_down", "weight")
         ffn_gate = ops.elementwise(
-            torch.nn.functional.silu, ops.matmul(x, ffn_gate_weight)
+            torch.nn.functional.silu, ops.linear(x, ffn_gate_weight)
         )
-        ffn_up = ops.matmul(x, ffn_up_weight)
-        ffn_down = ops.matmul(
+        ffn_up = ops.linear(x, ffn_up_weight)
+        ffn_down = ops.linear(
             ops.elementwise(torch.mul, ffn_gate, ffn_up), ffn_down_weight
         )
         summed = ops.sharded_sum(ffn_down)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -7,7 +7,7 @@
 # This file contains overrides of the standard ops for normal torch and
 # generic primitive/quantized types.
 
-from typing import Optional
+from typing import Optional, List
 
 import torch
 from torch import Tensor, dtype
@@ -107,7 +107,7 @@ def linear_default(input, weight, bias, *, accum_dtype) -> Tensor:
     bias = None if bias is None else unbox_tensor(bias)
     if weight.dtype != input.dtype:
         weight = weight.to(dtype=input.dtype)
-    result = torch.matmul(input, weight.T)
+    result = matmul(input, weight.T)
     if bias is not None:
         result = result + bias
     return result
@@ -145,6 +145,12 @@ def rms_norm_Tensor_QuantizedTensor(
     x = unbox_tensor(x)
     weight = weight.unpack().dequant(x.dtype)
     return rms_norm_default(x, weight, epsilon=epsilon)
+
+
+@permute.override(Tensor)
+def permute(tensor: Tensor, dims: List[int]):
+    torch_tensor = unbox_tensor(tensor)
+    return torch.permute(torch_tensor, dims)
 
 
 # Sharded default impls (do nothing).

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -107,7 +107,7 @@ def linear_default(input, weight, bias, *, accum_dtype) -> Tensor:
     bias = None if bias is None else unbox_tensor(bias)
     if weight.dtype != input.dtype:
         weight = weight.to(dtype=input.dtype)
-    result = matmul(input, weight.T)
+    result = matmul(input, weight, transpose_rhs=True)
     if bias is not None:
         result = result + bias
     return result

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -8,6 +8,7 @@
 """
 
 from typing import Optional
+from torch import Tensor
 
 import warnings
 
@@ -153,3 +154,20 @@ linear.override(QuantizedTensor, QuantizedTensor)(qlinear_tensor_scaled_integer)
 linear.override(QuantizedTensor, QuantizedTensor, AnyTensor)(
     qlinear_tensor_scaled_integer
 )
+
+
+def linear_quantized_weight(
+    x: Tensor,
+    weight: QuantizedTensor,
+    bias: Optional[AnyTensor],
+    *,
+    accum_dtype: Optional[torch.dtype],
+) -> AnyTensor:
+    res = matmul(x, weight, transpose_rhs=True)
+    if bias is not None:
+        res = res + bias
+    return res
+
+
+linear.override(Tensor, QuantizedTensor)(linear_quantized_weight)
+linear.override(Tensor, QuantizedTensor, AnyTensor)(linear_quantized_weight)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -6,7 +6,7 @@
 
 """Signatures for dynamic dispatch of ops covering our fundamental tensor types."""
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Union, List
 
 import torch
 import numbers
@@ -23,6 +23,7 @@ __all__ = [
     "layer_norm",
     "linear",
     "matmul",
+    "permute",
     "rms_norm",
     "sharded_cat",
     "sharded_sum",
@@ -203,7 +204,7 @@ def _layer_norm_trampoline(
 def linear(
     input: AnyTensor,
     weight: AnyTensor,
-    bias: Optional[AnyTensor],
+    bias: Optional[AnyTensor] = None,
     *,
     accum_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
@@ -230,7 +231,7 @@ def _linear_trampoline(
     d: SignatureDispatcher,
     input: AnyTensor,
     weight: AnyTensor,
-    bias: Optional[AnyTensor],
+    bias: Optional[AnyTensor] = None,
     *,
     accum_dtype: Optional[torch.dtype] = None,
 ):
@@ -244,7 +245,7 @@ def _linear_trampoline(
 
 
 @overridable
-def matmul(lhs: AnyTensor, rhs: AnyTensor, *, transpose_rhs: bool = True):
+def matmul(lhs: AnyTensor, rhs: AnyTensor, *, transpose_rhs: bool = False):
     """Performs a matmul where the RHS may be an InferenceTensor.
 
     Unlike torch.matmul, this variant is optimized for emission of a fused
@@ -263,11 +264,32 @@ def matmul(lhs: AnyTensor, rhs: AnyTensor, *, transpose_rhs: bool = True):
 
 
 @matmul.trampoline
-def _matmul_trampoline(d: SignatureDispatcher, lhs, rhs, *, transpose_rhs: bool = True):
+def _matmul_trampoline(
+    d: SignatureDispatcher, lhs, rhs, *, transpose_rhs: bool = False
+):
     tensors = (lhs, rhs)
     assert isinstance(rhs, numbers.Number) or len(rhs.shape) == 2
     for override in d.find_overrides(tensors):
         result = override(lhs, rhs, transpose_rhs=transpose_rhs)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def permute(tensor: AnyTensor, dims: List[int]) -> AnyTensor:
+    """Permute the tensor dimensions according to the permutation `dims` in line
+    notation.
+    The semantics are the same as torch.permute."""
+    ...
+
+
+@permute.trampoline
+def _sharded_sum_trampoline(d: SignatureDispatcher, tensor: AnyTensor, dims: List[int]):
+    tensors = (tensor,)
+    for override in d.find_overrides(tensors):
+        result = override(tensor, dims)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -286,7 +286,7 @@ def permute(tensor: AnyTensor, dims: List[int]) -> AnyTensor:
 
 
 @permute.trampoline
-def _sharded_sum_trampoline(d: SignatureDispatcher, tensor: AnyTensor, dims: List[int]):
+def _permute_trampoline(d: SignatureDispatcher, tensor: AnyTensor, dims: List[int]):
     tensors = (tensor,)
     for override in d.find_overrides(tensors):
         result = override(tensor, dims)

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -10,7 +10,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
-import shark_turbine.ops as ops
 from ..utils.math import ceildiv
 from shark_turbine.aot import (
     ExternalTensorTrait,
@@ -238,6 +237,14 @@ class InferenceTensor(ABC):
     ) -> "InferenceTensor":
         raise NotImplementedError(
             f"InferenceTensor {type(self)} does not implement _clone_with_globals"
+        )
+
+    @property
+    def T(self) -> "InferenceTensor":
+        from ..ops import permute
+
+        return permute(
+            self, dims=torch.flip(torch.arange(len(self.shape)), dims=[0]).tolist()
         )
 
 

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -243,9 +243,12 @@ class InferenceTensor(ABC):
     def T(self) -> "InferenceTensor":
         from ..ops import permute
 
-        return permute(
-            self, dims=torch.flip(torch.arange(len(self.shape)), dims=[0]).tolist()
-        )
+        # Reverse the dimension range.
+        rank = len(self.shape)
+        assert rank == 2, "T will be deprecated in torch for non-2D tensors"
+        dims = [rank - 1 - i for i in range(rank)]
+
+        return permute(self, dims=dims)
 
 
 REGISTERED_INFERENCE_TENSOR_CLASSES: dict[str, Type[InferenceTensor]] = {}

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -141,7 +141,7 @@ class PermuteTest(unittest.TestCase):
         assert torch.equal(expected_result, permuted_primitive_tensor)
 
     def testTensorPropertyT(self):
-        torch_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
+        torch_tensor = torch.rand(3, 5, dtype=torch.float32)
         primitive_tensor = DefaultPrimitiveTensor(data=torch_tensor)
         assert torch.equal(torch_tensor.T, primitive_tensor.T)
 

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -55,7 +55,7 @@ class MatmulTest(unittest.TestCase):
     def testTorchImplTransposedRHS(self):
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
-        result = ops.matmul(t1, t2)
+        result = ops.matmul(t1, t2.T)
         expected = torch.matmul(t1, t2.T.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIs(
@@ -67,7 +67,7 @@ class MatmulTest(unittest.TestCase):
     def testTorchImplNonTransposedRHS(self):
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(16, 48, dtype=torch.float16)
-        result = ops.matmul(t1, t2, transpose_rhs=False)
+        result = ops.matmul(t1, t2)
         expected = torch.matmul(t1, t2.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIsNot(
@@ -80,7 +80,7 @@ class MatmulTest(unittest.TestCase):
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
         t2_pt = DefaultPrimitiveTensor(data=t2)
-        result = ops.matmul(t1, t2_pt)
+        result = ops.matmul(t1, t2_pt.T)
         expected = torch.matmul(t1, t2.T.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIs(
@@ -98,7 +98,7 @@ class MatmulTest(unittest.TestCase):
         rhs_pqt = PlanarQuantizedTensor(
             shape=[3200, 3200], layout=BlockScaledLayout([3200, 3200], d, qs)
         )
-        result = ops.matmul(a, rhs_pqt)
+        result = ops.matmul(a, rhs_pqt, transpose_rhs=True)
         # Just verifying dispatch. Numerics are tested at the kernel level.
         self.assertIs(
             ops._registry._TEST_LAST_OP_DISPATCH,
@@ -117,7 +117,7 @@ class MatmulTest(unittest.TestCase):
             shape=[3200, 3200],
             layout=BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
         )
-        result = ops.matmul(a, rhs_pqt)
+        result = ops.matmul(a, rhs_pqt, transpose_rhs=True)
         # Just verifying dispatch. Numerics are tested at the kernel level.
         self.assertIs(
             ops._registry._TEST_LAST_OP_DISPATCH,
@@ -125,6 +125,25 @@ class MatmulTest(unittest.TestCase):
         )
 
     # TODO: mmt_super_block_scaled_offset_q4_unsigned
+
+
+class PermuteTest(unittest.TestCase):
+    def testPermute(self):
+        torch_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
+        permutation = [1, 0, 2]
+        primitive_tensor = DefaultPrimitiveTensor(data=torch_tensor)
+        expected_result = torch.permute(torch_tensor, permutation)
+
+        permuted_torch_tensor = ops.permute(torch_tensor, permutation)
+        permuted_primitive_tensor = ops.permute(primitive_tensor, permutation)
+
+        assert torch.equal(expected_result, permuted_torch_tensor)
+        assert torch.equal(expected_result, permuted_primitive_tensor)
+
+    def testTensorPropertyT(self):
+        torch_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
+        primitive_tensor = DefaultPrimitiveTensor(data=torch_tensor)
+        assert torch.equal(torch_tensor.T, primitive_tensor.T)
 
 
 class RmsNormTest(unittest.TestCase):
@@ -173,7 +192,7 @@ class TestOpExport(unittest.TestCase):
                     shape=[3200, 3200],
                     layout=BlockScaledI4Layout([3200, 3200], d, qs, m=m, signed=False),
                 )
-                result = ops.matmul(a, rhs_pqt)
+                result = ops.linear(a, rhs_pqt)
                 return result
 
         my_module = MyModule()


### PR DESCRIPTION
Add the `permute` function that is equivalent to `torch.permute`. Add the `T` property to `InferenceTensor`.
Implement `linear` for some sharded tensor cases.