### PR TITLE
[quant] Dedynamize the integer kernels.

### DIFF
--- a/sharktank/integration/models/punet/integration_test.py
+++ b/sharktank/integration/models/punet/integration_test.py
@@ -21,7 +21,7 @@ def punet_goldens():
     from huggingface_hub import hf_hub_download
 
     REPO_ID = "amd-shark/sharktank-goldens"
-    REVISION = "230dad4d85fbcb8759a331dcf1d45f0562875abe"
+    REVISION = "1d4cb6c452d15a180c1928246848128cdff5ddc8"
 
     def download(filename):
         return hf_hub_download(
@@ -35,6 +35,9 @@ def punet_goldens():
         ),
         "outputs_int8.safetensors": download(
             "classifier_free_guidance_int8_outputs.safetensors"
+        ),
+        "outputs_int8_emulated.safetensors": download(
+            "classifier_free_guidance_int8_emulated_outputs.safetensors"
         ),
     }
 
@@ -203,8 +206,8 @@ def test_punet_eager_fp16_validation(punet_goldens, sdxl_fp16_dataset, temp_dir)
 def test_punet_eager_int8_validation(punet_goldens, sdxl_int8_dataset, temp_dir):
     from sharktank.models.punet.tools import run_punet
 
-    # ROCM code generation isn't good enough for these dynamic eager kernels.
-    # Just use CPU for now.
+    # Eager runtime issues keep this from producing reliable results on multi
+    # GPU systems, so validate on CPU for now.
     # device = testing.get_best_torch_device()
     device = "cpu"
     output_path = (
@@ -256,5 +259,5 @@ def test_punet_eager_int8_emulated_validation(
             ]
         )
     testing.assert_golden_safetensors(
-        output_path, punet_goldens["outputs_int8.safetensors"]
+        output_path, punet_goldens["outputs_int8_emulated.safetensors"]
     )

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -58,36 +58,60 @@ class conv_2d_nchw_fchw(CustomOp):
         h_out = math.floor((h_pad - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
         w_out = math.floor((w_pad - dilations[1] * (k1 - 1) - 1) / strides[1] + 1)
         c_desc = ksel.return_new_tensor([n, f, h_out, w_out], dtype=inputs_desc.t.dtype)
+        specialize_all_known_dims(inputs_desc)
+        specialize_all_known_dims(weights_desc)
+        specialize_all_known_dims(bias_desc)
+        specialize_all_known_dims(c_desc)
+
+        # Always specialize the our W/H as we presently do not materialize the output
+        # size computation in the IR.
+        inputs_desc.specialize_dims(-1, -2)
+        weights_desc.specialize_dims(-1, -2)
+        c_desc.specialize_dims(-1, -2)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         inputs = kb.arg_value(0)
-        inputs_tensor_type = RankedTensorType(inputs.type)
         strides = ksel.arg_descs[3].v
         dilations = ksel.arg_descs[4].v
-        result_desc = ksel.result_descs[0].t.shape
-        H_out = result_desc[2]
-        W_out = result_desc[3]
+        result_desc = ksel.result_descs[0]
+        result_shape = result_desc.t.shape
+        H_out = result_shape[2]
+        W_out = result_shape[3]
 
+        # Generate specialization signature and types.
+        inputs_asm_type, inputs_ident, accum_type = unpack_tensor_type(inputs.type)
+        weights_asm_type, weights_ident, _ = unpack_tensor_type(kb.arg_value(1).type)
+        bias_asm_type, bias_ident, _ = unpack_tensor_type(kb.arg_value(2).type)
+        spec_sig = (
+            f"I{inputs_ident}_W{weights_ident}_B{bias_ident}"
+            f"_S{strides[0]}x{strides[1]}"
+            f"_D{dilations[0]}x{dilations[1]}"
+        )
+        template_file = "conv_2d_nchw_fchw.mlir"
+        target_function_name = f"sharktank_conv_2d_nchw_fchw_{spec_sig}"
+
+        # Template params.
+        result_asm_type = f"tensor<{'x'.join('?' if d is None else str(d) for d in result_desc.spec_dims)}x{accum_type}>"
         strides = [str(i) for i in strides]
         dilations = [str(i) for i in dilations]
         H_out = str(H_out)
         W_out = str(W_out)
 
-        dtype_str = str(inputs_tensor_type.element_type)
-
-        template_file = "conv_2d_nchw_fchw.mlir"
-        target_function_name = f"sharktank_conv_2d_nchw_fchw_{strides[0]}_{strides[1]}_{dilations[0]}_{dilations[1]}_{dtype_str}"
-
         target_function = inline_template_function(
             kb,
             template_file,
             target_function_name,
+            spec_sig=spec_sig,
+            inputs_asm_type=inputs_asm_type,
+            weights_asm_type=weights_asm_type,
+            bias_asm_type=bias_asm_type,
+            result_asm_type=result_asm_type,
             H_out=H_out,
             W_out=W_out,
             strides_H=strides[0],
             strides_W=strides[1],
             dilations_H=dilations[0],
             dilations_W=dilations[1],
-            dtype=dtype_str,
+            accum_type=str(accum_type),
         )
         kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/pooling_nchw_sum.py
+++ b/sharktank/sharktank/kernels/pooling_nchw_sum.py
@@ -23,55 +23,66 @@ class pooling_nchw_sum(CustomOp):
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
-        weights_size_desc = ksel.attr_list_int(1)  # Shape [2]
+        kernel_size_desc = ksel.attr_list_int(1)  # Shape [2]
         strides_desc = ksel.attr_list_int(2)  # Shape [2]
         dilations_desc = ksel.attr_list_int(3)  # Shape [2]
 
         # unpack
         n, c, h_pad, w_pad = inputs_desc.t.shape
 
-        weights_size = weights_size_desc.v
+        kernel_size = kernel_size_desc.v
         strides = strides_desc.v
         dilations = dilations_desc.v
 
         # pooling shape math
-        h_out = math.floor((h_pad - weights_size[0]) / strides[0] + 1)
-        w_out = math.floor((w_pad - weights_size[1]) / strides[1] + 1)
+        h_out = math.floor((h_pad - kernel_size[0]) / strides[0] + 1)
+        w_out = math.floor((w_pad - kernel_size[1]) / strides[1] + 1)
         c_desc = ksel.return_new_tensor([n, c, h_out, w_out], dtype=inputs_desc.t.dtype)
+        specialize_all_known_dims(inputs_desc)
+        specialize_all_known_dims(c_desc)
+
+        # Require specialization of width/height.
+        inputs_desc.specialize_dims(-1, -2)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         inputs = kb.arg_value(0)
         inputs_tensor_type = RankedTensorType(inputs.type)
-        weights = ksel.arg_descs[1].v
+        kernel_size = ksel.arg_descs[1].v
         strides = ksel.arg_descs[2].v
         dilations = ksel.arg_descs[3].v
-        result_desc = ksel.result_descs[0].t.shape
-        H_out = result_desc[2]
-        W_out = result_desc[3]
+        result_desc = ksel.result_descs[0]
+        result_shape = result_desc.t.shape
+        _, _, H_out, W_out = result_desc.t.shape
 
-        weights = [str(i) for i in weights]
-        strides = [str(i) for i in strides]
-        dilations = [str(i) for i in dilations]
-        H_out = str(H_out)
-        W_out = str(W_out)
-
-        dtype_str = str(inputs_tensor_type.element_type)
-
+        # Generate specialization signature and types.
+        inputs_asm_type, inputs_ident, accum_type = unpack_tensor_type(inputs.type)
+        spec_sig = (
+            f"I{inputs_ident}"
+            f"_K{kernel_size[0]}x{kernel_size[1]}"
+            f"_S{strides[0]}x{strides[1]}"
+            f"_D{dilations[0]}x{dilations[1]}"
+        )
         template_file = "pooling_nchw_sum.mlir"
-        target_function_name = f"sharktank_pooling_nchw_sum_{strides[0]}_{strides[1]}_{dilations[0]}_{dilations[1]}_{dtype_str}"
+        target_function_name = f"sharktank_pooling_nchw_sum_{spec_sig}"
+
+        # Template params.
+        result_asm_type = f"tensor<{'x'.join('?' if d is None else str(d) for d in result_desc.spec_dims)}x{accum_type}>"
 
         target_function = inline_template_function(
             kb,
             template_file,
             target_function_name,
-            H_out=H_out,
-            W_out=W_out,
-            weights_H=weights[0],
-            weights_W=weights[1],
-            strides_H=strides[0],
-            strides_W=strides[1],
-            dilations_H=dilations[0],
-            dilations_W=dilations[1],
-            dtype=dtype_str,
+            spec_sig=spec_sig,
+            inputs_asm_type=inputs_asm_type,
+            result_asm_type=result_asm_type,
+            H_out=str(H_out),
+            W_out=str(W_out),
+            ks_H=str(kernel_size[0]),
+            ks_W=str(kernel_size[1]),
+            strides_H=str(strides[0]),
+            strides_W=str(strides[1]),
+            dilations_H=str(dilations[0]),
+            dilations_W=str(dilations[1]),
+            accum_type=accum_type,
         )
         kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -7,34 +7,46 @@
 #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
 
-!dtype = {{dtype}}
-!dynamic_tensor_type = tensor<?x?x?x?x!dtype>
-!out_tensor_type = !dynamic_tensor_type
+!accum_type = {{accum_type}}
+!inputs_asm_type = {{inputs_asm_type}}
+!weights_asm_type = {{weights_asm_type}}
+!bias_asm_type = {{bias_asm_type}}
+!result_asm_type = {{result_asm_type}}
+!dynamic_result_asm_type = tensor<?x?x?x?x{{accum_type}}>
 
 module {
 
-util.func private @sharktank_conv_2d_nchw_fchw_{{strides_H}}_{{strides_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input_pad: !dynamic_tensor_type, %weights: !dynamic_tensor_type, %bias: tensor<?x!dtype>)
-    -> !out_tensor_type {
-  %zero = arith.constant 0: !dtype
+util.func private @sharktank_conv_2d_nchw_fchw_{{spec_sig}}
+  (%input_pad: !inputs_asm_type, %weights: !weights_asm_type, %bias: !bias_asm_type)
+    -> !result_asm_type {
+  %zero = arith.constant 0: !accum_type
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  %rN = tensor.dim %input_pad, %c0 : !dynamic_tensor_type
-  %rC = tensor.dim %weights, %c0 : !dynamic_tensor_type
+  %rN = tensor.dim %input_pad, %c0 : !inputs_asm_type
+  %rC = tensor.dim %weights, %c0 : !weights_asm_type
   %rH = arith.constant {{H_out}} : index
   %rW = arith.constant {{W_out}} : index
-  %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
-  %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
-  %result = linalg.conv_2d_nchw_fchw {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !dynamic_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
-  %result_biased = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%result, %bias : !dynamic_tensor_type, tensor<?x!dtype>) outs(%result : !out_tensor_type) {
-    ^bb0(%in: !dtype, %in_1: !dtype, %out: !dtype):
-      %add = arith.addi %in, %in_1 : !dtype
-      linalg.yield %add : !dtype
-    } -> !out_tensor_type
-  util.return %result_biased : !out_tensor_type
+  %result_empty_dynamic = tensor.empty(%rN, %rC, %rH, %rW) : !dynamic_result_asm_type
+  %result_empty = tensor.cast %result_empty_dynamic : !dynamic_result_asm_type to !result_asm_type
+  %result_fill = linalg.fill ins(%zero: !accum_type) outs(%result_empty: !result_asm_type) -> !result_asm_type
+  %result = linalg.conv_2d_nchw_fchw
+    {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>,
+     strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>}
+    ins(%input_pad, %weights: !inputs_asm_type, !weights_asm_type)
+    outs(%result_fill: !result_asm_type) -> !result_asm_type
+  %result_biased = linalg.generic {
+      indexing_maps = [#map0, #map1, #map0],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%result, %bias : !result_asm_type, !bias_asm_type)
+    outs(%result : !result_asm_type) {
+    ^bb0(%in: !accum_type, %in_1: !accum_type, %out: !accum_type):
+      %add = arith.addi %in, %in_1 : !accum_type
+      linalg.yield %add : !accum_type
+    } -> !result_asm_type
+  util.return %result_biased : !result_asm_type
 }
 
 }

--- a/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
+++ b/sharktank/sharktank/kernels/templates/pooling_nchw_sum.mlir
@@ -4,31 +4,37 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-!dtype = {{dtype}}
-!dynamic_tensor_type = tensor<?x?x?x?x!dtype>
-!weights_tensor_type = tensor<{{weights_H}}x{{weights_W}}x!dtype>
-!out_tensor_type = !dynamic_tensor_type
+!accum_dtype = {{accum_type}}
+!inputs_asm_type = {{inputs_asm_type}}
+!result_asm_type = {{result_asm_type}}
+!dynamic_result_asm_type = tensor<?x?x?x?x!accum_dtype>
+!weights_tensor_type = tensor<{{ks_H}}x{{ks_W}}x!accum_dtype>
 
 module {
 
-util.func private @sharktank_pooling_nchw_sum_{{strides_H}}_{{strides_W}}_{{dilations_H}}_{{dilations_W}}_{{dtype}} (
-    %input_pad: !dynamic_tensor_type)
-    -> !out_tensor_type {
-  %zero = arith.constant 0: !dtype
+util.func private @sharktank_pooling_nchw_sum_{{spec_sig}} (
+    %input_pad: !inputs_asm_type)
+    -> !result_asm_type {
+  %zero = arith.constant 0: !accum_dtype
   %weights = tensor.empty() : !weights_tensor_type
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
   %c3 = arith.constant 3: index
 
-  %rN = tensor.dim %input_pad, %c0 : !dynamic_tensor_type
-  %rC = tensor.dim %input_pad, %c1 : !dynamic_tensor_type
+  %rN = tensor.dim %input_pad, %c0 : !inputs_asm_type
+  %rC = tensor.dim %input_pad, %c1 : !inputs_asm_type
   %rH = arith.constant {{H_out}} : index
   %rW = arith.constant {{W_out}} : index
-  %result_empty = tensor.empty(%rN, %rC, %rH, %rW) : !out_tensor_type
-  %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !out_tensor_type) -> !out_tensor_type
-  %result = linalg.pooling_nchw_sum {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>, strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>} ins(%input_pad, %weights: !dynamic_tensor_type, !weights_tensor_type) outs(%result_fill: !out_tensor_type) -> !out_tensor_type
-  util.return %result : !out_tensor_type
+  %result_empty_dynamic = tensor.empty(%rN, %rC, %rH, %rW) : !dynamic_result_asm_type
+  %result_empty = tensor.cast %result_empty_dynamic : !dynamic_result_asm_type to !result_asm_type
+  %result_fill = linalg.fill ins(%zero: !accum_dtype) outs(%result_empty: !result_asm_type) -> !result_asm_type
+  %result = linalg.pooling_nchw_sum
+    {dilations = dense<[{{dilations_H}}, {{dilations_W}}]> : tensor<2xi64>,
+     strides = dense<[{{strides_H}}, {{strides_W}}]> : tensor<2xi64>}
+    ins(%input_pad, %weights: !inputs_asm_type, !weights_tensor_type)
+    outs(%result_fill: !result_asm_type) -> !result_asm_type
+  util.return %result : !result_asm_type
 }
 
 }

--- a/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
+++ b/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
@@ -57,7 +57,7 @@ class batch_matmul_transpose_b_test(unittest.TestCase):
         output = aot.export(ep)
         output.verify()
         asm = str(output.mlir_module)
-        self.assertIn("@sharktank_batch_matmul_transpose_b_8_2_i32", asm)
+        self.assertIn("@sharktank_batch_matmul_transpose_b_L4x16x2xi32_R4x8x2xi32", asm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This produces precise specializations based on the level of dynamism in use vs punning everything to fully dynamic. As a byproduct, this fixes a bug where some conv/sum kernels did not have a function signature that was sufficiently specialized, resulting in aliasing and bad kernel selection.