### PR TITLE
Guard the testing facility used to verify last op dispatch.

### DIFF
--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -32,7 +32,25 @@ _TargetOverride = collections.namedtuple(
 
 
 # When an op is dispatched, it will be stashed here for testing to verify.
+# Use _test_enable_last_op_dispatch(True) / _test_enable_last_op_dispatch(False)
+# in test cases to enable/disable tracking of the last op dispatched.
+# The last op can be queried with _test_get_last_op_dispatch().
+_ENABLE_TEST_LAST_OP_DISPATCH = False
 _TEST_LAST_OP_DISPATCH = None
+
+
+def _test_enable_last_op_dispatch(en: bool = True):
+    global _TEST_LAST_OP_DISPATCH
+    global _ENABLE_TEST_LAST_OP_DISPATCH
+    _TEST_LAST_OP_DISPATCH = None
+    _ENABLE_TEST_LAST_OP_DISPATCH = en
+
+
+def _test_get_last_op_dispatch():
+    assert (
+        _ENABLE_TEST_LAST_OP_DISPATCH
+    ), "Cannot get last op dispatched without calling _test_enable_last_op_dispatch()"
+    return _TEST_LAST_OP_DISPATCH
 
 
 class SignatureDispatcher:
@@ -61,8 +79,9 @@ class SignatureDispatcher:
         trampoline = self._trampoline
         assert trampoline is not None
         selected_override, *results = trampoline(self, *args, **kwargs)
-        global _TEST_LAST_OP_DISPATCH
-        _TEST_LAST_OP_DISPATCH = selected_override
+        if _ENABLE_TEST_LAST_OP_DISPATCH:
+            global _TEST_LAST_OP_DISPATCH
+            _TEST_LAST_OP_DISPATCH = selected_override
         arity = len(results)
         if arity == 1:
             return results[0]

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -12,6 +12,8 @@ import torch.nn.functional as F
 from sharktank import ops
 from sharktank.types import *
 
+ops._registry._ENABLE_TEST_LAST_OP_DISPATCH = True
+
 
 class EqualTest(unittest.TestCase):
     def testEqualTorchTensors(self):
@@ -70,6 +72,9 @@ class EmbeddingLookupTest(unittest.TestCase):
 
 
 class MatmulTest(unittest.TestCase):
+    def tearDown(self):
+        ops._registry._test_enable_last_op_dispatch(False)
+
     def testMatchFail(self):
         # This is just using matmul as a victim to test that failure/exceptions
         # are properly raised when no override is found.
@@ -81,30 +86,33 @@ class MatmulTest(unittest.TestCase):
 
     @unittest.skip("https://github.com/nod-ai/sharktank/issues/44")
     def testTorchImplTransposedRHS(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
         result = ops.matmul(t1, t2.T)
         expected = torch.matmul(t1, t2.T.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.custom_impls.matmul_mmtfp_tensor_tensor,
         )
 
     @unittest.skip("https://github.com/nod-ai/sharktank/issues/44")
     def testTorchImplNonTransposedRHS(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(16, 48, dtype=torch.float16)
         result = ops.matmul(t1, t2)
         expected = torch.matmul(t1, t2.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIsNot(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.custom_impls.matmul_mmtfp_tensor_tensor,
         )
 
     @unittest.skip("https://github.com/nod-ai/sharktank/issues/44")
     def testTorchImplTransposedPrimitiveRHS(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         t1 = torch.rand(32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
         t2_pt = DefaultPrimitiveTensor(data=t2)
@@ -112,11 +120,12 @@ class MatmulTest(unittest.TestCase):
         expected = torch.matmul(t1, t2.T.to(torch.float32))
         torch.testing.assert_close(result, expected)
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.custom_impls.matmul_mmtfp_tensor_tensor,
         )
 
     def testTorchImplTransposedQuantizedRHS_BlockScaledLayout(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         a_dtype = torch.float32
         d_dtype = torch.float32
         ref_dtype = torch.float32
@@ -129,11 +138,12 @@ class MatmulTest(unittest.TestCase):
         result = ops.matmul(a, rhs_pqt, transpose_rhs=True)
         # Just verifying dispatch. Numerics are tested at the kernel level.
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.custom_impls.matmul_generic_tensor_block_scaled,
         )
 
     def testTorchImplTransposedQuantizedRHS_BlockScaledOffsetI4(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         a_dtype = torch.float32
         d_dtype = torch.float32
         ref_dtype = torch.float32
@@ -148,7 +158,7 @@ class MatmulTest(unittest.TestCase):
         result = ops.matmul(a, rhs_pqt, transpose_rhs=True)
         # Just verifying dispatch. Numerics are tested at the kernel level.
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.custom_impls.matmul_generic_tensor_block_scaled_i4,
         )
 

--- a/sharktank/tests/ops/qconv_test.py
+++ b/sharktank/tests/ops/qconv_test.py
@@ -42,7 +42,11 @@ class QConvTest(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(12345)
 
+    def tearDown(self):
+        ops._registry._test_enable_last_op_dispatch(False)
+
     def testInputSymPerTensor_WeightAsymPerChannel_NoBias(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         input = _randomize_per_axis(
             torch.rand(4, 8, 16, 16, dtype=torch.float32), axis=1
         )
@@ -66,7 +70,7 @@ class QConvTest(unittest.TestCase):
             .dequant()
         )
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.qconv_impls.qconv2d_tensor_scaled_integer,
         )
         y_ref = torch.nn.functional.conv2d(
@@ -79,6 +83,7 @@ class QConvTest(unittest.TestCase):
         torch.testing.assert_close(y_actual, y_ref)
 
     def testInputSymPerTensor_WeightAsymPerChannel_FloatBias(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         input = _randomize_per_axis(
             torch.rand(4, 8, 16, 16, dtype=torch.float32), axis=1
         )
@@ -99,7 +104,7 @@ class QConvTest(unittest.TestCase):
 
         y_actual = ops.conv2d(input_q, weight_q, bias, stride=1, padding=(1, 1))
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.qconv_impls.qconv2d_tensor_scaled_integer,
         )
         y_ref = torch.nn.functional.conv2d(
@@ -112,6 +117,7 @@ class QConvTest(unittest.TestCase):
         torch.testing.assert_close(y_actual, y_ref)
 
     def testInputSymPerTensor_WeightAsymPerChannel_QuantizedBias(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         input = _randomize_per_axis(
             torch.rand(4, 8, 16, 16, dtype=torch.float32), axis=1
         )
@@ -140,7 +146,7 @@ class QConvTest(unittest.TestCase):
             .dequant()
         )
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.qconv_impls.qconv2d_tensor_scaled_integer,
         )
         y_ref = torch.nn.functional.conv2d(
@@ -153,6 +159,7 @@ class QConvTest(unittest.TestCase):
         torch.testing.assert_close(y_actual, y_ref)
 
     def testInputSymPerTensor_WeightSymPerTensor_NoBias(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         input = _randomize_per_axis(
             torch.rand(4, 8, 16, 16, dtype=torch.float32), axis=1
         )
@@ -176,7 +183,7 @@ class QConvTest(unittest.TestCase):
             .dequant()
         )
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.qconv_impls.qconv2d_tensor_scaled_integer,
         )
         y_ref = torch.nn.functional.conv2d(
@@ -190,6 +197,7 @@ class QConvTest(unittest.TestCase):
 
     @unittest.skip("Bug in joint offset application #55")
     def testInputAsymPerChannel_WeightAsymPerChannel_NoBias(self):
+        ops._registry._test_enable_last_op_dispatch(True)
         input = _randomize_per_axis(
             torch.rand(4, 8, 16, 16, dtype=torch.float32), axis=1, offset_range=-0.2
         )
@@ -215,7 +223,7 @@ class QConvTest(unittest.TestCase):
             .dequant()
         )
         self.assertIs(
-            ops._registry._TEST_LAST_OP_DISPATCH,
+            ops._registry._test_get_last_op_dispatch(),
             ops.qconv_impls.qconv2d_tensor_scaled_integer,
         )
         y_ref = torch.nn.functional.conv2d(


### PR DESCRIPTION
Only enables it when needed.
This trips up Dynamo to have multiple things mutating this global.