### PR TITLE
[quant] Convert custom conv op to mixed precision.

### DIFF
--- a/sharktank/integration/models/punet/integration_test.py
+++ b/sharktank/integration/models/punet/integration_test.py
@@ -202,7 +202,6 @@ def test_punet_eager_fp16_validation(punet_goldens, sdxl_fp16_dataset, temp_dir)
 @pytest.mark.model_punet
 @pytest.mark.expensive
 @pytest.mark.golden
-@pytest.mark.skip("Not yet working")
 def test_punet_eager_int8_validation(punet_goldens, sdxl_int8_dataset, temp_dir):
     from sharktank.models.punet.tools import run_punet
 

--- a/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
+++ b/sharktank/sharktank/kernels/conv_2d_nchw_fchw.py
@@ -15,15 +15,41 @@ __all__ = [
 ]
 
 
+_LEGAL_OUTPUT_TYPES = {
+    # Legal integer types.
+    (torch.int8, torch.int8, "torch.int8"): torch.int8,
+    (torch.int8, torch.int8, "torch.int16"): torch.int16,
+    (torch.int8, torch.int8, "torch.int32"): torch.int32,
+    (torch.int16, torch.int16, "torch.int16"): torch.int16,
+    (torch.int16, torch.int16, "torch.int32"): torch.int32,
+    # Legal fp types.
+    (torch.float16, torch.float16, "torch.float16"): torch.float16,
+    (torch.float16, torch.float16, "torch.float32"): torch.float32,
+    (torch.float32, torch.float32, "torch.float32"): torch.float32,
+}
+
+# Ensure that every output type above is in this table.
+_OUTPUT_TYPE_TO_ASM = {
+    torch.int8: "i8",
+    torch.int16: "i16",
+    torch.int32: "i32",
+    torch.float16: "f16",
+    torch.float32: "f32",
+}
+
+
 @CustomOp.register(library=LIBRARY)
 class conv_2d_nchw_fchw(CustomOp):
