### PR TITLE
[punet] Add direct to linalg integer kernels for mmt, conv, pooling sum.

### DIFF
--- a/docs/debug_flags.md
+++ b/docs/debug_flags.md
@@ -1,0 +1,27 @@
+# Debug flags
+
+Various debug flags are managed via environment variables.
+
+## Modeling flags
+
+Model level flags (used for running or compiling a model) are defined via the
+`TURBINE_LLM_DEBUG` environment variable. This is a comma delimeted string of
+`name[=value]` pairs. For boolean options the `=value` is not included. Instead,
+presence of the name sets the flag to true. Prefixing it with `-` sets it to
+false.
+
+### Flags:
+
+* `enable_tensor_trace`: Boolean flag that enables the trace_tensor facility
+  to emit information. When disabled, it is a no-op.
+* `enable_nan_checks`: Enables certain expensive nan checks that may be
+  included in the model.
+* `save_goldens_path`: When set to a path, any tensor traced via
+  `trace_tensor(golden=True)` will be added to a safetensors file and output
+  in a deterministic way to the path.
+* `use_custom_int_conv_kernel`: Uses custom kernels for integer convolution
+  arithmetic. This produces the most optimal compiled results but can impede
+  debugging and interactive use. Defaults to True.
+* `use_custom_int_mm_kernel`: Uses custom kernels for integer matmul
+  arithmetic. This produces the most optimal compiled results but can impede
+  debugging and interactive use. Defaults to True.

--- a/sharktank/sharktank/kernels/__init__.py
+++ b/sharktank/sharktank/kernels/__init__.py
@@ -8,3 +8,6 @@ from .mmtfp import *
 from .mmt_block_scaled_offset_q4 import *
 from .mmt_block_scaled_q8 import *
 from .mmt_super_block_scaled_offset_q4 import *
+from .batch_matmul_transpose_b import *
+from .conv_2d_nchw_fchw import *
+from .pooling_nchw_sum import *

--- a/sharktank/sharktank/kernels/base.py
+++ b/sharktank/sharktank/kernels/base.py
@@ -54,6 +54,7 @@ def call_function(target_function: Operation, *operands: Value) -> Sequence[Valu
         StringAttr(target_function.attributes["sym_name"]).value_bytes
     )
     ftype = FunctionType(TypeAttr(target_function.attributes["function_type"]).value)
