### PR TITLE
Add sharding specs

### DIFF
--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -11,7 +11,7 @@ from typing import Optional, Sequence, Union, List
 import torch
 import numbers
 from torch import Tensor, dtype
-from ..types import ShardedTensor
+from ..types import ShardedTensor, Theta, sharding
 
 from ._registry import *
 
@@ -28,6 +28,7 @@ __all__ = [
     "permute",
     "rms_norm",
     "replicate",
+    "reshard",
     "reshard_split",
     "reshard_like",
     "sharded_cat",
@@ -379,6 +380,31 @@ def _replicate_trampoline(
 
 
 @overridable
+def reshard(
+    input: AnyTensor | Theta,
+    spec: sharding.TensorSharding
+    | sharding.ThetaLayerSharding
+    | sharding.ThetaSharding,
+) -> AnyTensor | Theta:
+    """Reshard to the given specification.
+    If a Theta is given then the tensor nesting is preserved,
+    but the tensors are sharded according to the spec.
+    """
+    ...
+
+
+@reshard.trampoline
+def _reshard_trampoline(d: SignatureDispatcher, input, spec) -> ShardedTensor:
+    dispatch_args = (input, spec)
+    for override in d.find_overrides(dispatch_args):
+        result = override(input, spec)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(dispatch_args)
+
+
+@overridable
 def reshard_split(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
     """Split `input` along `dim`.
     This does not mean that a sharded tensor is further sharded.
@@ -388,7 +414,7 @@ def reshard_split(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
 
 
 @reshard_split.trampoline
-def _shard_trampoline(
+def _reshard_split_trampoline(
     d: SignatureDispatcher, input: AnyTensor, dim: int, count: int
 ) -> ShardedTensor:
     tensors = (input,)

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Specifications describing how a tensor, ops, layers and blocks are
+sharded."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from . import Theta
+
+
+class Sharding(ABC):
+    def __init__(self):
+        pass
+
+
+class TensorSharding(Sharding):
+    def __init__(self, *, shard_count: int):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+
+
+class Unsharded(TensorSharding):
+    def __init__(self):
+        super().__init__(shard_count=1)
+
+
+class Replicated(TensorSharding):
+    def __init__(self, *, shard_count: int):
+        super().__init__(shard_count=shard_count)
+
+
+class Split(TensorSharding):
+    def __init__(self, *, shard_count: int, shard_dim: int):
+        super().__init__(shard_count=shard_count)
+        self.shard_dim = shard_dim
+
+
+class ThetaSharding(dict):
+    """Sharding for each tensor in a theta.
+    It is of type dict[str, "ThetaSharding" | TensorSharding].
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class ThetaLayerSharding(Sharding):
+    def __init__(self):
+        super().__init__()
+
+    @abstractmethod
+    def theta_sharding(self) -> ThetaSharding:
+        """Returns the leaf tensor shardings.
+        The nested structure would match the one of a corresponding theta for this
+        layer.
+
+        ```python
+        form sharktank.ops import reshard
+        theta = ...
+        theta_layer_sharding = ...
+        theta_sharding = theta_layer_sharding.theta_sharding()
+        sharded_testa = reshard(theta, theta_sharding)
+        ```
+        """
+        ...
+
+
+class GroupNormSplitChannelSharding(ThetaLayerSharding):
+    def __init__(self, shard_count: int):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+
+    def theta_sharding(self) -> ThetaSharding:
+        return ThetaSharding(
+            {
+                "weight": Split(shard_count=self.shard_count, shard_dim=0),
+                "bias": Split(shard_count=self.shard_count, shard_dim=0),
+            }
+        )

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -8,8 +8,6 @@
 sharded."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from . import Theta
 
 
 class Sharding(ABC):
@@ -59,11 +57,11 @@ class ThetaLayerSharding(Sharding):
         layer.
 
         ```python
-        form sharktank.ops import reshard
+        from sharktank.ops import reshard
         theta = ...
         theta_layer_sharding = ...
         theta_sharding = theta_layer_sharding.theta_sharding()
-        sharded_testa = reshard(theta, theta_sharding)
+        sharded_theta = reshard(theta, theta_sharding)
         ```
         """
         ...

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -155,7 +155,7 @@ class Theta:
     def tensors(self) -> Collection[InferenceTensor]:
         return [v for v in self._tensors.values() if isinstance(v, InferenceTensor)]
 
-    def __call__(self, *name_path: str | int) -> "Theta":
+    def __call__(self, *name_path: str | int) -> Union["Theta", InferenceTensor]:
         name_path = _norm_name_path(name_path)
         current_ts = self._tensors
         try:
@@ -165,6 +165,8 @@ class Theta:
             raise KeyError(
                 f"Sub-theta {name_path} not found (of {self._tensors.keys()})"
             )
+        if isinstance(current_ts, InferenceTensor):
+            return current_ts
         return Theta(current_ts)
 
     def __repr__(self):


### PR DESCRIPTION
Sharding specs are concise description of tensor and layer sharding. They can be applied to tensors and thetas to get the sharded counterpart.

This is mostly the pluming around specific cases. Only sharing of the channel dimension in group normalization is provided.