### PR TITLE
Add sharding of ResnetBlock2D

### DIFF
--- a/sharktank/sharktank/models/punet/sharding.py
+++ b/sharktank/sharktank/models/punet/sharding.py
@@ -1,0 +1,42 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Specifications describing how block/layers of punet are sharded."""
+
+from ...types.sharding import *
+
+
+class ResnetBlock2DSplitOutputChannelsSharding(ThetaLayerSharding):
+    """Shards the input channel and output channels of the convolutions."""
+
+    def __init__(self, shard_count: int):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+
+    def theta_sharding(self) -> ThetaSharding:
+        result = ThetaSharding(
+            {
+                "norm1": GroupNormSplitChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv1": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "norm2": GroupNormSplitChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv2": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "time_emb_proj": LinearReplicatedInputSplitWeightAndBiasSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv_shortcut": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+            }
+        )
+        return result

--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -18,6 +18,7 @@ and layouts.
 
 from . import _registry
 from .signatures import *
+from .shape import *
 
 # Ensure that implementations are registered.
 # Note that delegation prefers matching ops defined later, so order here

--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -14,16 +14,13 @@ import functools
 
 import torch
 from torch import Tensor
-from ..types import InferenceTensor, PrimitiveTensor, QuantizedTensor
+from ..types import PrimitiveTensor, QuantizedTensor
 
 __all__ = [
-    "AnyTensor",
     "SignatureDispatcher",
     "overridable",
     "unbox_tensor",
 ]
-
-AnyTensor = Union[torch.Tensor, InferenceTensor]
 
 _TargetOverride = collections.namedtuple(
     "_TargetOverride",

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -13,8 +13,8 @@ import torch
 from torch import Tensor, dtype
 import torch.nn.functional as F
 
-from ..types import InferenceTensor, PrimitiveTensor, QuantizedTensor
-from ._registry import unbox_tensor, AnyTensor
+from ..types import PrimitiveTensor, QuantizedTensor
+from ._registry import unbox_tensor
 from .signatures import *
 
 # conv2d

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -16,13 +16,14 @@ import torch
 from sharktank import kernels
 
 from ..types import (
+    AnyTensor,
     QuantizedTensor,
     PlanarQuantizedTensor,
     TensorScaledLayout,
 )
 from ..utils import debugging
 
-from ._registry import unbox_tensor, AnyTensor
+from ._registry import unbox_tensor
 from .signatures import (
     IntOrSequenceInt,
     conv2d,

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -15,13 +15,14 @@ import torch
 from torch import Tensor
 
 from ..types import (
+    AnyTensor,
     QuantizedTensor,
     PlanarQuantizedTensor,
     TensorScaledLayout,
 )
 from ..utils import debugging
 
-from ._registry import unbox_tensor, AnyTensor
+from ._registry import unbox_tensor
 from .signatures import *
 
 from sharktank import kernels

--- a/sharktank/sharktank/ops/shape.py
+++ b/sharktank/sharktank/ops/shape.py
@@ -4,15 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Collection
+from typing import Sequence
 from ..types.tensors import AnyTensor
 
 
 def broadcast_dim(
-    dim: int, shaped_or_shape: Collection[Collection[int] | AnyTensor]
+    dim: int, shaped_or_shape: Sequence[Sequence[int] | AnyTensor]
 ) -> int:
-    """Returns the dimension corresponding to `args[0]`'s dimension `dim` after
-    broadcasting `args`.
+    """Returns the dimension corresponding to `shaped_or_shape[0]`'s dimension `dim` after
+    broadcasting `shaped_or_shape`.
 
     Parameters
     ----------
@@ -25,19 +25,12 @@ def broadcast_dim(
     assert d == 3
     ```
     """
-    # assert len(args) > 0
-    # if hasattr(args[0], "shape"):
-    #     # Tensors case.
-    #     return broadcast_dim(dim, *[tensor.shape for tensor in args])
-    # ranks = [len(shape) for shape in args]
-    # broadcast_rank = max(ranks)
-    # return dim + max(0, broadcast_rank - len(args[0]))
     return broadcast_dims([dim], shaped_or_shape)[0]
 
 
 def broadcast_dims(
-    dims: Collection[int], shaped_or_shape: Collection[Collection[int] | AnyTensor]
-) -> Collection[int]:
+    dims: Sequence[int], shaped_or_shape: Sequence[Sequence[int] | AnyTensor]
+) -> Sequence[int]:
     """Returns the dimensions corresponding to `shaped_or_shape`s' dimensions after
     broadcasting `shaped_or_shape`.
 
@@ -49,7 +42,7 @@ def broadcast_dims(
     shape1 = [2, 3, 1]
     shape2 = [4, 2, 3, 5]
     dims = [2, 2]
-    res = broadcast_dims(2, [shape1, shape2])
+    res = broadcast_dims(dims, [shape1, shape2])
     print(res) # [3, 2]
     ```
     """

