### PR TITLE
Add sharding of Punet's up/down block

### DIFF
--- a/sharktank/sharktank/models/punet/layers.py
+++ b/sharktank/sharktank/models/punet/layers.py
@@ -80,7 +80,7 @@ class UpDownBlock2D(ThetaLayer):
         hidden_states: torch.Tensor,
         temb: Optional[torch.Tensor] = None,
         *,
-        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor],
         attention_mask: Optional[torch.Tensor],
         encoder_attention_mask: Optional[torch.Tensor],
         upsample_size: Optional[int] = None,
@@ -93,7 +93,7 @@ class UpDownBlock2D(ThetaLayer):
             if res_hidden_states_tuple is not None:
                 res_hidden_states = res_hidden_states_tuple[-1]
                 res_hidden_states_tuple = res_hidden_states_tuple[:-1]
-                hidden_states = torch.cat([hidden_states, res_hidden_states], dim=1)
+                hidden_states = ops.cat([hidden_states, res_hidden_states], dim=1)
 
             hidden_states = resnet(hidden_states, temb)
             output_states = output_states + (hidden_states,)
@@ -250,11 +250,11 @@ class Upsample2D(ThetaLayer):
     def forward(self, hidden_states: torch.Tensor, output_size: Optional[int] = None):
         if self.interpolate:
             if output_size is None:
