### PR TITLE
Insert padding for conv and pooling ops before bit-width extend operations of operands

### DIFF
--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -61,8 +61,15 @@ class conv_2d_nchw_fchw(CustomOp):
         )
 
         # subtract padding shape
-        h_out = h_pad - padding[0] - padding[0]
-        w_out = w_pad - padding[1] - padding[1]
+        original_h = h_pad - padding[0] * 2
+        original_w = w_pad - padding[1] * 2
+        # convolution shape math
+        h_out = math.floor(
+            (original_h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1
+        )
+        w_out = math.floor(
+            (original_w + 2 * padding[1] - dilations[1] * (k1 - 1) - 1) / strides[1] + 1
+        )
         c_desc = ksel.return_new_tensor(
             [n, f, h_out, w_out], dtype=inputs_pad_desc.t.dtype
         )
@@ -74,14 +81,14 @@ class conv_2d_nchw_fchw(CustomOp):
         padding = ksel.arg_descs[4].v
         dilations = ksel.arg_descs[5].v
         result_desc = ksel.result_descs[0].t.shape
-        H_input_pad = result_desc[2] + padding[0] * 2
-        W_input_pad = result_desc[3] + padding[1] * 2
+        H_out = result_desc[2]
+        W_out = result_desc[3]
 
         strides = [str(i) for i in strides]
         padding = [str(i) for i in padding]
         dilations = [str(i) for i in dilations]
-        H_input_pad = str(H_input_pad)
-        W_input_pad = str(W_input_pad)
+        H_out = str(H_out)
+        W_out = str(W_out)
 
         dtype_str = str(inputs_pad_tensor_type.element_type)
 
@@ -92,8 +99,8 @@ class conv_2d_nchw_fchw(CustomOp):
             kb,
             template_file,
             target_function_name,
-            H_input_pad=H_input_pad,
-            W_input_pad=W_input_pad,
+            H_out=H_out,
+            W_out=W_out,
             strides_H=strides[0],
             strides_W=strides[1],
             padding_H=padding[0],

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -23,15 +23,16 @@ class conv_2d_nchw_fchw(CustomOp):
     Will be specialized for all values of strides, padding, dilations, and LHS dtype.
     """
 
-    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor inputs_pad, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
-        weights_desc = ksel.arg_tensor(1)
-        bias_desc = ksel.arg_tensor(2)
-        strides_desc = ksel.attr_list_int(3)  # Shape [2]
-        padding_desc = ksel.attr_list_int(4)  # Shape [2]
-        dilations_desc = ksel.attr_list_int(5)  # Shape [2]
+        inputs_pad_desc = ksel.arg_tensor(1)
+        weights_desc = ksel.arg_tensor(2)
+        bias_desc = ksel.arg_tensor(3)
+        strides_desc = ksel.attr_list_int(4)  # Shape [2]
+        padding_desc = ksel.attr_list_int(5)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(6)  # Shape [2]
 
         # unpack
         n, c, h, w = inputs_desc.t.shape
@@ -73,9 +74,11 @@ class conv_2d_nchw_fchw(CustomOp):
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         inputs = kb.arg_value(0)
         inputs_tensor_type = RankedTensorType(inputs.type)
-        strides = ksel.arg_descs[3].v
-        padding = ksel.arg_descs[4].v
-        dilations = ksel.arg_descs[5].v
+        inputs_pad = kb.arg_value(1)
+        inputs_pad_tensor_type = RankedTensorType(inputs_pad.type)
+        strides = ksel.arg_descs[4].v
+        padding = ksel.arg_descs[5].v
+        dilations = ksel.arg_descs[6].v
 
         strides = [str(i) for i in strides]
         padding = [str(i) for i in padding]

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -23,15 +23,14 @@ class conv_2d_nchw_fchw(CustomOp):
     Will be specialized for all values of strides, padding, dilations, and LHS dtype.
     """
 
-    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] dilations) -> (Tensor)"
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
         weights_desc = ksel.arg_tensor(1)
         bias_desc = ksel.arg_tensor(2)
         strides_desc = ksel.attr_list_int(3)  # Shape [2]