+    operands = [i for i in operands if i is not None]
     return Operation.create(
         "util.call",
         results=ftype.results,

--- a/sharktank/sharktank/kernels/batch_matmul_transpose_b.py
+++ b/sharktank/sharktank/kernels/batch_matmul_transpose_b.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.kernels.base import *
+
+import torch
+
+__all__ = [
+    "batch_matmul_transpose_b",
+]
+
+
+@CustomOp.register(library=LIBRARY)
+class batch_matmul_transpose_b(CustomOp):
+    """Generic block scaled matmul with transposed RHS.
+
+    This corresponds to the BlockScaledLayout and operates on planar `d`
+    and `qs` tensors as specified there:
+
+    * `d`: `[N, K // 32, 1]`
+    * `qs`: `[N, K // 32, 32]`
+
+    The LHS is expected to be a 3d tensor of shape [B, M, K]. The kernel
+    will be specialized for all values of N, K and LHS dtype.
+    """
+
+    signature = "batch_matmul_transpose_b(Tensor lhs, Tensor rhs) -> (Tensor)"
+
+    def select(self, ksel: KernelSelection):
+        lhs_desc = ksel.arg_tensor(0)  # Shape [b, ] m, k
+        rhs_desc = ksel.arg_tensor(1)  # Shape [N, K // BLOCK_SIZE, 1]
+
+        # a arg
+        lhs_batch, lhs_m, lhs_k = lhs_desc.t.shape
+
+        # d arg
+        rhs_batch, rhs_n, rhs_k = rhs_desc.t.shape
+        torch._check(
+            rhs_k == lhs_k,
+            lambda: f"batch_matmul_transpose_b arg 'rhs': Incorrect shape (got {rhs_desc.t.shape})",
+        )
+
+        # Specialize on K, N, BS
+        lhs_desc.specialize_dims(-1, -2)
+        rhs_desc.specialize_dims(-1, -2)
+
+        # Shape batch..., m, n
+        c_desc = ksel.return_new_tensor(
+            [lhs_batch, lhs_m, rhs_n], dtype=lhs_desc.t.dtype
+        )
+        c_desc.specialize_dims(-1, -2)
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        lhs = kb.arg_value(0)
+        lhs_tensor_type = RankedTensorType(lhs.type)
+        rhs = kb.arg_value(1)
+        rhs_tensor_type = RankedTensorType(rhs.type)
+
+        b, m, k = lhs_tensor_type.shape
+        b, n, k = rhs_tensor_type.shape
+        dtype_str = str(lhs_tensor_type.element_type)
+
+        template_file = "batch_matmul_transpose_b.mlir"
+        target_function_name = (
+            f"sharktank_batch_matmul_transpose_b_{m}_{n}_{k}_{dtype_str}"
+        )
+
+        target_function = inline_template_function(
+            kb,
+            template_file,
+            target_function_name,
+            n=n,
+            k=k,
+            m=m,
+            b=b,
+            dtype=dtype_str,
+        )
+        kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -17,22 +17,21 @@ __all__ = [
 
 @CustomOp.register(library=LIBRARY)
 class conv_2d_nchw_fchw(CustomOp):
-    """Generic convolution that lowers directly to linalg ops.
+    """Generic convolution
 
 
     Will be specialized for all values of strides, padding, dilations, and LHS dtype.
     """
 
-    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor inputs_pad, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
-        inputs_pad_desc = ksel.arg_tensor(1)
-        weights_desc = ksel.arg_tensor(2)
-        bias_desc = ksel.arg_tensor(3)
-        strides_desc = ksel.attr_list_int(4)  # Shape [2]
-        padding_desc = ksel.attr_list_int(5)  # Shape [2]
-        dilations_desc = ksel.attr_list_int(6)  # Shape [2]
+        weights_desc = ksel.arg_tensor(1)
+        bias_desc = ksel.arg_tensor(2)
+        strides_desc = ksel.attr_list_int(3)  # Shape [2]
+        padding_desc = ksel.attr_list_int(4)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(5)  # Shape [2]
 
         # unpack
         n, c, h, w = inputs_desc.t.shape
@@ -74,12 +73,9 @@ class conv_2d_nchw_fchw(CustomOp):
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         inputs = kb.arg_value(0)
         inputs_tensor_type = RankedTensorType(inputs.type)
-        inputs_pad = kb.arg_value(1)
-        inputs_pad_tensor_type = RankedTensorType(inputs_pad.type)
-        strides = ksel.arg_descs[4].v
-        padding = ksel.arg_descs[5].v
-        dilations = ksel.arg_descs[6].v
-        # import pdb; pdb.set_trace()
+        strides = ksel.arg_descs[3].v
+        padding = ksel.arg_descs[4].v
+        dilations = ksel.arg_descs[5].v
 
         strides = [str(i) for i in strides]
         padding = [str(i) for i in padding]

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.kernels.base import *
+
+import math
+
+import torch
+
+__all__ = [
+    "conv_2d_nchw_fchw",
+]
+
+
+@CustomOp.register(library=LIBRARY)
+class conv_2d_nchw_fchw(CustomOp):
+    """Generic convolution that lowers directly to linalg ops.
+
+
+    Will be specialized for all values of strides, padding, dilations, and LHS dtype.
+    """
+
+    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor inputs_pad, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+
+    def select(self, ksel: KernelSelection):
+        inputs_desc = ksel.arg_tensor(0)
+        inputs_pad_desc = ksel.arg_tensor(1)
+        weights_desc = ksel.arg_tensor(2)
+        bias_desc = ksel.arg_tensor(3)
+        strides_desc = ksel.attr_list_int(4)  # Shape [2]
+        padding_desc = ksel.attr_list_int(5)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(6)  # Shape [2]
+
+        # unpack
+        n, c, h, w = inputs_desc.t.shape
+        f, g, k0, k1 = weights_desc.t.shape
+        (b,) = bias_desc.t.shape
+
+        strides = strides_desc.v
+        dilations = dilations_desc.v
+        padding = padding_desc.v
+
+        # check
+        torch._check(
+            b == f,
+            lambda: f"conv_2d_nchw_fchw bias shape should match out_channels shape but got {b} instead of {f}",
+        )
+        torch._check(
+            len(strides) == 2,
+            lambda: f"conv_2d_nchw_fchw requires exactly 2 strides; strides: {strides}",
+        )
+        torch._check(
+            len(dilations) == 2,
+            lambda: f"conv_2d_nchw_fchw requires exactly 2 dilations; dilations: {dilations}",
+        )
+        torch._check(
+            len(padding) == 2,
+            lambda: f"conv_2d_nchw_fchw requires exactly 2 padding; padding: {padding}",
+        )
+
+        # convolution shape math
+        h_out = math.floor(
+            (h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1
+        )
+        w_out = math.floor(
+            (w + 2 * padding[1] - dilations[1] * (k1 - 1) - 1) / strides[1] + 1
+        )
+
+        c_desc = ksel.return_new_tensor([n, f, h_out, w_out], dtype=inputs_desc.t.dtype)
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        inputs = kb.arg_value(0)
+        inputs_tensor_type = RankedTensorType(inputs.type)
+        inputs_pad = kb.arg_value(1)
+        inputs_pad_tensor_type = RankedTensorType(inputs_pad.type)
+        strides = ksel.arg_descs[4].v
+        padding = ksel.arg_descs[5].v
+        dilations = ksel.arg_descs[6].v
+        # import pdb; pdb.set_trace()
+
+        strides = [str(i) for i in strides]
+        padding = [str(i) for i in padding]
+        dilations = [str(i) for i in dilations]
+
+        dtype_str = str(inputs_tensor_type.element_type)
+
+        template_file = "conv_2d_nchw_fchw.mlir"
+        target_function_name = f"sharktank_conv_2d_nchw_fchw_{strides[0]}_{strides[1]}_{padding[0]}_{padding[1]}_{dilations[0]}_{dilations[1]}_{dtype_str}"
+
+        target_function = inline_template_function(
+            kb,
+            template_file,
+            target_function_name,
+            strides_H=strides[0],
+            strides_W=strides[1],
+            padding_H=padding[0],
+            padding_W=padding[1],
+            dilations_H=dilations[0],
+            dilations_W=dilations[1],
+            dtype=dtype_str,
+        )
+        kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/pooling_nchw_sum.py
+++ b/sharktank/sharktank/kernels/pooling_nchw_sum.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.kernels.base import *
+
+import math
+
+import torch
+
+__all__ = [
+    "pooling_nchw_sum",
+]
+
+
+@CustomOp.register(library=LIBRARY)
+class pooling_nchw_sum(CustomOp):
+    """Generic block scaled pooling sum.
+
+    This corresponds to the BlockScaledLayout and operates on planar `d`
+    and `qs` tensors as specified there:
+
+    * `d`: `[N, K // 32, 1]`
+    * `qs`: `[N, K // 32, 32]`
+
+    """
+
+    signature = "pooling_nchw_sum(Tensor a, int[] weights_size, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+
+    def select(self, ksel: KernelSelection):
+        input_desc = ksel.arg_tensor(0)  # Shape [b, ] m, k
+        weights_size_desc = ksel.attr_list_int(1)  # Shape [2]
+        strides_desc = ksel.attr_list_int(2)  # Shape [2]
+        padding_desc = ksel.attr_list_int(3)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(4)  # Shape [2]
+
+        # unpack
+        n, c, h, w = input_desc.t.shape
+
+        weights_size = weights_size_desc.v
+        strides = strides_desc.v
+        padding = padding_desc.v
+        dilations = padding_desc.v
+
+        input_desc.specialize_all_dims()
+
+        # pooling shape math
+        h_out = math.floor((h + 2 * padding[0] - weights_size[0]) / strides[0] + 1)
+        w_out = math.floor((w + 2 * padding[1] - weights_size[1]) / strides[1] + 1)
+
+        c_desc = ksel.return_new_tensor([n, c, h_out, w_out], dtype=input_desc.t.dtype)
+        c_desc.specialize_all_dims()
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        input = kb.arg_value(0)
+        input_tensor_type = RankedTensorType(input.type)
+        input_dim_sizes = "x".join(
+            str(input_tensor_type.get_dim_size(i))
+            for i in range(input_tensor_type.rank)
+        )
+        weights = ksel.arg_descs[1].v
+        strides = ksel.arg_descs[2].v
+        padding = ksel.arg_descs[3].v
+        dilations = ksel.arg_descs[4].v
+        pooling_nchw_sum = ksel.result_descs[0]
+        pooling_nchw_sum_output_shape = pooling_nchw_sum.mlir_type_asm
+        input_padding = input_tensor_type.shape
+        input_padding[-2] = input_padding[-2] + padding[0] * 2
+        input_padding[-1] = input_padding[-1] + padding[1] * 2
+
+        weights = [str(i) for i in weights]
+        strides = [str(i) for i in strides]
+        padding = [str(i) for i in padding]
+        dilations = [str(i) for i in dilations]
+        input_padding = [str(i) for i in input_padding]
+
+        dtype_str = str(input_tensor_type.element_type)
+
+        template_file = "pooling_nchw_sum.mlir"
+        target_function_name = f"sharktank_pooling_nchw_sum_{input_dim_sizes}_{weights[0]}_{weights[1]}_{strides[0]}_{strides[1]}_{padding[0]}_{padding[1]}_{dilations[0]}_{dilations[1]}_{dtype_str}"
+
+        target_function = inline_template_function(
+            kb,
+            template_file,
+            target_function_name,
+            input_dim_sizes=input_dim_sizes,
+            input_tensor_type=input_tensor_type,
+            input_padding_N=input_padding[0],
+            input_padding_C=input_padding[1],
+            input_padding_H=input_padding[2],
+            input_padding_W=input_padding[3],
+            pooling_nchw_sum_output_shape=pooling_nchw_sum_output_shape,
+            weights_H=weights[0],
+            weights_W=weights[1],
+            strides_H=strides[0],
+            strides_W=strides[1],
+            padding_H=padding[0],
+            padding_W=padding[1],
+            dilations_H=dilations[0],
+            dilations_W=dilations[1],
+            dtype=dtype_str,
+        )
+        kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/pooling_nchw_sum.py
+++ b/sharktank/sharktank/kernels/pooling_nchw_sum.py
@@ -17,15 +17,7 @@ __all__ = [
 
 @CustomOp.register(library=LIBRARY)
 class pooling_nchw_sum(CustomOp):
-    """Generic block scaled pooling sum.
-
-    This corresponds to the BlockScaledLayout and operates on planar `d`
-    and `qs` tensors as specified there:
-
-    * `d`: `[N, K // 32, 1]`
-    * `qs`: `[N, K // 32, 32]`
-
-    """
+    """Generic pooling sum."""
 
     signature = "pooling_nchw_sum(Tensor a, int[] weights_size, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
 

--- a/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
+++ b/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
@@ -1,0 +1,27 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+!dtype = {{dtype}}
+!a_tensor_type = tensor<?x{{m}}x{{k}}x!dtype>
+!b_tensor_type = tensor<?x{{n}}x{{k}}x!dtype>
+!c_tensor_type = tensor<?x{{m}}x{{n}}x!dtype>
+
+module {
+
+util.func private @sharktank_batch_matmul_transpose_b_{{m}}_{{n}}_{{k}}_{{dtype}}(
+    %a: !a_tensor_type, %b: !b_tensor_type)
+    -> !c_tensor_type {
+  %zero = arith.constant 0: !dtype
+  %c0 = arith.constant 0: index
+  %batch = tensor.dim %a, %c0 : !a_tensor_type
+  %result_empty = tensor.empty(%batch) : !c_tensor_type
+  %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !c_tensor_type) -> !c_tensor_type
+  %result = linalg.batch_matmul_transpose_b ins(%a, %b: !a_tensor_type, !b_tensor_type) outs(%result_fill: !c_tensor_type) -> !c_tensor_type
+
+  util.return %result : !c_tensor_type
+}
+
+}

--- a/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
+++ b/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
@@ -5,22 +5,23 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 !dtype = {{dtype}}
-!a_tensor_type = tensor<?x{{m}}x{{k}}x!dtype>
+!a_tensor_type = tensor<?x?x{{k}}x!dtype>
 !b_tensor_type = tensor<?x{{n}}x{{k}}x!dtype>
-!c_tensor_type = tensor<?x{{m}}x{{n}}x!dtype>
+!c_tensor_type = tensor<?x?x{{n}}x!dtype>
 
 module {
 
-util.func private @sharktank_batch_matmul_transpose_b_{{m}}_{{n}}_{{k}}_{{dtype}}(
+util.func private @sharktank_batch_matmul_transpose_b_{{n}}_{{k}}_{{dtype}}(
     %a: !a_tensor_type, %b: !b_tensor_type)
     -> !c_tensor_type {
   %zero = arith.constant 0: !dtype
   %c0 = arith.constant 0: index
-  %batch = tensor.dim %a, %c0 : !a_tensor_type
-  %result_empty = tensor.empty(%batch) : !c_tensor_type
+  %c1 = arith.constant 1: index
+  %batch_dim = tensor.dim %a, %c0 : !a_tensor_type
+  %m_dim = tensor.dim %a, %c1 : !a_tensor_type
+  %result_empty = tensor.empty(%batch_dim, %m_dim) : !c_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !c_tensor_type) -> !c_tensor_type
   %result = linalg.batch_matmul_transpose_b ins(%a, %b: !a_tensor_type, !b_tensor_type) outs(%result_fill: !c_tensor_type) -> !c_tensor_type
-
   util.return %result : !c_tensor_type
 }
 

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -14,7 +14,7 @@
 module {
 
 util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
+    %input: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %c0 = arith.constant 0: index
@@ -22,10 +22,10 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{pad
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  // %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
-  // ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
-  //   tensor.yield %zero : !dtype
-  // } : !dynamic_tensor_type to !dynamic_tensor_type
+  %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
+  ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
+    tensor.yield %zero : !dtype
+  } : !dynamic_tensor_type to !dynamic_tensor_type
 
 
   // Convolution size math, equivalent to:

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -1,0 +1,78 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+
+!dtype = {{dtype}}
+!dynamic_tensor_type = tensor<?x?x?x?x!dtype>
+!out_tensor_type = !dynamic_tensor_type
+
+module {
+
+util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
+    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
+    -> !out_tensor_type {
+  %zero = arith.constant 0: !dtype
+  %c0 = arith.constant 0: index
+  %c1 = arith.constant 1: index
+  %c2 = arith.constant 2: index
+  %c3 = arith.constant 3: index
+
+  // %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
+  // ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
+  //   tensor.yield %zero : !dtype
+  // } : !dynamic_tensor_type to !dynamic_tensor_type
+
+
+  // Convolution size math, equivalent to:
+  // h_out = math.floor((h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
+  // w_out = math.floor((w + 2 * padding[1] - dilations[1] * (k1 - 1) - 1) / strides[1] + 1)
+  %iH = tensor.dim %input, %c2 : !dynamic_tensor_type
+  %kH = tensor.dim %weights, %c2 : !dynamic_tensor_type
+  %sH = arith.constant {{strides_H}} : index
+  %dH = arith.constant {{dilations_H}} : index
+  %pH = arith.constant {{padding_H}} : index
+
+  %rH_0 = arith.subi %kH, %c1 : index
+  %rH_1 = arith.muli %dH, %rH_0 : index
+  %rH_2 = arith.muli %pH, %c2 : index
+  %rH_3 = arith.addi %iH, %rH_2 : index
+  %rH_4 = arith.subi %rH_3, %rH_1 : index
+  %rH_5 = arith.subi %rH_4, %c1 : index
+  %rH_6 = arith.addi %rH_5, %sH : index
+  %rH   = arith.divsi %rH_6, %sH : index
+
+  %iW = tensor.dim %input, %c3 : !dynamic_tensor_type
+  %kW = tensor.dim %weights, %c3 : !dynamic_tensor_type
+  %sW = arith.constant {{strides_W}} : index
+  %dW = arith.constant {{dilations_W}} : index
+  %pW = arith.constant {{padding_W}} : index
+
+  %rW_0 = arith.subi %kW, %c1 : index
+  %rW_1 = arith.muli %dW, %rW_0 : index
+  %rW_2 = arith.muli %pW, %c2 : index
+  %rW_3 = arith.addi %iW, %rW_2 : index
+  %rW_4 = arith.subi %rW_3, %rW_1 : index
+  %rW_5 = arith.subi %rW_4, %c1 : index
+  %rW_6 = arith.addi %rW_5, %sW : index
+  %rW   = arith.divsi %rW_6, %sW : index
+
+
+  %rN = tensor.dim %input, %c0 : !dynamic_tensor_type
+  %rC = tensor.dim %weights, %c0 : !dynamic_tensor_type
+  %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
+  %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
+  %result = linalg.conv_2d_nchw_fchw {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !dynamic_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
+  %result_biased = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%result, %bias : !dynamic_tensor_type, tensor<?x!dtype>) outs(%result : !dynamic_tensor_type) {
+    ^bb0(%in: !dtype, %in_1: !dtype, %out: !dtype):
+      %add = arith.addi %in, %in_1 : !dtype
+      linalg.yield %add : !dtype
+    } -> !dynamic_tensor_type
+  util.return %result_biased : !out_tensor_type
+}
+
+}

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -20,7 +20,7 @@ util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{stri
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
-  
+
   %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
   ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
     tensor.yield %zero : !dtype
@@ -33,7 +33,7 @@ util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{stri
   %sH = arith.constant {{strides_H}} : index // strides[0]
   %dH = arith.constant {{dilations_H}} : index
   %pH = arith.constant {{padding_H}} : index // padding[0]
-  
+
   %rH_0 = arith.muli %pH, %c2 : index
   %rH_1 = arith.addi %iH, %rH_0 : index
   %rH_2 = arith.subi %rH_1, %kH : index

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -1,0 +1,36 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+!dtype = {{dtype}}
+!input_tensor_type = {{input_tensor_type}}
+!weights_tensor_type = tensor<{{weights_H}}x{{weights_W}}x!dtype>
+!padding_out_tensor_type = tensor<{{input_padding_N}}x{{input_padding_C}}x{{input_padding_H}}x{{input_padding_W}}x!dtype>
+!out_tensor_type = {{pooling_nchw_sum_output_shape}}
+
+module {
+
+util.func private @sharktank_pooling_nchw_sum_{{input_dim_sizes}}_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
+    %input: !input_tensor_type)
+    -> !out_tensor_type {
+  %zero = arith.constant 0: !dtype
+  %weights = tensor.empty() : !weights_tensor_type
+  %c0 = arith.constant 0: index
+  %c1 = arith.constant 1: index
+  %c2 = arith.constant 2: index
+  %c3 = arith.constant 3: index
+
+  %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
+  ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
+    tensor.yield %zero : !dtype
+  } : !input_tensor_type to !padding_out_tensor_type
+
+  %result_empty = tensor.empty() : !out_tensor_type
+  %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
+  %result = linalg.pooling_nchw_sum {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !padding_out_tensor_type, !weights_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
+  util.return %result : !out_tensor_type
+}
+
+}

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -5,15 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 !dtype = {{dtype}}
-!input_tensor_type = {{input_tensor_type}}
+!dynamic_tensor_type = tensor<?x?x?x?x!dtype>
 !weights_tensor_type = tensor<{{weights_H}}x{{weights_W}}x!dtype>
-!padding_out_tensor_type = tensor<{{input_padding_N}}x{{input_padding_C}}x{{input_padding_H}}x{{input_padding_W}}x!dtype>
-!out_tensor_type = {{pooling_nchw_sum_output_shape}}
+!out_tensor_type = !dynamic_tensor_type
 
 module {
 
-util.func private @sharktank_pooling_nchw_sum_{{input_dim_sizes}}_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !input_tensor_type)
+util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
+    %input: !dynamic_tensor_type)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %weights = tensor.empty() : !weights_tensor_type
@@ -21,15 +20,44 @@ util.func private @sharktank_pooling_nchw_sum_{{input_dim_sizes}}_{{weights_H}}_
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
-
+  
   %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
   ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
     tensor.yield %zero : !dtype
-  } : !input_tensor_type to !padding_out_tensor_type
+  } : !dynamic_tensor_type to !dynamic_tensor_type
 
-  %result_empty = tensor.empty() : !out_tensor_type
+  // Pooling size math, equivalent to:
+  // h_out = math.floor((h + 2 * padding[0] - weights_size[0]) / strides[0] + 1)
+  %iH = tensor.dim %input, %c2 : !dynamic_tensor_type
+  %kH = arith.constant {{weights_H}} : index // weights_size[0]
+  %sH = arith.constant {{strides_H}} : index // strides[0]
+  %dH = arith.constant {{dilations_H}} : index
+  %pH = arith.constant {{padding_H}} : index // padding[0]
+  
+  %rH_0 = arith.muli %pH, %c2 : index
+  %rH_1 = arith.addi %iH, %rH_0 : index
+  %rH_2 = arith.subi %rH_1, %kH : index
+  %rH_3 = arith.addi %rH_2, %sH : index
+  %rH   = arith.divsi %rH_3, %sH : index
+
+  // w_out = math.floor((w + 2 * padding[1] - weights_size[1]) / strides[1] + 1)
+  %iW = tensor.dim %input, %c3 : !dynamic_tensor_type
+  %kW = arith.constant {{weights_H}} : index // weights_size[1]
+  %sW = arith.constant {{strides_W}} : index // strides[1]
+  %dW = arith.constant {{dilations_W}} : index
+  %pW = arith.constant {{padding_W}} : index // padding[1]
+
+  %rW_0 = arith.muli %pW, %c2 : index
+  %rW_1 = arith.addi %iW, %rW_0 : index
+  %rW_2 = arith.subi %rW_1, %kW : index
+  %rW_3 = arith.addi %rW_2, %sW : index
+  %rW   = arith.divsi %rW_3, %sW : index
+
+  %rN = tensor.dim %input, %c0 : !dynamic_tensor_type
+  %rC = tensor.dim %input, %c1 : !dynamic_tensor_type
+  %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
-  %result = linalg.pooling_nchw_sum {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !padding_out_tensor_type, !weights_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
+  %result = linalg.pooling_nchw_sum {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !weights_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
   util.return %result : !out_tensor_type
 }
 

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -107,7 +107,7 @@ def qconv2d_tensor_scaled_integer(
         # to the output NCHW shape.
         rescale_d = (flat_input_d * flat_weight_d).reshape(1, -1, 1, 1)
 
-    # TODO: Use a real mixed precision op.
+    # Perform the actual convolution.
     stride = _expand_int_to_2_tuple(stride)
     padding = _expand_int_to_2_tuple(padding)
     dilation = _expand_int_to_2_tuple(dilation)

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -12,6 +12,7 @@ from typing import Optional
 import warnings
 
 import torch
+from torch import Tensor
 
 from ..types import (
     QuantizedTensor,
@@ -161,3 +162,20 @@ linear.override(QuantizedTensor, QuantizedTensor)(qlinear_tensor_scaled_integer)
 linear.override(QuantizedTensor, QuantizedTensor, AnyTensor)(
     qlinear_tensor_scaled_integer
 )
+
+
+def linear_quantized_weight(
+    x: Tensor,
+    weight: QuantizedTensor,
+    bias: Optional[AnyTensor],
+    *,
+    accum_dtype: Optional[torch.dtype],
+) -> AnyTensor:
+    res = matmul(x, weight, transpose_rhs=True)
+    if bias is not None:
+        res = res + bias
+    return res
+
+
+linear.override(Tensor, QuantizedTensor)(linear_quantized_weight)
+linear.override(Tensor, QuantizedTensor, AnyTensor)(linear_quantized_weight)

--- a/sharktank/sharktank/utils/debugging.py
+++ b/sharktank/sharktank/utils/debugging.py
@@ -32,6 +32,10 @@ class DebugFlags:
     save_goldens_path: Optional[Path] = None
     golden_sequence_value: int = 0
 
+    # Feature flags.
+    use_custom_int_conv_kernel: bool = True
+    use_custom_int_mm_kernel: bool = True
+
     def set(self, part: str):
         m = re.match(SETTING_PART_PATTERN, part)
         if not m:
@@ -47,6 +51,10 @@ class DebugFlags:
             self.enable_nan_checks = logical_sense
         elif name == "save_goldens_path":
             self.save_goldens_path = Path(value)
+        elif name == "use_custom_int_conv_kernel":
+            self.use_custom_int_conv_kernel = logical_sense
+        elif name == "use_custom_int_mm_kernel":
+            self.use_custom_int_mm_kernel = logical_sense
         else:
             logger.warn("Unrecognized %s flag: '%s'", FLAGS_ENV_NAME, name)
 

--- a/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
+++ b/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from shark_turbine import aot
+from sharktank import kernels
+
+
+class batch_matmul_transpose_b_test(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    @parameterized.expand(
+        [
+            (1e-3, 1e-5),
+            (1e-3, 1e-5),
+            (1e-3, 1e-5),
+        ]
+    )
+    def testBS32(self, atol, rtol):
+        dtype = torch.int32
+        a = (torch.rand([4, 16, 3200]) * 64).to(dtype)
+        b = (torch.rand([4, 8, 3200]) * 64).to(dtype)
+        result = kernels.batch_matmul_transpose_b(a, b)
+
+        # Dequantize and test with normal matmul.
+        # Tolerances are empirical and results are not expected to match exactly.
+        bT = torch.transpose(b, 1, 2)
+        ref = torch.matmul(a, bT)
+        torch.testing.assert_close(result, ref, atol=atol, rtol=rtol)
+
+    def testExportStaticDims(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, a, b):
+                return kernels.batch_matmul_transpose_b(a, b)
+
+        mod = MyModule()
+        dtype = torch.int32
+        ep = torch.export.export(
+            mod,
+            args=(
+                (torch.rand([4, 16, 2]) * 64).to(dtype),
+                (torch.rand([4, 8, 2]) * 64).to(dtype),
+            ),
+        )
+        output = aot.export(ep)
+        output.verify()
+        asm = str(output.mlir_module)
+        self.assertIn("@sharktank_batch_matmul_transpose_b_16_8_2_i32", asm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
+++ b/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
@@ -57,7 +57,7 @@ class batch_matmul_transpose_b_test(unittest.TestCase):
         output = aot.export(ep)
         output.verify()
         asm = str(output.mlir_module)
-        self.assertIn("@sharktank_batch_matmul_transpose_b_16_8_2_i32", asm)
+        self.assertIn("@sharktank_batch_matmul_transpose_b_8_2_i32", asm)
 
 
 if __name__ == "__main__":

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from shark_turbine import aot
+from sharktank import kernels
+
+
+class conv_2d_nchw_fchw_test(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    @parameterized.expand(
+        [
+            (1e-3, 1e-5),
+            # (1e-3, 1e-5),
+            # (1e-3, 1e-5),
+        ]
+    )
+    def testBS32(self, atol, rtol):
+        dtype = torch.int8
+        # inputs = (torch.rand([4,6,8,10]) * 64).to(dtype)
+        # weights = (torch.rand([6,6,1,1]) * 64).to(dtype)
+        # bias = (torch.rand([6]) * 64).to(dtype)
+        # inputs = (torch.rand([2, 4, 128, 128]) * 64).to(dtype)
+        # weights = (torch.rand([320, 4, 3, 3]) * 64).to(dtype)
+        # bias = (torch.rand([320]) * 64).to(dtype)
+        inputs = (torch.rand([2, 320, 64, 64]) * 64).to(dtype)
+        extended_padding = [1, 1, 1, 1]
+        inputs_pad = torch.nn.functional.pad(inputs, extended_padding)
+        weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
+        bias = (torch.rand([640]) * 64).to(dtype)
+        result = kernels.conv_2d_nchw_fchw(
+            inputs, inputs_pad, weights, bias, [1, 1], [1, 1], [1, 1]
+        )
+
+        # Tolerances are empirical and results are not expected to match exactly.
+        ref = torch.nn.functional.conv2d(
+            inputs, weights, bias=bias, stride=(1, 1), padding=(1, 1), dilation=(1, 1)
+        )
+        print(result.shape)
+        print(ref.shape)
+        torch.testing.assert_close(result, ref, atol=atol, rtol=rtol)
+
+    def testExportStaticDims(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                return kernels.conv_2d_nchw_fchw(a, b, c, d, [1, 1], [1, 1], [1, 1])
+
+        mod = MyModule()
+        dtype = torch.int8
+        inputs = torch.rand([2, 320, 64, 64]) * 64
+        extended_padding = [1, 1, 1, 1]
+        inputs_pad = torch.nn.functional.pad(inputs, extended_padding)
+        ep = torch.export.export(
+            mod,
+            args=(
+                (inputs).to(dtype),
+                (inputs_pad).to(dtype),
+                (torch.rand([640, 320, 3, 3]) * 64).to(dtype),
+                (torch.rand([640]) * 64).to(dtype),
+            ),
+        )
+        output = aot.export(ep)
+        output.verify()
+        asm = str(output.mlir_module)
+        self.assertIn("@sharktank_conv_2d_nchw_fchw", asm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -24,25 +24,17 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
     @parameterized.expand(
         [
             (1e-3, 1e-5),
-            # (1e-3, 1e-5),
-            # (1e-3, 1e-5),
+            (1e-3, 1e-5),
+            (1e-3, 1e-5),
         ]
     )
     def testBS32(self, atol, rtol):
         dtype = torch.int8
-        # inputs = (torch.rand([4,6,8,10]) * 64).to(dtype)
-        # weights = (torch.rand([6,6,1,1]) * 64).to(dtype)
-        # bias = (torch.rand([6]) * 64).to(dtype)
-        # inputs = (torch.rand([2, 4, 128, 128]) * 64).to(dtype)
-        # weights = (torch.rand([320, 4, 3, 3]) * 64).to(dtype)
-        # bias = (torch.rand([320]) * 64).to(dtype)
         inputs = (torch.rand([2, 320, 64, 64]) * 64).to(dtype)
-        extended_padding = [1, 1, 1, 1]
-        inputs_pad = torch.nn.functional.pad(inputs, extended_padding)
         weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
         bias = (torch.rand([640]) * 64).to(dtype)
         result = kernels.conv_2d_nchw_fchw(
-            inputs, inputs_pad, weights, bias, [1, 1], [1, 1], [1, 1]
+            inputs, weights, bias, [1, 1], [1, 1], [1, 1]
         )
 
         # Tolerances are empirical and results are not expected to match exactly.
@@ -55,19 +47,15 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
 
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
-            def forward(self, a, b, c, d):
-                return kernels.conv_2d_nchw_fchw(a, b, c, d, [1, 1], [1, 1], [1, 1])
+            def forward(self, a, b, c):
+                return kernels.conv_2d_nchw_fchw(a, b, c, [1, 1], [1, 1], [1, 1])
 
         mod = MyModule()
         dtype = torch.int8
-        inputs = torch.rand([2, 320, 64, 64]) * 64
-        extended_padding = [1, 1, 1, 1]
-        inputs_pad = torch.nn.functional.pad(inputs, extended_padding)
         ep = torch.export.export(
             mod,
             args=(
-                (inputs).to(dtype),
-                (inputs_pad).to(dtype),
+                (torch.rand([2, 320, 64, 64]) * 64).to(dtype),
                 (torch.rand([640, 320, 3, 3]) * 64).to(dtype),
                 (torch.rand([640]) * 64).to(dtype),
             ),

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -17,6 +17,25 @@ from shark_turbine import aot
 from sharktank import kernels
 
 
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from shark_turbine import aot
+from sharktank import kernels
+
+
 class pooling_nchw_sum_test(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)
@@ -30,7 +49,6 @@ class pooling_nchw_sum_test(unittest.TestCase):
     )
     def testBS32(self, atol, rtol):
         dtype = torch.int32
-        # a = (torch.rand([2,1,128,128]) * 64)#.to(dtype)
         a = (torch.randint(0, 100, (2, 1, 128, 128))).to(torch.float32)
         weight_shape = [3, 3]
         stride = [1, 1]

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -17,25 +17,6 @@ from shark_turbine import aot
 from sharktank import kernels
 
 
-# Copyright 2024 Advanced Micro Devices, Inc
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-import logging
-
-logging.basicConfig(level=logging.DEBUG)
-
-import unittest
-from parameterized import parameterized
-
-import torch
-
-from shark_turbine import aot
-from sharktank import kernels
-
-
 class pooling_nchw_sum_test(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -1,0 +1,72 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from shark_turbine import aot
+from sharktank import kernels
+
+
+class pooling_nchw_sum_test(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    @parameterized.expand(
+        [
+            (1e-3, 1e-5),
+            (1e-3, 1e-5),
+            (1e-3, 1e-5),
+        ]
+    )
+    def testBS32(self, atol, rtol):
+        dtype = torch.int32
+        # a = (torch.rand([2,1,128,128]) * 64)#.to(dtype)
+        a = (torch.randint(0, 100, (2, 1, 128, 128))).to(torch.float32)
+        weight_shape = [3, 3]
+        stride = [1, 1]
+        padding = [1, 1]
+        dilations = [1, 1]
+        result = kernels.pooling_nchw_sum(
+            a.to(dtype), weight_shape, stride, padding, dilations
+        )
+
+        # Tolerances are empirical and results are not expected to match exactly.
+        ref = torch.nn.functional.avg_pool2d(
+            a,
+            weight_shape,
+            stride=stride,
+            padding=padding,
+            divisor_override=1,
+        ).to(dtype)
+        torch.testing.assert_close(result, ref, atol=atol, rtol=rtol)
+
+    def testExportStaticDims(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, a):
+                return kernels.pooling_nchw_sum(a, [3, 3], [1, 1], [1, 1], [1, 1])
+
+        mod = MyModule()
+        dtype = torch.int32
+        ep = torch.export.export(
+            mod,
+            args=((torch.rand([2, 1, 128, 128]) * 64).to(dtype),),
+        )
+        output = aot.export(ep)
+        output.verify()
+        asm = str(output.mlir_module)
+        print(asm)
+        self.assertIn("@sharktank_pooling_nchw_sum", asm)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Our quantization scheme relies on having integer kernels for a few key ops. While torch mm/conv ops are technically defined for integer operands, in practice, the type matrix is very sparsely implemented across backends. As such, we just define IREE specific ops for these and use them.

Unlike mm/conv, torch does not have a good pooling sum operator, instead using avg_pool with a denominator override (only defined for FP). Therefore, we provide that too.