-    """Generic convolution on explicitly padded inputs.
-
+    """Generic convolution on explicitly padded inputs on mixed precision
+    operands. This is meant to be used for pure integer convolutions and
+    supports automatic type promotion. It can be invoked either with uniform
+    types or any combination of signed integer inputs and a wider, signed
+    output type. Note that the ops this lower to only support signed extension.
 
     Will be specialized for all values of strides, padding, dilations, and LHS dtype.
     """
 
-    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] dilations) -> (Tensor)"
+    signature = "conv_2d_nchw_fchw(Tensor inputs, Tensor weights, Tensor bias, int[] strides, int[] dilations, str output_dtype) -> (Tensor)"
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
@@ -31,6 +57,9 @@ class conv_2d_nchw_fchw(CustomOp):
         bias_desc = ksel.arg_tensor(2)
         strides_desc = ksel.attr_list_int(3)  # Shape [2]
         dilations_desc = ksel.attr_list_int(4)  # Shape [2]
+        output_dtype_name = ksel.attr_str(5).v
+        if "." not in output_dtype_name:
+            output_dtype_name = f"torch.{output_dtype_name}"
 
         # unpack
         n, c, h_pad, w_pad = inputs_desc.t.shape
@@ -39,6 +68,18 @@ class conv_2d_nchw_fchw(CustomOp):
 
         strides = strides_desc.v
         dilations = dilations_desc.v
+
+        # validate types
+        type_tuple = (inputs_desc.t.dtype, weights_desc.t.dtype, output_dtype_name)
+        output_dtype = _LEGAL_OUTPUT_TYPES.get(type_tuple)
+        torch._check(
+            output_dtype is not None,
+            lambda: f"conv_2d_nchw_fchw unsupported dtype combination: got {type_tuple}. allowed:\n  {list(_LEGAL_OUTPUT_TYPES.keys())}",
+        )
+        torch._check(
+            bias_desc.t.dtype == output_dtype,
+            lambda: f"conv_2d_nchw_fchw bias type must match output dtype: got {bias_desc.t.dtype}, expected {output_dtype}",
+        )
 
         # check
         torch._check(
@@ -57,7 +98,7 @@ class conv_2d_nchw_fchw(CustomOp):
         # convolution shape math
         h_out = math.floor((h_pad - dilations[0] * (k0 - 1) - 1) / strides[0] + 1)
         w_out = math.floor((w_pad - dilations[1] * (k1 - 1) - 1) / strides[1] + 1)
-        c_desc = ksel.return_new_tensor([n, f, h_out, w_out], dtype=inputs_desc.t.dtype)
+        c_desc = ksel.return_new_tensor([n, f, h_out, w_out], dtype=output_dtype)
         specialize_all_known_dims(inputs_desc)
         specialize_all_known_dims(weights_desc)
         specialize_all_known_dims(bias_desc)
@@ -79,11 +120,14 @@ class conv_2d_nchw_fchw(CustomOp):
         W_out = result_shape[3]
 
         # Generate specialization signature and types.
-        inputs_asm_type, inputs_ident, accum_type = unpack_tensor_type(inputs.type)
+        result_dtype = result_desc.t.dtype
+        accum_type = _OUTPUT_TYPE_TO_ASM[result_dtype]
+        inputs_asm_type, inputs_ident, _ = unpack_tensor_type(inputs.type)
         weights_asm_type, weights_ident, _ = unpack_tensor_type(kb.arg_value(1).type)
         bias_asm_type, bias_ident, _ = unpack_tensor_type(kb.arg_value(2).type)
         spec_sig = (
             f"I{inputs_ident}_W{weights_ident}_B{bias_ident}"
+            f"_O{accum_type}"
             f"_S{strides[0]}x{strides[1]}"
             f"_D{dilations[0]}x{dilations[1]}"
         )
@@ -97,6 +141,7 @@ class conv_2d_nchw_fchw(CustomOp):
         H_out = str(H_out)
         W_out = str(W_out)
 
+        is_floating_point = result_dtype.is_floating_point
         target_function = inline_template_function(
             kb,
             template_file,
@@ -113,5 +158,7 @@ class conv_2d_nchw_fchw(CustomOp):
             dilations_H=dilations[0],
             dilations_W=dilations[1],
             accum_type=str(accum_type),
+            zero=("0." if is_floating_point else "0"),
+            add_op=("arith.addf" if is_floating_point else "arith.addi"),
         )
         kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -19,7 +19,7 @@ module {
 util.func private @sharktank_conv_2d_nchw_fchw_{{spec_sig}}
   (%input_pad: !inputs_asm_type, %weights: !weights_asm_type, %bias: !bias_asm_type)
     -> !result_asm_type {
-  %zero = arith.constant 0: !accum_type
+  %zero = arith.constant {{zero}}: !accum_type
   %c0 = arith.constant 0: index
   %c1 = arith.constant 1: index
   %c2 = arith.constant 2: index
@@ -43,7 +43,7 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{spec_sig}}
     ins(%result, %bias : !result_asm_type, !bias_asm_type)
     outs(%result : !result_asm_type) {
     ^bb0(%in: !accum_type, %in_1: !accum_type, %out: !accum_type):
-      %add = arith.addi %in, %in_1 : !accum_type
+      %add = {{add_op}} %in, %in_1 : !accum_type
       linalg.yield %add : !accum_type
     } -> !result_asm_type
   util.return %result_biased : !result_asm_type

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -24,24 +24,33 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (1e-3, 1e-5),
-            (1e-3, 1e-5),
-            (1e-3, 1e-5),
+            (torch.int8, "int32", 1e-3, 1e-5),
+            (torch.int8, "int8", 1e-3, 1e-5),
+            (torch.float16, "float16", 1e-1, 1e-1),  # Different accumulators from ref
+            (torch.float16, "float32", 1e-3, 1e-5),
+            (torch.float32, "float32", 1e-3, 1e-5),
         ]
     )
-    def testBS32(self, atol, rtol):
-        dtype = torch.int8
-        inputs = (torch.rand([2, 320, 64, 64]) * 64).to(dtype)
+    def testBS32(self, input_dtype, output_dtype_name, atol, rtol):
+        output_dtype = getattr(torch, output_dtype_name)
+        inputs = (torch.rand([2, 4, 64, 64]) * 64).to(input_dtype)
         padding = [1, 1]
         extended_list = [item for item in padding for _ in range(2)]
         inputs_pad = _pad_last_2d(inputs, extended_list)
-        weights = (torch.rand([640, 320, 3, 3]) * 64).to(dtype)
-        bias = (torch.rand([640]) * 64).to(dtype)
-        result = kernels.conv_2d_nchw_fchw(inputs_pad, weights, bias, [1, 1], [1, 1])
+        weights = (torch.rand([8, 4, 3, 3]) * 64).to(input_dtype)
+        bias = (torch.rand([8]) * 64).to(dtype=output_dtype)
+        result = kernels.conv_2d_nchw_fchw(
+            inputs_pad, weights, bias, [1, 1], [1, 1], output_dtype=output_dtype_name
+        )
 
         # Tolerances are empirical and results are not expected to match exactly.
         ref = torch.nn.functional.conv2d(
-            inputs, weights, bias=bias, stride=(1, 1), padding=(1, 1), dilation=(1, 1)
+            inputs.to(dtype=output_dtype),
+            weights.to(dtype=output_dtype),
+            bias=bias.to(dtype=output_dtype),
+            stride=(1, 1),
+            padding=(1, 1),
+            dilation=(1, 1),
         )
         print(result.shape)
         print(ref.shape)
@@ -50,7 +59,9 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
     def testExportStaticDims(self):
         class MyModule(torch.nn.Module):
             def forward(self, a, b, c):
-                return kernels.conv_2d_nchw_fchw(a, b, c, [1, 1], [1, 1])
+                return kernels.conv_2d_nchw_fchw(
+                    a, b, c, [1, 1], [1, 1], output_dtype="int32"
+                )
 
         mod = MyModule()
         dtype = torch.int8
@@ -63,13 +74,16 @@ class conv_2d_nchw_fchw_test(unittest.TestCase):
             args=(
                 (inputs_pad).to(dtype),
                 (torch.rand([640, 320, 3, 3]) * 64).to(dtype),
-                (torch.rand([640]) * 64).to(dtype),
+                (torch.rand([640]) * 64).to(torch.int32),
             ),
         )
         output = aot.export(ep)
         output.verify()
         asm = str(output.mlir_module)
-        self.assertIn("@sharktank_conv_2d_nchw_fchw", asm)
+        self.assertIn(
+            "@sharktank_conv_2d_nchw_fchw_I2x320x66x66xi8_W640x320x3x3xi8_B640xi32_Oi32_S1x1_D1x1",
+            asm,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This requires less reconstruction by fusion on the compiler side and allows us to better enforce the exact type signatures that are supported.