--- a/sharktank/sharktank/ops/shape.py
+++ b/sharktank/sharktank/ops/shape.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Collection
+from ..types.tensors import AnyTensor
+
+
+def broadcast_dim(
+    dim: int, shaped_or_shape: Collection[Collection[int] | AnyTensor]
+) -> int:
+    """Returns the dimension corresponding to `args[0]`'s dimension `dim` after
+    broadcasting `args`.
+
+    Parameters
+    ----------
+    args: is a collection of shapes or tensors.
+
+    ```python
+    shape1 = [2, 3, 1]
+    shape2 = [4, 2, 3, 5]
+    d = broadcast_dim(2, shape1, shape2)
+    assert d == 3
+    ```
+    """
+    # assert len(args) > 0
+    # if hasattr(args[0], "shape"):
+    #     # Tensors case.
+    #     return broadcast_dim(dim, *[tensor.shape for tensor in args])
+    # ranks = [len(shape) for shape in args]
+    # broadcast_rank = max(ranks)
+    # return dim + max(0, broadcast_rank - len(args[0]))
+    return broadcast_dims([dim], shaped_or_shape)[0]
+
+
+def broadcast_dims(
+    dims: Collection[int], shaped_or_shape: Collection[Collection[int] | AnyTensor]
+) -> Collection[int]:
+    """Returns the dimensions corresponding to `shaped_or_shape`s' dimensions after
+    broadcasting `shaped_or_shape`.
+
+    Parameters
+    ----------
+    args: is a collection of shapes or tensors.
+
+    ```python
+    shape1 = [2, 3, 1]
+    shape2 = [4, 2, 3, 5]
+    dims = [2, 2]
+    res = broadcast_dims(2, [shape1, shape2])
+    print(res) # [3, 2]
+    ```
+    """
+    assert len(dims) > 0 and len(shaped_or_shape) >= len(dims)
+    if hasattr(shaped_or_shape[0], "shape"):
+        # Tensors case.
+        return broadcast_dims(dims, [tensor.shape for tensor in shaped_or_shape])
+    ranks = [len(shape) for shape in shaped_or_shape]
+    broadcast_rank = max(ranks)
+    return [dim + max(0, broadcast_rank - rank) for dim, rank in zip(dims, ranks)]

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -93,3 +93,58 @@ class GroupNormSplitChannelSharding(ThetaLayerSharding):
                 "bias": Split(shard_count=self.shard_count, shard_dim=0),
             }
         )
+
+
+class LinearReplicatedInputSplitWeightAndBiasSharding(ThetaLayerSharding):
+    def __init__(self, shard_count: int, weight_and_bias_spit_dim: int = 0):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+        self.weight_and_bias_spit_dim = weight_and_bias_spit_dim
+
+    def theta_sharding(self) -> ThetaSharding:
+        return ThetaSharding(
+            {
+                "premul_input": Replicated(shard_count=self.shard_count),
+                "weight": Split(
+                    shard_count=self.shard_count,
+                    shard_dim=self.weight_and_bias_spit_dim,
+                ),
+                "bias": Split(
+                    shard_count=self.shard_count,
+                    shard_dim=self.weight_and_bias_spit_dim,
+                ),
+            }
+        )
+
+
+class ResnetBlock2DSplitOutputChannelsSharding(ThetaLayerSharding):
+    """Shards the input channel and output channels of the convolutions."""
+
+    def __init__(self, shard_count: int):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+
+    def theta_sharding(self) -> ThetaSharding:
+        result = ThetaSharding(
+            {
+                "norm1": GroupNormSplitChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv1": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "norm2": GroupNormSplitChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv2": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "time_emb_proj": LinearReplicatedInputSplitWeightAndBiasSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+                "conv_shortcut": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+            }
+        )
+        return result

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -115,36 +115,3 @@ class LinearReplicatedInputSplitWeightAndBiasSharding(ThetaLayerSharding):
                 ),
             }
         )
-
-
-class ResnetBlock2DSplitOutputChannelsSharding(ThetaLayerSharding):
-    """Shards the input channel and output channels of the convolutions."""
-
-    def __init__(self, shard_count: int):
-        super(Sharding).__init__()
-        self.shard_count = shard_count
-
-    def theta_sharding(self) -> ThetaSharding:
-        result = ThetaSharding(
-            {
-                "norm1": GroupNormSplitChannelSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-                "conv1": Conv2DSplitOutputChannelSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-                "norm2": GroupNormSplitChannelSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-                "conv2": Conv2DSplitOutputChannelSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-                "time_emb_proj": LinearReplicatedInputSplitWeightAndBiasSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-                "conv_shortcut": Conv2DSplitOutputChannelSharding(
-                    shard_count=self.shard_count
-                ).theta_sharding(),
-            }
-        )
-        return result

