### PR TITLE
Expand sharded element-wise binary ops support

### DIFF
--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -24,7 +24,7 @@ from ..types import (
     SuperBlockOffsetScaled_4_6_Layout,
 )
 
-from ._registry import unbox_tensor, AnyTensor
+from ._registry import unbox_tensor
 from .signatures import *
 
 
@@ -45,16 +45,6 @@ from .signatures import *
 
 
 # Quantized Matmul
-
-
-@equal.override(Tensor, QuantizedTensor)
-def equal_tensor_quantized_tensor(a, b: QuantizedTensor) -> bool:
-    assert "TODO: implement"
-
-
-@equal.override(QuantizedTensor)
-def equal_tensor_quantized_tensor(a: QuantizedTensor, b: AnyTensor) -> bool:
-    assert "TODO: implement"
 
 
 @matmul.override(Tensor, QuantizedTensor)

--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -24,7 +24,7 @@ from ..types import (
     SuperBlockOffsetScaled_4_6_Layout,
 )
 
-from ._registry import unbox_tensor
+from ._registry import unbox_tensor, AnyTensor
 from .signatures import *
 
 
@@ -45,6 +45,16 @@ from .signatures import *
 
 
 # Quantized Matmul
+
+
+@equal.override(Tensor, QuantizedTensor)
+def equal_tensor_quantized_tensor(a, b: QuantizedTensor) -> bool:
+    assert "TODO: implement"
+
+
+@equal.override(QuantizedTensor)
+def equal_tensor_quantized_tensor(a: QuantizedTensor, b: AnyTensor) -> bool:
+    assert "TODO: implement"
 
 
 @matmul.override(Tensor, QuantizedTensor)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -14,7 +14,7 @@ from torch import Tensor, dtype
 import torch.nn.functional as F
 
 from ..types import InferenceTensor, PrimitiveTensor, QuantizedTensor
-from ._registry import unbox_tensor
+from ._registry import unbox_tensor, AnyTensor
 from .signatures import *
 
 # conv2d
@@ -79,6 +79,11 @@ def embedding_lookup_Tensor_QuantizedTensor(
 ):
     dequant = embedding_matrix.unpack().dequant(dtype=dtype)
     return F.embedding(unbox_tensor(input), dequant)
+
+
+@equal.override(Tensor, Tensor)
+def equal_default(a, b) -> bool:
+    return torch.equal(unbox_tensor(a), unbox_tensor(b))
 
 
 # Group norm.

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -160,10 +160,6 @@ def equal(a: AnyTensor, b: AnyTensor) -> bool:
     raise NotImplementedError
 
 
-def _not_equal(a: AnyTensor, b: AnyTensor) -> bool:
-    return False
-
-
 @equal.trampoline
 def _equal_trampoline(d: SignatureDispatcher, a: AnyTensor, b: AnyTensor):
     # Try first more specific matching the 2 operands.
@@ -176,15 +172,14 @@ def _equal_trampoline(d: SignatureDispatcher, a: AnyTensor, b: AnyTensor):
         if result is not NotImplemented:
             return override, result
 
-    # Try less specific matching the first operand.
+    # Less specific. Try matching only the first operand.
     tensors = (a,)
     for override in d.find_overrides(tensors):
         result = override(a, b)
         if result is not NotImplemented:
             return override, result
-
-    # If we don't match anything we assume not equal.
-    return _not_equal, _not_equal(a, b)
+    else:
+        d.fail(tensors)
 
 
 @overridable

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -250,6 +250,13 @@ class InferenceTensor(ABC):
 
         return permute(self, dims=dims)
 
+    def __add__(
+        self, rhs: "sharktank.ops._registry.AnyTensor"
+    ) -> "sharktank.ops._registry.AnyTensor":
+        from ..ops import elementwise
+
+        return elementwise(torch.add, self, rhs)
+
 
 REGISTERED_INFERENCE_TENSOR_CLASSES: dict[str, Type[InferenceTensor]] = {}
 

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -250,9 +250,7 @@ class InferenceTensor(ABC):
 
         return permute(self, dims=dims)
 
