### PR TITLE
Allow sharktank tensors to be part of export function signatures

### DIFF
--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -196,6 +196,13 @@ class Theta:
             meta = inference_tensor.add_to_archive(irpa)
             inference_tensor_metas[name] = meta
 
+    def rename_tensors_to_paths(self):
+        """Rename each tensor to have name equal to its path in the theta.
+        Example: name="a.b.c"
+        """
+        for path, tensor in self.flatten().items():
+            tensor.name = path
+
 
 def flat_to_nested_dict(flat: dict[str, Any]) -> dict[str, Any]:
     """Nest a flat or semi-flat dictionary.


### PR DESCRIPTION
Adds flattening and unflattening of our tensor types according to torch requirements.
This allows us to pass and return such tensors when exporting functions.

Add function to populate names of tensors in a theta with the natural name corresponding to its path in the theta.
When exporting a dataset each tensor must have a unique name.

Make name a property in InferenceTensor.
Renaming of sharded tensors needs to rename the shards as well.