--- a/sharktank/tests/layers/resnet_test.py
+++ b/sharktank/tests/layers/resnet_test.py
@@ -1,0 +1,134 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.models.punet.layers import ResnetBlock2D
+from sharktank.types import *
+from sharktank.types import sharding
+from sharktank import ops
+
+
+class ResnetBlockTest(unittest.TestCase):
+    def testResnetBlock2DSplitInputAndOutputChannelsSharding(self):
+        torch.set_default_dtype(torch.float32)
+        batches = 2
+        in_channels = 6
+        out_channels = [12, 8]
+        height = 17
+        width = 19
+        kernel_height = 5
+        kernel_width = 5
+        input_time_emb_shape = [batches, 8]
+        norm_groups = 2
+        eps = 0.01
+        shard_count = 2
+        theta = Theta(
+            {
+                "norm1.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(in_channels, dtype=torch.float32)
+                ),
+                "norm1.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(in_channels, dtype=torch.float32)
+                ),
+                "conv1.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(
+                        out_channels[0],
+                        in_channels,
+                        kernel_height,
+                        kernel_width,
+                        dtype=torch.float32,
+                    )
+                ),
+                "conv1.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[0], dtype=torch.float32),
+                ),
+                "norm2.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[0], dtype=torch.float32)
+                ),
+                "norm2.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[0], dtype=torch.float32)
+                ),
+                "conv2.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(
+                        out_channels[1],
+                        out_channels[0],
+                        kernel_height,
+                        kernel_width,
+                        dtype=torch.float32,
+                    )
+                ),
+                "conv2.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[1], dtype=torch.float32),
+                ),
+                "time_emb_proj.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(
+                        out_channels[0], input_time_emb_shape[1], dtype=torch.float32
+                    ),
+                ),
+                "time_emb_proj.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[0], dtype=torch.float32),
+                ),
+                "conv_shortcut.weight": DefaultPrimitiveTensor(
+                    data=torch.rand(
+                        out_channels[1],
+                        in_channels,
+                        kernel_height,
+                        kernel_width,
+                        dtype=torch.float32,
+                    )
+                ),
+                "conv_shortcut.bias": DefaultPrimitiveTensor(
+                    data=torch.rand(out_channels[1], dtype=torch.float32),
+                ),
+            }
+        )
+        resnet_block = ResnetBlock2D(
+            theta=theta,
+            groups=norm_groups,
+            eps=eps,
+            non_linearity="relu",
+            output_scale_factor=None,
+            dropout=0.0,
+            temb_channels=input_time_emb_shape[1],
+            time_embedding_norm="default",
+        )
+        input_image = torch.rand(
+            batches,
+            in_channels,
+            width,
+            height,
+        )
+        input_time_emb = torch.rand(input_time_emb_shape)
+        unsharded_result = resnet_block(input_image, input_time_emb)
+        expected_result = ops.reshard_split(unsharded_result, dim=1, count=shard_count)
+
+        sharding_spec = sharding.ResnetBlock2DSplitOutputChannelsSharding(
+            shard_count=shard_count
+        )
+        sharded_theta = ops.reshard(theta, sharding_spec)
+        sharded_resnet_block = ResnetBlock2D(
+            theta=sharded_theta,
+            groups=norm_groups,
+            eps=eps,
+            non_linearity="relu",
+            output_scale_factor=None,
+            dropout=0.0,
+            temb_channels=input_time_emb_shape[1],
+            time_embedding_norm="default",
+        )
+        sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
+        sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
+        actual_result = sharded_resnet_block(
+            sharded_input_image, sharded_input_time_emb
+        )
+        assert ops.equal(expected_result, actual_result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -13,6 +13,27 @@ from sharktank import ops
 from sharktank.types import *
 
 
+class BroadcastDimsTest(unittest.TestCase):
+    def testBroadcastDimForSmallerRankTensor(self):
+        a = torch.empty(2, 5, 1)
+        b = torch.empty(4, 2, 5, 1)
+        assert ops.broadcast_dim(2, [a, b]) == 3
+
+    def testBroadcastDimForLargestRankTensor(self):
+        a = torch.empty(4, 2, 5, 1)
+        b = torch.empty(2, 5, 1)
+        assert ops.broadcast_dim(2, [a, b]) == 2
+
+    def testBroadcastDims(self):
+        a = torch.empty(4, 2, 1, 2)
+        b = torch.empty(2, 3, 2)
+        tensors = [a, b]
+        dims = [0, 1]
+        res = ops.broadcast_dims(dims, tensors)
+        assert res[0] == 0
+        assert res[1] == 2
+
+
 class EqualTest(unittest.TestCase):
     def testEqualTorchTensors(self):
         a = torch.rand(2, 3, dtype=torch.float32)


### PR DESCRIPTION
Add one case of resnet block sharding
`ResnetBlock2DSplitOutputChannelsSharding`.

Move AnyTensor to avoid cyclic dependencies.

Add broadcast_dim(s) functions and handle broadcasting for element-wise binary with sharded split tensors.

Make sharded linear override for a cartesian product of type sets. Let the constituent ops fail if they can't handle the input.

Add matmul for replicated LHS and split RHS.

Fix resharding of thetas.

Add unshard op.

Fix slicing of split tensor.

Refactor Theta to reflect that it is actually a tree of tensors and expose the tree.
Fix some asserts during construction.