-    def __add__(
-        self, rhs: "sharktank.ops._registry.AnyTensor"
-    ) -> "sharktank.ops._registry.AnyTensor":
+    def __add__(self, rhs):
         from ..ops import elementwise
 
         return elementwise(torch.add, self, rhs)

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -11,32 +11,31 @@ import torch.nn.functional as F
 
 from sharktank import ops
 from sharktank.types import *
-from copy import deepcopy
 
 
 class EqualTest(unittest.TestCase):
     def testEqualTorchTensors(self):
         a = torch.rand(2, 3, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         assert ops.equal(a, b)
         assert ops.equal(b, a)
 
     def testNotEqualTorchTensors(self):
         a = torch.rand(2, 3, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         b[0, 0] += 1
         assert not ops.equal(a, b)
         assert not ops.equal(b, a)
 
     def testEqualTorchTensorAndPrimitiveTensor(self):
         a = torch.rand(2, 3, dtype=torch.float32)
-        b = DefaultPrimitiveTensor(data=deepcopy(a))
+        b = DefaultPrimitiveTensor(data=torch.clone(a))
         assert ops.equal(a, b)
         assert ops.equal(b, a)
 
     def testEqualTorchTensorAndPrimitiveTensor(self):
         a = torch.rand(2, 3, dtype=torch.float32)
-        b = DefaultPrimitiveTensor(data=deepcopy(a))
+        b = DefaultPrimitiveTensor(data=torch.clone(a))
         b.as_torch()[0, 0] += 1
         assert not ops.equal(a, b)
         assert not ops.equal(b, a)

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -11,6 +11,35 @@ import torch.nn.functional as F
 
 from sharktank import ops
 from sharktank.types import *
+from copy import deepcopy
+
+
+class EqualTest(unittest.TestCase):
+    def testEqualTorchTensors(self):
+        a = torch.rand(2, 3, dtype=torch.float32)
+        b = deepcopy(a)
+        assert ops.equal(a, b)
+        assert ops.equal(b, a)
+
+    def testNotEqualTorchTensors(self):
+        a = torch.rand(2, 3, dtype=torch.float32)
+        b = deepcopy(a)
+        b[0, 0] += 1
+        assert not ops.equal(a, b)
+        assert not ops.equal(b, a)
+
+    def testEqualTorchTensorAndPrimitiveTensor(self):
+        a = torch.rand(2, 3, dtype=torch.float32)
+        b = DefaultPrimitiveTensor(data=deepcopy(a))
+        assert ops.equal(a, b)
+        assert ops.equal(b, a)
+
+    def testEqualTorchTensorAndPrimitiveTensor(self):
+        a = torch.rand(2, 3, dtype=torch.float32)
+        b = DefaultPrimitiveTensor(data=deepcopy(a))
+        b.as_torch()[0, 0] += 1
+        assert not ops.equal(a, b)
+        assert not ops.equal(b, a)
 
 
 class EmbeddingLookupTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -309,7 +309,7 @@ class PermuteTest(unittest.TestCase):
         permuted_sharded_tensor = ops.permute(sharded_tensor, permutation)
         result = ops.sharded_cat(permuted_sharded_tensor)
 
-        assert torch.equal(expected_result, result)
+        assert ops.equal(expected_result, result)
 
 
 class MatmulTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -433,9 +433,24 @@ class ShardTest(unittest.TestCase):
         shard_count = 3
         replicated_tensor = ops.replicate(tensor, count=shard_count)
         actual_result = ops.shard(replicated_tensor, dim=shard_dim, count=shard_count)
-
         expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        assert expected_result.is_deep_equal(actual_result)
 
+    def testShardLikeReplicatedToSharded(self):
+        tensor = torch.rand(4, 5, 6, dtype=torch.float32)
+        shard_dim = 2
+        shard_count = 3
+        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        replicated_tensor = ops.replicate(tensor, count=shard_count)
+        actual_result = ops.shard_like(replicated_tensor, expected_result)
+        assert expected_result.is_deep_equal(actual_result)
+
+    def testShardLikeUnshardedToSharded(self):
+        tensor = torch.rand(4, 5, 6, dtype=torch.float32)
+        shard_dim = 2
+        shard_count = 3
+        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.shard_like(tensor, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import unittest
+from parameterized import parameterized
 
 import torch
 
 from sharktank import ops
 from sharktank.types import *
-from copy import deepcopy
 
 
 class ConvTest(unittest.TestCase):
@@ -144,95 +144,101 @@ class ElementwiseTest(unittest.TestCase):
 
         shard_dim = 2
         shard_count = 3
-        sharded_a = ops.shard(a, dim=shard_dim, count=shard_count)
-        sharded_b = ops.shard(b, dim=shard_dim, count=shard_count)
+        sharded_a = ops.reshard(a, dim=shard_dim, count=shard_count)
+        sharded_b = ops.reshard(b, dim=shard_dim, count=shard_count)
         sharded_result = sharded_a + sharded_b
-        actual_result = ops.shard_like(sharded_result, expected_result)
+        actual_result = ops.reshard_like(sharded_result, expected_result)
 
         torch.testing.assert_close(actual_result, expected_result)
 
-    def testBinaryOperators(self):
-        operators = [torch.add, torch.div, torch.fmin, torch.fmax, torch.sub]
+    @parameterized.expand(
+        [
+            (torch.add,),
+            (torch.div,),
+            (torch.fmin,),
+            (torch.fmax,),
+            (torch.sub),
+        ]
+    )
+    def testBinaryOperators(self, operator):
+        a = torch.rand(4, 5, 6, dtype=torch.float32)
+        b = torch.rand(4, 5, 6, dtype=torch.float32)
+        shard_dim = 2
+        shard_count = 3
+        expected_result = operator(a, b)
 
-        for operator in operators:
-            a = torch.rand(4, 5, 6, dtype=torch.float32)
-            b = torch.rand(4, 5, 6, dtype=torch.float32)
-            shard_dim = 2
-            shard_count = 3
-            expected_result = operator(a, b)
+        # Sharded LHS and RHS
+        sharded_a = ops.reshard(a, dim=shard_dim, count=shard_count)
+        sharded_b = ops.reshard(b, dim=shard_dim, count=shard_count)
+        sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
+        assert isinstance(sharded_result, ShardedTensor)
+        assert not sharded_result.is_replicated
+        assert sharded_result.shard_count == sharded_a.shard_count
+        assert sharded_result.shard_dim == sharded_a.shard_dim
+        actual_result = ops.reshard_like(sharded_result, expected_result)
+        torch.testing.assert_close(actual_result, expected_result)
 
-            # Sharded LHS and RHS
-            sharded_a = ops.shard(a, dim=shard_dim, count=shard_count)
-            sharded_b = ops.shard(b, dim=shard_dim, count=shard_count)
-            sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
-            assert isinstance(sharded_result, ShardedTensor)
-            assert not sharded_result.is_replicated
-            assert sharded_result.shard_count == sharded_a.shard_count
-            assert sharded_result.shard_dim == sharded_a.shard_dim
-            actual_result = ops.shard_like(sharded_result, expected_result)
-            torch.testing.assert_close(actual_result, expected_result)
+        # Replicated LHS and Sharded RHS
+        sharded_a = ops.replicate(a, count=shard_count)
+        sharded_b = ops.reshard(b, dim=shard_dim, count=shard_count)
+        sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
+        assert isinstance(sharded_result, ShardedTensor)
+        assert not sharded_result.is_replicated
+        assert sharded_result.shard_count == sharded_b.shard_count
+        assert sharded_result.shard_dim == sharded_b.shard_dim
+        actual_result = ops.reshard_like(sharded_result, expected_result)
+        torch.testing.assert_close(actual_result, expected_result)
 
-            # Replicated LHS and Sharded RHS
-            sharded_a = ops.replicate(a, count=shard_count)
-            sharded_b = ops.shard(b, dim=shard_dim, count=shard_count)
-            sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
-            assert isinstance(sharded_result, ShardedTensor)
-            assert not sharded_result.is_replicated
-            assert sharded_result.shard_count == sharded_b.shard_count
-            assert sharded_result.shard_dim == sharded_b.shard_dim
-            actual_result = ops.shard_like(sharded_result, expected_result)
-            torch.testing.assert_close(actual_result, expected_result)
-
-            # Sharded LHS and Replicated RHS
-            sharded_a = ops.shard(a, dim=shard_dim, count=shard_count)
-            sharded_b = ops.replicate(b, count=shard_count)
-            sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
-            assert isinstance(sharded_result, ShardedTensor)
-            assert not sharded_result.is_replicated
-            assert sharded_result.shard_count == sharded_a.shard_count
-            assert sharded_result.shard_dim == sharded_a.shard_dim
-            actual_result = ops.shard_like(sharded_result, expected_result)
-            torch.testing.assert_close(actual_result, expected_result)
+        # Sharded LHS and Replicated RHS
+        sharded_a = ops.reshard(a, dim=shard_dim, count=shard_count)
+        sharded_b = ops.replicate(b, count=shard_count)
+        sharded_result = ops.elementwise(operator, sharded_a, sharded_b)
+        assert isinstance(sharded_result, ShardedTensor)
+        assert not sharded_result.is_replicated
+        assert sharded_result.shard_count == sharded_a.shard_count
+        assert sharded_result.shard_dim == sharded_a.shard_dim
+        actual_result = ops.reshard_like(sharded_result, expected_result)
+        torch.testing.assert_close(actual_result, expected_result)
 
 
 class EqualTest(unittest.TestCase):
     def testNotEqualReplicated(self):
         a = torch.rand(3, 4, 5, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         shard_count = 2
         a_sharded = ops.replicate(a, count=shard_count)
-        b_sharded = ops.shard_like(b, a_sharded)
+        b_sharded = ops.reshard_like(b, a_sharded)
         assert ops.equal(a_sharded, b_sharded)
         assert ops.equal(b_sharded, a_sharded)
 
     def testNotEqualReplicated(self):
         a = torch.rand(3, 4, 5, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         b[0, 0, 0] += 1
         shard_count = 2
         a_sharded = ops.replicate(a, count=shard_count)
-        b_sharded = ops.shard_like(b, a_sharded)
+        b_sharded = ops.reshard_like(b, a_sharded)
         assert not ops.equal(a_sharded, b_sharded)
         assert not ops.equal(b_sharded, a_sharded)
 
     def testEqualSharded(self):
         a = torch.rand(3, 4, 5, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         shard_dim = 1
         shard_count = 2
-        a_sharded = ops.shard(a, dim=shard_dim, count=shard_count)
-        b_sharded = ops.shard_like(b, a_sharded)
+        a_sharded = ops.reshard(a, dim=shard_dim, count=shard_count)
+        b_sharded = ops.reshard_like(b, a_sharded)
         assert ops.equal(a_sharded, b_sharded)
         assert ops.equal(b_sharded, a_sharded)
 
     def testNotEqualSharded(self):
         a = torch.rand(3, 4, 5, dtype=torch.float32)
-        b = deepcopy(a)
+        b = torch.clone(a)
         b[0, 0, 0] += 1
         shard_dim = 1
         shard_count = 2
-        a_sharded = ops.shard(a, dim=shard_dim, count=shard_count)
-        b_sharded = ops.shard_like(b, a_sharded)
+        a_sharded = ops.reshard(a, dim=shard_dim, count=shard_count)
+        b_sharded = ops.reshard_like(b, a_sharded)
         assert not ops.equal(a_sharded, b_sharded)
         assert not ops.equal(b_sharded, a_sharded)
 
@@ -485,92 +491,92 @@ class ReplicateTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
-class ShardTest(unittest.TestCase):
-    def testShardReplicated(self):
+class ReshardTest(unittest.TestCase):
+    def testReshardReplicated(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
         shard_count = 3
         replicated_tensor = ops.replicate(tensor, count=shard_count)
-        actual_result = ops.shard(replicated_tensor, dim=shard_dim, count=shard_count)
-        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard(replicated_tensor, dim=shard_dim, count=shard_count)
+        expected_result = ops.reshard(tensor, dim=shard_dim, count=shard_count)
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardUnsharded(self):
+    def testReshardUnsharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
         shard_count = 3
-        actual_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard(tensor, dim=shard_dim, count=shard_count)
         expected_result = ShardedPrimitiveTensor(
             ts=tensor, shard_count=shard_count, shard_dim=shard_dim
         )
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardSharded(self):
+    def testReshardSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
         shard_count = 3
         expected_result = ShardedPrimitiveTensor(
             ts=tensor, shard_count=shard_count, shard_dim=shard_dim
         )
-        actual_result = ops.shard(expected_result, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard(expected_result, dim=shard_dim, count=shard_count)
         assert expected_result.is_deep_equal(actual_result)
 
 
 class ShardLikeTest(unittest.TestCase):
-    def testShardLikeReplicatedToReplicated(self):
+    def testReshardLikeReplicatedToReplicated(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_count = 2
         expected_result = ops.replicate(tensor, count=shard_count)
-        actual_result = ops.shard_like(expected_result, expected_result)
+        actual_result = ops.reshard_like(expected_result, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardLikeReplicatedToSharded(self):
+    def testReshardLikeReplicatedToSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
         shard_count = 3
-        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
+        expected_result = ops.reshard(tensor, dim=shard_dim, count=shard_count)
         replicated_tensor = ops.replicate(tensor, count=shard_count)
-        actual_result = ops.shard_like(replicated_tensor, expected_result)
+        actual_result = ops.reshard_like(replicated_tensor, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardLikeReplicatedToUnsharded(self):
+    def testReshardLikeReplicatedToUnsharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_count = 2
         replicated = ops.replicate(tensor, count=shard_count)
-        actual_result = ops.shard_like(replicated, tensor)
+        actual_result = ops.reshard_like(replicated, tensor)
         expected_result = tensor
         assert ops.equal(expected_result, actual_result)
 
-    def testShardLikeShardedToUnsharded(self):
+    def testReshardLikeShardedToUnsharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 0
         shard_count = 2
-        sharded = ops.shard(tensor, dim=shard_dim, count=shard_count)
-        actual_result = ops.shard_like(sharded, tensor)
+        sharded = ops.reshard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard_like(sharded, tensor)
         expected_result = tensor
         assert ops.equal(expected_result, actual_result)
 
-    def testShardLikeUnshardedToReplicated(self):
+    def testReshardLikeUnshardedToReplicated(self):
         tensor = torch.rand(4, 5, dtype=torch.float32)
         shard_count = 3
         expected_result = ops.replicate(tensor, count=shard_count)
-        actual_result = ops.shard_like(tensor, expected_result)
+        actual_result = ops.reshard_like(tensor, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardLikeUnshardedToSharded(self):
+    def testReshardLikeUnshardedToSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
         shard_count = 3
-        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
-        actual_result = ops.shard_like(tensor, expected_result)
+        expected_result = ops.reshard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard_like(tensor, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
-    def testShardLikeShardedToShared(self):
+    def testReshardLikeShardedToShared(self):
         tensor = torch.rand(5, 6, dtype=torch.float32)
         shard_dim = 1
         shard_count = 3
-        expected_result = ops.shard(tensor, dim=shard_dim, count=shard_count)
-        actual_result = ops.shard_like(expected_result, expected_result)
+        expected_result = ops.reshard(tensor, dim=shard_dim, count=shard_count)
+        actual_result = ops.reshard_like(expected_result, expected_result)
         assert expected_result.is_deep_equal(actual_result)
 
 


### PR DESCRIPTION
Add polymorphic `replicate`, `shard` and `shard_like` ops.
Add operator `+` for InferenceTensor.
Add `ops.equal`, analogous to `torch.equal` that operates on sharktank tensor types.