-        padding_desc = ksel.attr_list_int(4)  # Shape [2]
-        dilations_desc = ksel.attr_list_int(5)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(4)  # Shape [2]
 
         # unpack
         n, c, h_pad, w_pad = inputs_desc.t.shape
@@ -40,7 +39,6 @@ class conv_2d_nchw_fchw(CustomOp):
 
         strides = strides_desc.v
         dilations = dilations_desc.v
-        padding = padding_desc.v
 
         # check
         torch._check(
@@ -55,28 +53,17 @@ class conv_2d_nchw_fchw(CustomOp):
             len(dilations) == 2,
             lambda: f"conv_2d_nchw_fchw requires exactly 2 dilations; dilations: {dilations}",
         )
-        torch._check(
-            len(padding) == 2,
-            lambda: f"conv_2d_nchw_fchw requires exactly 2 padding; padding: {padding}",
-        )
 
-        # subtract padding shape
-        original_h = h_pad - padding[0] * 2
-        original_w = w_pad - padding[1] * 2
         # convolution shape math
-        h_out = math.floor(
-            (original_h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1
-        )
-        w_out = math.floor(
-            (original_w + 2 * padding[1] - dilations[1] * (k1 - 1) - 1) / strides[1] + 1
-        )
+        h_out = math.floor((h_pad - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
+        w_out = math.floor((w_pad - dilations[1] * (k1 - 1) - 1) / strides[1] + 1)
         c_desc = ksel.return_new_tensor([n, f, h_out, w_out], dtype=inputs_desc.t.dtype)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         inputs = kb.arg_value(0)
         inputs_tensor_type = RankedTensorType(inputs.type)
         strides = ksel.arg_descs[3].v
-        dilations = ksel.arg_descs[5].v
+        dilations = ksel.arg_descs[4].v
         result_desc = ksel.result_descs[0].t.shape
         H_out = result_desc[2]
         W_out = result_desc[3]

--- a/sharktank/sharktank/kernels/pooling_nchw_sum.py
+++ b/sharktank/sharktank/kernels/pooling_nchw_sum.py
@@ -19,14 +19,15 @@ __all__ = [
 class pooling_nchw_sum(CustomOp):
     """Generic pooling sum."""
 
-    signature = "pooling_nchw_sum(Tensor a, int[] weights_size, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
+    signature = "pooling_nchw_sum(Tensor a, Tensor b, int[] weights_size, int[] strides, int[] padding, int[] dilations) -> (Tensor)"
 
     def select(self, ksel: KernelSelection):
         input_desc = ksel.arg_tensor(0)  # Shape [b, ] m, k
-        weights_size_desc = ksel.attr_list_int(1)  # Shape [2]
-        strides_desc = ksel.attr_list_int(2)  # Shape [2]
-        padding_desc = ksel.attr_list_int(3)  # Shape [2]
-        dilations_desc = ksel.attr_list_int(4)  # Shape [2]
+        inputs_pad_desc = ksel.arg_tensor(1)
+        weights_size_desc = ksel.attr_list_int(2)  # Shape [2]
+        strides_desc = ksel.attr_list_int(3)  # Shape [2]
+        padding_desc = ksel.attr_list_int(4)  # Shape [2]
+        dilations_desc = ksel.attr_list_int(5)  # Shape [2]
 
         # unpack
         n, c, h, w = input_desc.t.shape
@@ -45,10 +46,12 @@ class pooling_nchw_sum(CustomOp):
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         input = kb.arg_value(0)
         input_tensor_type = RankedTensorType(input.type)
-        weights = ksel.arg_descs[1].v
-        strides = ksel.arg_descs[2].v
-        padding = ksel.arg_descs[3].v
-        dilations = ksel.arg_descs[4].v
+        inputs_pad = kb.arg_value(1)
+        inputs_pad_tensor_type = RankedTensorType(inputs_pad.type)
+        weights = ksel.arg_descs[2].v
+        strides = ksel.arg_descs[3].v
+        padding = ksel.arg_descs[4].v
+        dilations = ksel.arg_descs[5].v
 
         weights = [str(i) for i in weights]
         strides = [str(i) for i in strides]

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -14,7 +14,7 @@
 module {
 
 util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
+    %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %c0 = arith.constant 0: index
@@ -22,49 +22,27 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{pad
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  // Convolution size math, equivalent to:
-  // h_out = math.floor((h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
-  // w_out = math.floor((w + 2 * padding[1] - dilations[1] * (k1 - 1) - 1) / strides[1] + 1)
-  %iH = tensor.dim %input, %c2 : !dynamic_tensor_type
-  %kH = tensor.dim %weights, %c2 : !dynamic_tensor_type
-  %sH = arith.constant {{strides_H}} : index
-  %dH = arith.constant {{dilations_H}} : index
+  // remove padding from input_pad
   %pH = arith.constant {{padding_H}} : index
+  %H_input_pad = arith.constant {{H_input_pad}} : index
+  %pH_0 = arith.muli %pH, %c2 : index
+  %rH = arith.subi %H_input_pad, %pH_0 : index
 
-  %rH_0 = arith.subi %kH, %c1 : index
-  %rH_1 = arith.muli %dH, %rH_0 : index
-  %rH_2 = arith.muli %pH, %c2 : index
-  %rH_3 = arith.addi %iH, %rH_2 : index
-  %rH_4 = arith.subi %rH_3, %rH_1 : index
-  %rH_5 = arith.subi %rH_4, %c1 : index
-  %rH_6 = arith.addi %rH_5, %sH : index
-  %rH   = arith.divsi %rH_6, %sH : index
-
-  %iW = tensor.dim %input, %c3 : !dynamic_tensor_type
-  %kW = tensor.dim %weights, %c3 : !dynamic_tensor_type
-  %sW = arith.constant {{strides_W}} : index
-  %dW = arith.constant {{dilations_W}} : index
   %pW = arith.constant {{padding_W}} : index
+  %W_input_pad = arith.constant {{W_input_pad}} : index
+  %pW_0 = arith.muli %pW, %c2 : index
+  %rW = arith.subi %W_input_pad, %pW_0 : index
 
-  %rW_0 = arith.subi %kW, %c1 : index
-  %rW_1 = arith.muli %dW, %rW_0 : index
-  %rW_2 = arith.muli %pW, %c2 : index
-  %rW_3 = arith.addi %iW, %rW_2 : index
-  %rW_4 = arith.subi %rW_3, %rW_1 : index
-  %rW_5 = arith.subi %rW_4, %c1 : index
-  %rW_6 = arith.addi %rW_5, %sW : index
-  %rW   = arith.divsi %rW_6, %sW : index
-
-  %rN = tensor.dim %input, %c0 : !dynamic_tensor_type
+  %rN = tensor.dim %input_pad, %c0 : !dynamic_tensor_type
   %rC = tensor.dim %weights, %c0 : !dynamic_tensor_type
   %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
   %result = linalg.conv_2d_nchw_fchw {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !dynamic_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
-  %result_biased = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%result, %bias : !dynamic_tensor_type, tensor<?x!dtype>) outs(%result : !dynamic_tensor_type) {
+  %result_biased = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%result, %bias : !dynamic_tensor_type, tensor<?x!dtype>) outs(%result : !out_tensor_type) {
     ^bb0(%in: !dtype, %in_1: !dtype, %out: !dtype):
       %add = arith.addi %in, %in_1 : !dtype
       linalg.yield %add : !dtype
-    } -> !dynamic_tensor_type
+    } -> !out_tensor_type
   util.return %result_biased : !out_tensor_type
 }
 

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -13,7 +13,7 @@
 
 module {
 
-util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
+util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
     %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -14,19 +14,13 @@
 module {
 
 util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
+    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
-
-  %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
-  ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
-    tensor.yield %zero : !dtype
-  } : !dynamic_tensor_type to !dynamic_tensor_type
-
 
   // Convolution size math, equivalent to:
   // h_out = math.floor((h + 2 * padding[0] - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
@@ -60,7 +54,6 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{pad
   %rW_5 = arith.subi %rW_4, %c1 : index
   %rW_6 = arith.addi %rW_5, %sW : index
   %rW   = arith.divsi %rW_6, %sW : index
-
 
   %rN = tensor.dim %input, %c0 : !dynamic_tensor_type
   %rC = tensor.dim %weights, %c0 : !dynamic_tensor_type

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -22,19 +22,10 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{pad
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  // remove padding from input_pad
-  %pH = arith.constant {{padding_H}} : index
-  %H_input_pad = arith.constant {{H_input_pad}} : index
-  %pH_0 = arith.muli %pH, %c2 : index
-  %rH = arith.subi %H_input_pad, %pH_0 : index
-
-  %pW = arith.constant {{padding_W}} : index
-  %W_input_pad = arith.constant {{W_input_pad}} : index
-  %pW_0 = arith.muli %pW, %c2 : index
-  %rW = arith.subi %W_input_pad, %pW_0 : index
-
   %rN = tensor.dim %input_pad, %c0 : !dynamic_tensor_type
   %rC = tensor.dim %weights, %c0 : !dynamic_tensor_type
+  %rH = arith.constant {{H_out}} : index
+  %rW = arith.constant {{W_out}} : index
   %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
   %result = linalg.conv_2d_nchw_fchw {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !dynamic_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -12,7 +12,7 @@
 module {
 
 util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type)
+    %input_pad: !dynamic_tensor_type)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %weights = tensor.empty() : !weights_tensor_type
@@ -21,35 +21,10 @@ util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{stri
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  // Pooling size math, equivalent to:
-  // h_out = math.floor((h + 2 * padding[0] - weights_size[0]) / strides[0] + 1)
-  %iH = tensor.dim %input, %c2 : !dynamic_tensor_type
-  %kH = arith.constant {{weights_H}} : index // weights_size[0]
-  %sH = arith.constant {{strides_H}} : index // strides[0]
-  %dH = arith.constant {{dilations_H}} : index
-  %pH = arith.constant {{padding_H}} : index // padding[0]
-
-  %rH_0 = arith.muli %pH, %c2 : index
-  %rH_1 = arith.addi %iH, %rH_0 : index
-  %rH_2 = arith.subi %rH_1, %kH : index
-  %rH_3 = arith.addi %rH_2, %sH : index
-  %rH   = arith.divsi %rH_3, %sH : index
-
-  // w_out = math.floor((w + 2 * padding[1] - weights_size[1]) / strides[1] + 1)
-  %iW = tensor.dim %input, %c3 : !dynamic_tensor_type
-  %kW = arith.constant {{weights_H}} : index // weights_size[1]
-  %sW = arith.constant {{strides_W}} : index // strides[1]
-  %dW = arith.constant {{dilations_W}} : index
-  %pW = arith.constant {{padding_W}} : index // padding[1]
-
-  %rW_0 = arith.muli %pW, %c2 : index
-  %rW_1 = arith.addi %iW, %rW_0 : index
-  %rW_2 = arith.subi %rW_1, %kW : index
-  %rW_3 = arith.addi %rW_2, %sW : index
-  %rW   = arith.divsi %rW_3, %sW : index
-
-  %rN = tensor.dim %input, %c0 : !dynamic_tensor_type
-  %rC = tensor.dim %input, %c1 : !dynamic_tensor_type
+  %rN = tensor.dim %input_pad, %c0 : !dynamic_tensor_type
+  %rC = tensor.dim %input_pad, %c1 : !dynamic_tensor_type
+  %rH = arith.constant {{H_out}} : index
+  %rW = arith.constant {{W_out}} : index
   %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
   %result = linalg.pooling_nchw_sum {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !weights_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -12,7 +12,7 @@
 module {
 
 util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input: !dynamic_tensor_type)
+    %input: !dynamic_tensor_type, %input_pad: !dynamic_tensor_type)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype
   %weights = tensor.empty() : !weights_tensor_type
@@ -20,11 +20,6 @@ util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{stri
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
-
-  %input_pad = tensor.pad %input low[0, 0, {{padding_H}}, {{padding_W}}] high[0, 0, {{padding_H}}, {{padding_W}}] {
-  ^bb0(%arg0 : index, %arg1 : index, %arg2: index, %arg3: index):
-    tensor.yield %zero : !dtype
-  } : !dynamic_tensor_type to !dynamic_tensor_type
 
   // Pooling size math, equivalent to:
   // h_out = math.floor((h + 2 * padding[0] - weights_size[0]) / strides[0] + 1)

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -11,7 +11,7 @@
 
 module {
 
-util.func private @sharktank_pooling_nchw_sum_{{weights_H}}_{{weights_W}}_{{strides_H}}_{{strides_W}}_{{padding_H}}_{{padding_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
+util.func private @sharktank_pooling_nchw_sum_{{strides_H}}_{{strides_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
     %input_pad: !dynamic_tensor_type)
     -> !out_tensor_type {
   %zero = arith.constant 0: !dtype

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -114,6 +114,7 @@ def qconv2d_tensor_scaled_integer(
     dilation = _expand_int_to_2_tuple(dilation)
     extended_list = [item for item in padding for _ in range(2)]
     padded_input = _pad_last_2d(input_qs, extended_list)
+    print("input_qs: ", input_qs.shape)
     y_qs = _invoke_int32_conv2d(
         input_qs.to(torch.int32),
         padded_input.to(torch.int32),
@@ -124,6 +125,7 @@ def qconv2d_tensor_scaled_integer(
         dilation,
         accum_dtype=accum_dtype,
     )
+    print("y_qs 1: ", y_qs.shape)
 
     # Apply offset corrections.
     if input_m is not None:
@@ -216,7 +218,6 @@ def _invoke_int32_conv2d(
             # may want to support an optional bias through the kernel.
             bias = torch.zeros((weight.shape[1],), dtype=input.dtype)
         y_qs = kernels.conv_2d_nchw_fchw(
-            input,
             padded_input,
             weight,
             bias,
@@ -246,7 +247,6 @@ def _invoke_int32_pooling_sum(
     """
     if debugging.flags.use_custom_int_conv_kernel:
         output = kernels.pooling_nchw_sum(
-            input,
             padded_input,
             kernel_size,
             stride,

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -143,12 +143,15 @@ def qconv2d_tensor_scaled_integer(
         # output channels are zero, just
         # Note that we sum first to reduce the dimensionality by channel
         # prior, reducing memory and total computation.
-        weight_offset_fix = torch.sum(input_qs, dim=1, keepdim=True, dtype=accum_dtype)
-        weight_offset_fix_padded = _pad_last_2d(
-            weight_offset_fix, extended_padding_list
+        # weight_offset_fix = torch.sum(input_qs, dim=1, keepdim=True, dtype=accum_dtype)
+        # weight_offset_fix_padded = _pad_last_2d(
+        #     weight_offset_fix, extended_padding_list
+        # )
+        weight_offset_fix = torch.sum(
+            padded_input, dim=1, keepdim=True, dtype=accum_dtype
         )
         weight_offset_fix = _invoke_int32_pooling_sum(
-            weight_offset_fix_padded,
+            weight_offset_fix,
             [weight_qs.shape[2], weight_qs.shape[3]],
             stride,
             padding,

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -114,7 +114,6 @@ def qconv2d_tensor_scaled_integer(
     dilation = _expand_int_to_2_tuple(dilation)
     extended_list = [item for item in padding for _ in range(2)]
     padded_input = _pad_last_2d(input_qs, extended_list)
-    print("input_qs: ", input_qs.shape)
     y_qs = _invoke_int32_conv2d(
         input_qs.to(torch.int32),
         padded_input.to(torch.int32),
@@ -125,7 +124,6 @@ def qconv2d_tensor_scaled_integer(
         dilation,
         accum_dtype=accum_dtype,
     )
-    print("y_qs 1: ", y_qs.shape)
 
     # Apply offset corrections.
     if input_m is not None:

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -119,7 +119,6 @@ def qconv2d_tensor_scaled_integer(
         weight_qs.to(torch.int32),
         bias_qs.to(torch.int32) if bias_qs is not None else None,
         stride,
-        padding,
         dilation,
         accum_dtype=accum_dtype,
     )
@@ -143,10 +142,6 @@ def qconv2d_tensor_scaled_integer(
         # output channels are zero, just
         # Note that we sum first to reduce the dimensionality by channel
         # prior, reducing memory and total computation.
-        # weight_offset_fix = torch.sum(input_qs, dim=1, keepdim=True, dtype=accum_dtype)
-        # weight_offset_fix_padded = _pad_last_2d(
-        #     weight_offset_fix, extended_padding_list
-        # )
         weight_offset_fix = torch.sum(
             padded_input, dim=1, keepdim=True, dtype=accum_dtype
         )
@@ -154,7 +149,6 @@ def qconv2d_tensor_scaled_integer(
             weight_offset_fix,
             [weight_qs.shape[2], weight_qs.shape[3]],
             stride,
-            padding,
             dilation,
             accum_dtype=accum_dtype,
         )
@@ -200,9 +194,7 @@ conv2d.override(QuantizedTensor, QuantizedTensor, AnyTensor)(
 )
 
 
-def _invoke_int32_conv2d(
-    input, weight, bias, stride, padding, dilation, *, accum_dtype
-):
+def _invoke_int32_conv2d(input, weight, bias, stride, dilation, *, accum_dtype):
     """Does a low level invocation of a conv2d integer kernel on an explicitly padded input.
 
     This presumes that the stride/padding/dilation have already been normalized
@@ -223,7 +215,6 @@ def _invoke_int32_conv2d(
             weight,
             bias,
             stride,
-            padding,
             dilation,
         )
     else:
@@ -239,9 +230,7 @@ def _invoke_int32_conv2d(
     return y_qs
 
 
-def _invoke_int32_pooling_sum(
-    input, kernel_size, stride, padding, dilation, *, accum_dtype
-):
+def _invoke_int32_pooling_sum(input, kernel_size, stride, dilation, *, accum_dtype):
     """Invokes either a custom integer pooling sum or the built-in fp avg_pool2d
     kernel on an explicitly padded input.
     """
@@ -250,7 +239,6 @@ def _invoke_int32_pooling_sum(
             input,
             kernel_size,
             stride,
-            padding,
             dilation,
         )
     else:

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -15,25 +15,7 @@ import torch
 
 from shark_turbine import aot
 from sharktank import kernels
-
-
-def _pad_last_2d(input_tensor, pad_width):
-    # pad_width should be in the format [pad_left, pad_right, pad_top, pad_bottom]
-    pad_left, pad_right, pad_top, pad_bottom = pad_width
-    batch_size, channels, height, width = input_tensor.shape
-
-    # Create a new tensor with the desired padded size filled with zeros
-    padded_height = height + pad_top + pad_bottom
-    padded_width = width + pad_left + pad_right
-    padded_tensor = torch.zeros(
-        (batch_size, channels, padded_height, padded_width), dtype=input_tensor.dtype
-    )
-
-    # Copy the values from the input tensor to the appropriate location in the padded tensor
-    padded_tensor[
-        :, :, pad_top : pad_top + height, pad_left : pad_left + width
-    ] = input_tensor
-    return padded_tensor
+from sharktank.ops.qconv_impls import _pad_last_2d
 
 
 class conv_2d_nchw_fchw_test(unittest.TestCase):

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -50,8 +50,8 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
     def testBS32(self, atol, rtol):
         dtype = torch.int8
         inputs = (torch.rand([2, 320, 64, 64]) * 64).to(dtype)
-        pad_width = [1, 1]
-        extended_list = [item for item in pad_width for _ in range(2)]
+        padding = [1, 1]
+        extended_list = [item for item in padding for _ in range(2)]
         inputs_pad = _pad_last_2d(inputs, extended_list)
         weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
         bias = (torch.rand([640]) * 64).to(dtype)
@@ -75,8 +75,8 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
         mod = MyModule()
         dtype = torch.int8
         inputs = torch.rand([2, 320, 64, 64]) * 64
-        pad_width = [1, 1]
-        extended_list = [item for item in pad_width for _ in range(2)]
+        padding = [1, 1]
+        extended_list = [item for item in padding for _ in range(2)]
         inputs_pad = _pad_last_2d(inputs, extended_list)
         ep = torch.export.export(
             mod,

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -38,7 +38,7 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
         weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
         bias = (torch.rand([640]) * 64).to(dtype)
         result = kernels.conv_2d_nchw_fchw(
-            inputs, inputs_pad, weights, bias, [1, 1], [1, 1], [1, 1]
+            inputs_pad, weights, bias, [1, 1], [1, 1], [1, 1]
         )
 
         # Tolerances are empirical and results are not expected to match exactly.
@@ -51,8 +51,8 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
 
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
-            def forward(self, a, b, c, d):
-                return kernels.conv_2d_nchw_fchw(a, b, c, d, [1, 1], [1, 1], [1, 1])
+            def forward(self, a, b, c):
+                return kernels.conv_2d_nchw_fchw(a, b, c, [1, 1], [1, 1], [1, 1])
 
         mod = MyModule()
         dtype = torch.int8
@@ -63,7 +63,6 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
         ep = torch.export.export(
             mod,
             args=(
-                (inputs).to(dtype),
                 (inputs_pad).to(dtype),
                 (torch.rand([640, 320, 3, 3]) * 64).to(dtype),
                 (torch.rand([640]) * 64).to(dtype),

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -37,9 +37,7 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
         inputs_pad = _pad_last_2d(inputs, extended_list)
         weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
         bias = (torch.rand([640]) * 64).to(dtype)
-        result = kernels.conv_2d_nchw_fchw(
-            inputs_pad, weights, bias, [1, 1], [1, 1], [1, 1]
-        )
+        result = kernels.conv_2d_nchw_fchw(inputs_pad, weights, bias, [1, 1], [1, 1])
 
         # Tolerances are empirical and results are not expected to match exactly.
         ref = torch.nn.functional.conv2d(
@@ -52,7 +50,7 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
             def forward(self, a, b, c):
-                return kernels.conv_2d_nchw_fchw(a, b, c, [1, 1], [1, 1], [1, 1])
+                return kernels.conv_2d_nchw_fchw(a, b, c, [1, 1], [1, 1])
 
         mod = MyModule()
         dtype = torch.int8

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -39,7 +39,7 @@ class pooling_nchw_sum_test(unittest.TestCase):
         stride = [1, 1]
         dilations = [1, 1]
         result = kernels.pooling_nchw_sum(
-            inputs_pad.to(dtype), weight_shape, stride, padding, dilations
+            inputs_pad.to(dtype), weight_shape, stride, dilations
         )
 
         # Tolerances are empirical and results are not expected to match exactly.
@@ -55,7 +55,7 @@ class pooling_nchw_sum_test(unittest.TestCase):
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
             def forward(self, a):
-                return kernels.pooling_nchw_sum(a, [3, 3], [1, 1], [1, 1], [1, 1])
+                return kernels.pooling_nchw_sum(a, [3, 3], [1, 1], [1, 1])
 
         mod = MyModule()
         dtype = torch.int8

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -39,7 +39,7 @@ class pooling_nchw_sum_test(unittest.TestCase):
         stride = [1, 1]
         dilations = [1, 1]
         result = kernels.pooling_nchw_sum(
-            a.to(dtype), inputs_pad.to(dtype), weight_shape, stride, padding, dilations
+            inputs_pad.to(dtype), weight_shape, stride, padding, dilations
         )
 
         # Tolerances are empirical and results are not expected to match exactly.
@@ -54,8 +54,8 @@ class pooling_nchw_sum_test(unittest.TestCase):
 
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
-            def forward(self, a, b):
-                return kernels.pooling_nchw_sum(a, b, [3, 3], [1, 1], [1, 1], [1, 1])
+            def forward(self, a):
+                return kernels.pooling_nchw_sum(a, [3, 3], [1, 1], [1, 1], [1, 1])
 
         mod = MyModule()
         dtype = torch.int8
@@ -65,10 +65,7 @@ class pooling_nchw_sum_test(unittest.TestCase):
         inputs_pad = _pad_last_2d(inputs, extended_list)
         ep = torch.export.export(
             mod,
-            args=(
-                (inputs).to(dtype),
-                (inputs_pad).to(dtype),
-            ),
+            args=((inputs_pad).to(dtype),),
         )
         output = aot.export(ep)
         output.verify()

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -17,6 +17,25 @@ from shark_turbine import aot
 from sharktank import kernels
 
 
+def _pad_last_2d(input_tensor, pad_width):
+    # pad_width should be in the format [pad_left, pad_right, pad_top, pad_bottom]
+    pad_left, pad_right, pad_top, pad_bottom = pad_width
+    batch_size, channels, height, width = input_tensor.shape
+
+    # Create a new tensor with the desired padded size filled with zeros
+    padded_height = height + pad_top + pad_bottom
+    padded_width = width + pad_left + pad_right
+    padded_tensor = torch.zeros(
+        (batch_size, channels, padded_height, padded_width), dtype=input_tensor.dtype
+    )
+
+    # Copy the values from the input tensor to the appropriate location in the padded tensor
+    padded_tensor[
+        :, :, pad_top : pad_top + height, pad_left : pad_left + width
+    ] = input_tensor
+    return padded_tensor
+
+
 class pooling_nchw_sum_test(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)
@@ -29,14 +48,16 @@ class pooling_nchw_sum_test(unittest.TestCase):
         ]
     )
     def testBS32(self, atol, rtol):
-        dtype = torch.int32
+        dtype = torch.int8
         a = (torch.randint(0, 100, (2, 1, 128, 128))).to(torch.float32)
+        padding = [1, 1]
+        extended_list = [item for item in padding for _ in range(2)]
+        inputs_pad = _pad_last_2d(a, extended_list)
         weight_shape = [3, 3]
         stride = [1, 1]
-        padding = [1, 1]
         dilations = [1, 1]
         result = kernels.pooling_nchw_sum(
-            a.to(dtype), weight_shape, stride, padding, dilations
+            a.to(dtype), inputs_pad.to(dtype), weight_shape, stride, padding, dilations
         )
 
         # Tolerances are empirical and results are not expected to match exactly.
@@ -51,14 +72,21 @@ class pooling_nchw_sum_test(unittest.TestCase):
 
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
-            def forward(self, a):
-                return kernels.pooling_nchw_sum(a, [3, 3], [1, 1], [1, 1], [1, 1])
+            def forward(self, a, b):
+                return kernels.pooling_nchw_sum(a, b, [3, 3], [1, 1], [1, 1], [1, 1])
 
         mod = MyModule()
-        dtype = torch.int32
+        dtype = torch.int8
+        inputs = torch.rand([2, 1, 128, 128]) * 64
+        padding = [1, 1]
+        extended_list = [item for item in padding for _ in range(2)]
+        inputs_pad = _pad_last_2d(inputs, extended_list)
         ep = torch.export.export(
             mod,
-            args=((torch.rand([2, 1, 128, 128]) * 64).to(dtype),),
+            args=(
+                (inputs).to(dtype),
+                (inputs_pad).to(dtype),
+            ),
         )
         output = aot.export(ep)
         output.verify()

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -15,25 +15,7 @@ import torch
 
 from shark_turbine import aot
 from sharktank import kernels
-
-
-def _pad_last_2d(input_tensor, pad_width):
-    # pad_width should be in the format [pad_left, pad_right, pad_top, pad_bottom]
-    pad_left, pad_right, pad_top, pad_bottom = pad_width
-    batch_size, channels, height, width = input_tensor.shape
-
-    # Create a new tensor with the desired padded size filled with zeros
-    padded_height = height + pad_top + pad_bottom
-    padded_width = width + pad_left + pad_right
-    padded_tensor = torch.zeros(
-        (batch_size, channels, padded_height, padded_width), dtype=input_tensor.dtype
-    )
-
-    # Copy the values from the input tensor to the appropriate location in the padded tensor
-    padded_tensor[
-        :, :, pad_top : pad_top + height, pad_left : pad_left + width
-    ] = input_tensor
-    return padded_tensor
+from sharktank.ops.qconv_impls import _pad_last_2d
 
 
 class pooling_nchw_sum_test(unittest.TestCase):


### PR DESCRIPTION
Moves the padding for conv and pooling kernels before extsi operations of operands.
Fixes https://github.com/nod-ai/SHARK-Turbine/issues/750