### PR TITLE
Update the bias outs to use  for the conv_nchw template

### DIFF
--- a/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
+++ b/sharktank/sharktank/kernels/templates/conv_2d_nchw_fchw.mlir
@@ -41,7 +41,7 @@ util.func private @sharktank_conv_2d_nchw_fchw_{{spec_sig}}
       indexing_maps = [#map0, #map1, #map0],
       iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%result, %bias : !result_asm_type, !bias_asm_type)
-    outs(%result : !result_asm_type) {
+    outs(%result_empty : !result_asm_type) {
     ^bb0(%in: !accum_type, %in_1: !accum_type, %out: !accum_type):
       %add = {{add_op}} %in, %in_1 : !accum_type
       linalg.yield %add : !accum_type


### PR DESCRIPTION
This is a non-canonical form of linalg.generic because elementwise generics completely overwrite their output contents. By using an empty this removes a use of the conv and improves the ability for the compiler to optimize it.