-                hidden_states = nn.functional.interpolate(
+                hidden_states = ops.interpolate(
                     hidden_states, scale_factor=2.0, mode="nearest"
                 )
             else:
-                hidden_states = nn.functional.interpolate(
+                hidden_states = ops.interpolate(
                     hidden_states, size=output_size, mode="nearest"
                 )
         hidden_states = self.conv(hidden_states)

--- a/sharktank/sharktank/models/punet/sharding.py
+++ b/sharktank/sharktank/models/punet/sharding.py
@@ -13,7 +13,7 @@ class ResnetBlock2DSplitOutputChannelsSharding(ThetaLayerSharding):
     """Shards the input channel and output channels of the convolutions."""
 
     def __init__(self, shard_count: int):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
 
     def theta_sharding(self) -> ThetaSharding:
@@ -49,7 +49,7 @@ class UpDownSample2DSplitChannelSharding(ThetaLayerSharding):
     """
 
     def __init__(self, shard_count: int):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
 
     def theta_sharding(self) -> ThetaSharding:
@@ -76,7 +76,7 @@ class UpDownBlock2DSplitChannelsSharing(ThetaLayerSharding):
         upsamplers_count: int = 0,
         downsamplers_count: int = 0,
     ):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
         self.resnet_layers_count = resnet_layers_count
         self.upsamplers_count = upsamplers_count

--- a/sharktank/sharktank/models/punet/sharding.py
+++ b/sharktank/sharktank/models/punet/sharding.py
@@ -40,3 +40,60 @@ class ResnetBlock2DSplitOutputChannelsSharding(ThetaLayerSharding):
             }
         )
         return result
+
+
+class UpDownSample2DSplitChannelSharding(ThetaLayerSharding):
+    """Splits the output channels dimension of the convolution.
+
+    Sharding spec for `.layers.Upsample2D` or `.layers.Downsample2D`.
+    """
+
+    def __init__(self, shard_count: int):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+
+    def theta_sharding(self) -> ThetaSharding:
+        result = ThetaSharding(
+            {
+                "conv": Conv2DSplitOutputChannelSharding(
+                    shard_count=self.shard_count
+                ).theta_sharding(),
+            }
+        )
+        return result
+
+
+class UpDownBlock2DSplitChannelsSharing(ThetaLayerSharding):
+    """Splits the output channels dimension of the convolution.
+
+    Sharding spec for `.layers.Downsample2D` or `.layers.Upsample2D`.
+    """
+
+    def __init__(
+        self,
+        shard_count: int,
+        resnet_layers_count: int,
+        upsamplers_count: int = 0,
+        downsamplers_count: int = 0,
+    ):
+        super(Sharding).__init__()
+        self.shard_count = shard_count
+        self.resnet_layers_count = resnet_layers_count
+        self.upsamplers_count = upsamplers_count
+        self.downsamplers_count = downsamplers_count
+
+    def theta_sharding(self) -> ThetaSharding:
+        d = {}
+        for i in range(self.upsamplers_count):
+            d[f"upsamplers.{i}"] = UpDownSample2DSplitChannelSharding(
+                shard_count=self.shard_count
+            ).theta_sharding()
+        for i in range(self.downsamplers_count):
+            d[f"downsamplers.{i}"] = UpDownSample2DSplitChannelSharding(
+                shard_count=self.shard_count
+            ).theta_sharding()
+        for i in range(self.resnet_layers_count):
+            d[f"resnets.{i}"] = ResnetBlock2DSplitOutputChannelsSharding(
+                shard_count=self.shard_count
+            ).theta_sharding()
+        return ThetaSharding(d)

--- a/sharktank/sharktank/models/punet/testing.py
+++ b/sharktank/sharktank/models/punet/testing.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import List
+
+import torch
+
+from ...types.tensors import *
+from ...types.theta import Theta
+
+
+def make_conv2d_layer_theta(
+    in_channels: int,
+    out_channels: int,
+    kernel_height: int,
+    kernel_width: int,
+    dtype: torch.dtype | None = None,
+) -> Theta:
+    return Theta(
+        {
+            "weight": DefaultPrimitiveTensor(
+                data=torch.rand(
+                    out_channels,
+                    in_channels,
+                    kernel_height,
+                    kernel_width,
+                    dtype=dtype,
+                )
+            ),
+            "bias": DefaultPrimitiveTensor(
+                data=torch.rand(out_channels, dtype=dtype),
+            ),
+        }
+    )
+
+
+def make_resnet_block_2d_theta(
+    in_channels: int,
+    out_channels: List[int],
+    kernel_height: int,
+    kernel_width: int,
+    input_time_emb_channels: int,
+    dtype: torch.dtype | None = None,
+) -> Theta:
+    return Theta(
+        {
+            "norm1.weight": DefaultPrimitiveTensor(
+                data=torch.rand(in_channels, dtype=dtype)
+            ),
+            "norm1.bias": DefaultPrimitiveTensor(
+                data=torch.rand(in_channels, dtype=dtype)
+            ),
+            "conv1": make_conv2d_layer_theta(
+                in_channels=in_channels,
+                out_channels=out_channels[0],
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                dtype=dtype,
+            ).tree,
+            "norm2.weight": DefaultPrimitiveTensor(
+                data=torch.rand(out_channels[0], dtype=dtype)
+            ),
+            "norm2.bias": DefaultPrimitiveTensor(
+                data=torch.rand(out_channels[0], dtype=dtype)
+            ),
+            "conv2": make_conv2d_layer_theta(
+                in_channels=out_channels[0],
+                out_channels=out_channels[1],
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                dtype=dtype,
+            ).tree,
+            "time_emb_proj.weight": DefaultPrimitiveTensor(
+                data=torch.rand(out_channels[0], input_time_emb_channels, dtype=dtype),
+            ),
+            "time_emb_proj.bias": DefaultPrimitiveTensor(
+                data=torch.rand(out_channels[0], dtype=dtype),
+            ),
+            "conv_shortcut": make_conv2d_layer_theta(
+                in_channels=in_channels,
+                out_channels=out_channels[1],
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                dtype=dtype,
+            ).tree,
+        }
+    )
+
+
+def make_up_down_sample_2d_theta(
+    in_channels: int,
+    out_channels: int,
+    kernel_height: int,
+    kernel_width: int,
+    dtype: torch.dtype | None = None,
+):
+    return Theta(
+        {
+            "conv": make_conv2d_layer_theta(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                dtype=dtype,
+            ).tree,
+        }
+    )
+
+
+def make_up_down_block_2d_theta(
+    channels: int,
+    kernel_height: int,
+    kernel_width: int,
+    input_time_emb_channels: int,
+    resnet_layers: int,
+    is_up_block: bool,
+    dtype: torch.dtype | None = None,
+) -> Theta:
+    res = dict()
+    assert channels % 2 == 0
+    for i in range(resnet_layers):
+        res[f"resnets.{i}"] = make_resnet_block_2d_theta(
+            in_channels=channels,
+            out_channels=[channels, channels // 2],
+            kernel_height=kernel_height,
+            kernel_width=kernel_width,
+            input_time_emb_channels=input_time_emb_channels,
+            dtype=dtype,
+        ).tree
+    path_name = "upsamplers" if is_up_block else "downsamplers"
+    res[f"{path_name}.0"] = make_up_down_sample_2d_theta(
+        in_channels=channels // 2,
+        out_channels=channels // 2,
+        kernel_height=kernel_height,
+        kernel_width=kernel_width,
+        dtype=dtype,
+    ).tree
+    return Theta(res)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -7,15 +7,21 @@
 # This file contains overrides of the standard ops for normal torch and
 # generic primitive/quantized types.
 
-from typing import Optional, List
+from typing import Optional, List, Sequence
 
 import torch
 from torch import Tensor, dtype
 import torch.nn.functional as F
 
 from ..types import PrimitiveTensor, QuantizedTensor
-from ._registry import unbox_tensor
+from ._registry import unbox_tensor, AllOfType
 from .signatures import *
+
+
+@cat.override(AllOfType(Tensor, PrimitiveTensor))
+def cat_default(tensors: Sequence[Tensor | PrimitiveTensor], dim: int):
+    return torch.cat([unbox_tensor(t) for t in tensors], dim)
+
 
 # conv2d
 

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -19,7 +19,7 @@ class Sharding(ABC):
 
 class TensorSharding(Sharding):
     def __init__(self, *, shard_count: int):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
 
 
@@ -77,7 +77,7 @@ class ThetaLayerSharding(Sharding):
 
 class Conv2DSplitOutputChannelSharding(ThetaLayerSharding):
     def __init__(self, shard_count: int):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
 
     def theta_sharding(self) -> ThetaSharding:
@@ -91,7 +91,7 @@ class Conv2DSplitOutputChannelSharding(ThetaLayerSharding):
 
 class GroupNormSplitChannelSharding(ThetaLayerSharding):
     def __init__(self, shard_count: int):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
 
     def theta_sharding(self) -> ThetaSharding:
@@ -105,7 +105,7 @@ class GroupNormSplitChannelSharding(ThetaLayerSharding):
 
 class LinearReplicatedInputSplitWeightAndBiasSharding(ThetaLayerSharding):
     def __init__(self, shard_count: int, weight_and_bias_spit_dim: int = 0):
-        super(Sharding).__init__()
+        super().__init__()
         self.shard_count = shard_count
         self.weight_and_bias_spit_dim = weight_and_bias_spit_dim
 

--- a/sharktank/sharktank/types/sharding.py
+++ b/sharktank/sharktank/types/sharding.py
@@ -8,6 +8,8 @@
 sharded."""
 
 from abc import ABC, abstractmethod
+from ..utils import tree
+from ..types.theta import flat_to_nested_dict
 
 
 class Sharding(ABC):
@@ -43,7 +45,13 @@ class ThetaSharding(dict):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        d = flat_to_nested_dict(dict(*args, **kwargs))
+        for k, v in d.items():
+            d[k] = tree.map_nodes(
+                tree=v,
+                f=lambda x: x if isinstance(x, TensorSharding) else ThetaSharding(x),
+            )
+        super().__init__(d)
 
 
 class ThetaLayerSharding(Sharding):

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, Callable, Optional, Union, TypeVar, Generic, Type
+from typing import Any, Callable, Optional, Union, TypeVar, Generic, Type, Iterable
 from copy import deepcopy
 from collections.abc import Collection
 from numbers import Integral
@@ -17,19 +17,21 @@ from ..utils.math import ceildiv
 from shark_turbine.aot import (
     ExternalTensorTrait,
 )
+from ..utils import tree as tree_utils
 
 from ..utils.io import ShardedArchiveBuilder
 
 __all__ = [
     "AnyTensor",
-    "register_quantized_layout",
+    "DefaultPrimitiveTensor",
+    "flatten_tensor_tree",
     "InferenceTensor",
     "MetaDataValueType",
-    "DefaultPrimitiveTensor",
     "PlanarQuantizedTensor",
     "PrimitiveTensor",
-    "QuantizedTensor",
     "QuantizedLayout",
+    "QuantizedTensor",
+    "register_quantized_layout",
     "ReplicatedTensor",
     "ShardedTensor",
     "SplitPrimitiveTensor",
@@ -931,6 +933,21 @@ class UnreducedTensor(ShardedTensorBase):
         shape = list(ts[0].shape if shape is None else shape)
         assert all(shape == list(t.shape) for t in ts)
         super().__init__(name=name, ts=ts, shape=shape, shard_dim=None)
+
+
+def flatten_tensor_tree(
+    tree: tree_utils.Tree,
+) -> Iterable[torch.Tensor | InferenceTensor]:
+    return tree_utils.flatten(
+        tree,
+        is_leaf=lambda x: isinstance(
+            x,
+            (
+                torch.Tensor,
+                InferenceTensor,
+            ),
+        ),
+    )
 
 
 ########################################################################################

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -33,6 +33,7 @@ from .tensors import (
 
 __all__ = [
     "Dataset",
+    "flat_to_nested_dict",
     "Theta",
 ]
 
@@ -82,7 +83,7 @@ class Theta:
             tensors = {t.name: t for t in tensors}
         assert all(isinstance(k, str) for k in _all_keys(tensors))
         assert all(isinstance(v, InferenceTensor) for v in _leaf_values(tensors))
-        self._tree = _flat_to_nested_dict(tensors)
+        self._tree = flat_to_nested_dict(tensors)
 
     def transform(self, *transforms: InferenceTensorTransform) -> "Theta":
         """Transforms all inference tensors by applying transform functions.
@@ -191,7 +192,28 @@ class Theta:
             inference_tensor_metas[name] = meta
 
 
-def _flat_to_nested_dict(flat: dict[str, Any]) -> dict[str, Any]:
+def flat_to_nested_dict(flat: dict[str, Any]) -> dict[str, Any]:
+    """Nest a flat or semi-flat dictionary.
+
+    The key nesting separator is the "." symbol.
+    Example:
+    ```python
+    flat_to_nested_dict({
+        "a.b": 0,
+        "a": { "c": 1 }
+    })
+    ```
+
+    Results in:
+    ```python
+    {
+        "a": {
+            "b": 0,
+            "c": 1
+        }
+    }
+    ```
+    """
     nested: dict = {}
 
     def add_to_dict(

--- a/sharktank/sharktank/utils/tree.py
+++ b/sharktank/sharktank/utils/tree.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Dict, Any, Callable, Mapping, Iterable, Sequence, Union
+from collections.abc import Mapping as MappingABC, Iterable as IterableABC
+
+Key = Any
+Leaf = Any
+Tree = Mapping[Key, Union[Leaf, "Tree"]] | Iterable[Union[Leaf, "Tree"]] | Leaf
+IsLeaf = Callable[[Tree], bool]
+
+
+def is_leaf_default(tree: Tree) -> bool:
+    return not isinstance(tree, IterableABC)
+
+
+def map_nodes(
+    tree: Tree, f: Callable[[Tree], Tree], is_leaf: IsLeaf | None = None
+) -> Tree:
+    """Apply `f` for each node in the tree. Leaves and branches.
+
+    This includes the root `tree` as well."""
+    if is_leaf is None:
+        is_leaf = is_leaf_default
+
+    if is_leaf(tree):
+        return f(tree)
+    elif isinstance(tree, MappingABC):
+        return f({k: map_nodes(v, f, is_leaf) for k, v in tree.items()})
+    else:
+        return f([map_nodes(v, f, is_leaf) for v in tree])
+
+
+def flatten(tree: Tree, is_leaf: IsLeaf | None = None) -> Sequence[Leaf]:
+    """Get the leaves of the tree."""
+    return [x for x in _flatten(tree, is_leaf)]
+
+
+def _flatten(tree: Tree, is_leaf: IsLeaf | None = None) -> Iterable[Leaf]:
+    if is_leaf is None:
+        is_leaf = is_leaf_default
+    if is_leaf(tree):
+        yield tree
+    elif isinstance(tree, MappingABC):
+        for v in tree.values():
+            yield from flatten(v, is_leaf)
+    else:
+        for v in tree:
+            yield from flatten(v, is_leaf)

--- a/sharktank/tests/models/punet/up_down_block_test.py
+++ b/sharktank/tests/models/punet/up_down_block_test.py
@@ -1,0 +1,144 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+from typing import List
+from parameterized import parameterized
+
+import torch
+
+from sharktank.models.punet.testing import make_up_down_block_2d_theta
+from sharktank.models.punet.layers import UpDownBlock2D
+from sharktank.models.punet.sharding import UpDownBlock2DSplitChannelsSharing
+from sharktank.types import *
+from sharktank import ops
+from sharktank.types.tensors import flatten_tensor_tree
+
+
+class UpBlock2DTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+        ]
+    )
+    def testUpDownBlock2DSplitInputAndOutputChannelsSharding(self, is_up_block: bool):
+        torch.set_default_dtype(torch.float32)
+        batches = 2
+        channels = 12
+        height = 11
+        width = 13
+        kernel_height = 5
+        kernel_width = 5
+        input_time_emb_shape = [batches, channels]
+        norm_groups = 2
+        eps = 0.01
+        shard_count = 2
+        resnet_layers = 2
+        theta = make_up_down_block_2d_theta(
+            channels=channels,
+            kernel_height=kernel_height,
+            kernel_width=kernel_width,
+            input_time_emb_channels=channels,
+            resnet_layers=resnet_layers,
+            is_up_block=is_up_block,
+        )
+        block = UpDownBlock2D(
+            theta=theta,
+            num_layers=resnet_layers,
+            resnet_eps=eps,
+            resnet_act_fn="relu",
+            resnet_groups=norm_groups,
+            resnet_out_scale_factor=None,
+            resnet_time_scale_shift="default",
+            temb_channels=channels,
+            dropout=0.0,
+            add_upsample=is_up_block,
+            add_downsample=not is_up_block,
+            downsample_padding=1,
+        )
+        input_image = torch.rand(
+            batches,
+            channels // 2,
+            height,
+            width,
+        )
+        input_time_emb = torch.rand(input_time_emb_shape)
+        res_hidden_states_tuple = [
+            torch.rand(
+                batches,
+                channels // 2,
+                height - 2 * i * (kernel_height // 2),
+                width - 2 * i * (kernel_width // 2),
+            )
+            for i in range(resnet_layers)
+        ]
+        res_hidden_states_tuple.reverse()
+
+        expected_result = flatten_tensor_tree(
+            block(
+                hidden_states=input_image,
+                temb=input_time_emb,
+                res_hidden_states_tuple=res_hidden_states_tuple,
+                encoder_hidden_states=None,
+                attention_mask=None,
+                encoder_attention_mask=None,
+            )
+        )
+
+        sharding_spec = UpDownBlock2DSplitChannelsSharing(
+            shard_count=shard_count,
+            resnet_layers_count=resnet_layers,
+            upsamplers_count=1 if is_up_block else 0,
+            downsamplers_count=1 if not is_up_block else 0,
+        )
+        sharded_theta = ops.reshard(theta, sharding_spec)
+        sharded_block = UpDownBlock2D(
+            theta=sharded_theta,
+            num_layers=resnet_layers,
+            resnet_eps=eps,
+            resnet_act_fn="relu",
+            resnet_groups=norm_groups,
+            resnet_out_scale_factor=None,
+            resnet_time_scale_shift="default",
+            temb_channels=channels,
+            dropout=0.0,
+            add_upsample=is_up_block,
+            add_downsample=not is_up_block,
+            downsample_padding=1,
+        )
+        sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
+        sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
+        sharded_res_hidden_states_tuple = [
+            ops.reshard_split(tensor, dim=1, count=shard_count)
+            for tensor in res_hidden_states_tuple
+        ]
+        sharded_result = flatten_tensor_tree(
+            sharded_block(
+                hidden_states=sharded_input_image,
+                temb=sharded_input_time_emb,
+                res_hidden_states_tuple=sharded_res_hidden_states_tuple,
+                encoder_hidden_states=None,
+                attention_mask=None,
+                encoder_attention_mask=None,
+            )
+        )
+        assert all(
+            [
+                isinstance(r, SplitPrimitiveTensor)
+                and r.shard_dim == 1
+                and r.shard_count == shard_count
+                for r in sharded_result
+            ]
+        )
+        actual_result = [ops.unshard(r) for r in sharded_result]
+        assert len(expected_result) == len(actual_result)
+        for actual, expected in zip(actual_result, expected_result):
+            torch.testing.assert_close(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -15,6 +15,40 @@ from sharktank.types import sharding
 from sharktank.layers import Conv2DLayer
 
 
+class CatTest(unittest.TestCase):
+    def testCatSplitDim(self):
+        """Concatenation along the sharded split dimension."""
+        shard_dim = 1
+        shard_count = 2
+        cat_dim = 1
+        a = torch.rand(3, 6, dtype=torch.float32)
+        b = torch.rand(3, 4, dtype=torch.float32)
+        unsharded_result = torch.cat([a, b], dim=cat_dim)
+        expected_result = ops.reshard_split(
+            unsharded_result, count=shard_count, dim=shard_dim
+        )
+        sharded_a = ops.reshard_split(a, count=shard_count, dim=shard_dim)
+        sharded_b = ops.reshard_split(b, count=shard_count, dim=shard_dim)
+        actual_result = ops.cat([sharded_a, sharded_b], dim=cat_dim)
+        assert ops.equal(expected_result, actual_result)
+
+    def testCatNonSplitDim(self):
+        """Concatenation along a non-split dimension."""
+        shard_dim = 1
+        shard_count = 2
+        cat_dim = 0
+        a = torch.rand(5, 4, dtype=torch.float32)
+        b = torch.rand(3, 4, dtype=torch.float32)
+        unsharded_result = torch.cat([a, b], dim=cat_dim)
+        expected_result = ops.reshard_split(
+            unsharded_result, count=shard_count, dim=shard_dim
+        )
+        sharded_a = ops.reshard_split(a, count=shard_count, dim=shard_dim)
+        sharded_b = ops.reshard_split(b, count=shard_count, dim=shard_dim)
+        actual_result = ops.cat([sharded_a, sharded_b], dim=cat_dim)
+        assert ops.equal(expected_result, actual_result)
+
+
 class ConvTest(unittest.TestCase):
     def testAllGather(self):
         shard_count = 3


### PR DESCRIPTION
Add sharded cat with inefficient implementation.

Allow for overriding based on a general boolean type expression in SignatureDispatcher. This is used in the cat signature dispatch where we have a collection of tensors.

Add some tree structure utilities.