### PR TITLE
Disentangle the sharded and split notions

### DIFF
--- a/sharktank/sharktank/examples/sharding/export_ffn_net.py
+++ b/sharktank/sharktank/examples/sharding/export_ffn_net.py
@@ -29,16 +29,16 @@ def create_theta(
     # Columnwise (transposed) sharding of gate and up weight.
     gate_weight = torch.rand(hidden_dim, primary_dim, dtype=torch.float16)
     up_weight = torch.rand(hidden_dim, primary_dim, dtype=torch.float16)
-    sharded_gate_weight = ShardedPrimitiveTensor(
+    sharded_gate_weight = SplitPrimitiveTensor(
         name="ffn_gate.weight", shard_dim=0, ts=gate_weight.split(split_size, dim=0)
     )
-    sharded_up_weight = ShardedPrimitiveTensor(
+    sharded_up_weight = SplitPrimitiveTensor(
         name="ffn_up.weight", shard_dim=0, ts=up_weight.split(split_size, dim=0)
     )
 
     # Rowwise (transposed) sharding of down weight.
     down_weight = torch.rand(primary_dim, hidden_dim, dtype=torch.float16)
-    sharded_down_weight = ShardedPrimitiveTensor(
+    sharded_down_weight = SplitPrimitiveTensor(
         name="ffn_down.weight", shard_dim=1, ts=down_weight.split(split_size, dim=1)
     )
 

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -28,7 +28,7 @@ __all__ = [
     "permute",
     "rms_norm",
     "replicate",
-    "reshard",
+    "reshard_split",
     "reshard_like",
     "sharded_cat",
     "sharded_sum",
@@ -379,15 +379,15 @@ def _replicate_trampoline(
 
 
 @overridable
-def reshard(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
-    """Shard `input` along `dim`.
+def reshard_split(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
+    """Split `input` along `dim`.
     This does not mean that a sharded tensor is further sharded.
     It is not composition of sharding operations.
     """
     ...
 
 
-@reshard.trampoline
+@reshard_split.trampoline
 def _shard_trampoline(
     d: SignatureDispatcher, input: AnyTensor, dim: int, count: int
 ) -> ShardedTensor:

--- a/sharktank/sharktank/transforms/dataset/sharding.py
+++ b/sharktank/sharktank/transforms/dataset/sharding.py
@@ -19,7 +19,7 @@ __all__ = [
 class MmtRHSShardingTransform:
     """Shards tensors used as the RHS of a transposed matmul.
 
-    Tensors matching any of the patterns will be sharded, if supported, into
+    Tensors matching any of the patterns will be split, if supported, into
     `num_shards`.
     """
 
@@ -61,7 +61,7 @@ class MmtRHSShardingTransform:
             return None
         shard_split_size = shard_dim_size // self.num_shards
         shard_ts = t.split(shard_split_size, dim=shard_dim)
-        st = ShardedPrimitiveTensor(
+        st = SplitPrimitiveTensor(
             name=pt.name, shape=pt.shape, shard_dim=shard_dim, ts=shard_ts
         )
         logger.debug("Sharding tensor %r -> %r", pt, st)

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -28,7 +28,7 @@ __all__ = [
     "QuantizedLayout",
     "ReplicatedTensor",
     "ShardedTensor",
-    "ShardedPrimitiveTensor",
+    "SplitPrimitiveTensor",
     "UnreducedTensor",
 ]
 
@@ -670,8 +670,8 @@ class ShardedTensorBase(ShardedTensor):
 
 
 @register_inference_tensor
-class ShardedPrimitiveTensor(ShardedTensorBase):
-    """Sharded tensor which contains primitive tensors.
+class SplitPrimitiveTensor(ShardedTensorBase):
+    """Sharded tensor split along a dimension into primitive tensors.
 
     The sharded tensors have names with this tensor's name as the stem and
     a suffix of f".shard.{i}" where i is from 0..shard_count-1.
@@ -690,7 +690,7 @@ class ShardedPrimitiveTensor(ShardedTensorBase):
         If `ts` is a list of tensors, it is interpreted as the shards.
         Then `shard_count` must be None.
         If `ts` is a tensor then `shard_count` must be provided and it,
-        will be sharded along dimension `shard_dim` into `shard_count`
+        will be split along dimension `shard_dim` into `shard_count`
         number of pieces.
         """
         if isinstance(ts, torch.Tensor):
@@ -713,7 +713,7 @@ class ShardedPrimitiveTensor(ShardedTensorBase):
         for t in ts[1:]:
             assert (
                 t.shape == first_shape
-            ), f"Shape mismatch for sharded tensors: {t.shape} vs {first_shape}"
+            ), f"Shape mismatch for split tensors: {t.shape} vs {first_shape}"
             shard_dim_size += t.shape[shard_dim]
         assert (
             shard_dim_size == shape[shard_dim]

--- a/sharktank/tests/transforms/dataset_transforms_test.py
+++ b/sharktank/tests/transforms/dataset_transforms_test.py
@@ -52,8 +52,8 @@ class MmtRHSShardingTransformTest(MainRunnerTestBase):
         st_1 = flat_sts["blk.1.attn_k.weight"]
         st_2 = flat_sts["blk.2.attn_q.weight"]
         pt_3 = flat_sts["other"]
-        self.assertIsInstance(st_1, ShardedPrimitiveTensor)
-        self.assertIsInstance(st_2, ShardedPrimitiveTensor)
+        self.assertIsInstance(st_1, SplitPrimitiveTensor)
+        self.assertIsInstance(st_2, SplitPrimitiveTensor)
         self.assertIsInstance(pt_3, DefaultPrimitiveTensor)
         self.assertListEqual(st_1.shape, [32, 128])
         self.assertListEqual(st_2.shape, [48, 64])

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -79,7 +79,7 @@ class ShardedTensorTest(unittest.TestCase):
 
     def testShardedPrimitiveTensorSaveLoad(self):
         tensor = torch.rand([2, 6, 4], dtype=torch.float32)
-        sharded_tensor = ShardedPrimitiveTensor(
+        sharded_tensor = SplitPrimitiveTensor(
             ts=tensor, shard_count=3, name="the_tensor", shard_dim=1
         )
         theta = Theta([sharded_tensor])


### PR DESCRIPTION
We are using the term sharded as a general term to mean a tensor that is distributed across a number of logical devices.
On the other hand we are also using it to mean a tensor split along a dimension and distributed across the logical devices. To avoid confusion in the latter context we will talk about a sharded split tensor or simply a split tensor.