### PR TITLE
[punet] Implement QKV quantization fusion and adapt to Brevitas mechanism.

### DIFF
--- a/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
+++ b/sharktank/sharktank/models/punet/tools/import_brevitas_dataset.py
@@ -169,7 +169,7 @@ def apply_per_layer_quant(
         updated_tensors[bias_quant.name] = bias_quant
 
     # If dealing with a fused QKV layer, then we need to split the weight as
-    # Brevitas concats it along the [n * input_dim, output_dim] axis, where
+    # Brevitas concats it along the [n * output_dim, input_dim] axis, where
     # n is 2 (to_kv) or 3 (to_qkv).
     # We do this here vs in the model since it is much more efficient to
     # operate on the weights contiguously at rest.

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -82,7 +82,9 @@ class Theta:
         if not isinstance(tensors, dict):
             tensors = {t.name: t for t in tensors}
         assert all(isinstance(k, str) for k in _all_keys(tensors))
-        assert all(isinstance(v, InferenceTensor) for v in _leaf_values(tensors))
+        assert all(
+            v is None or isinstance(v, InferenceTensor) for v in _leaf_values(tensors)
+        )
         self._tree = flat_to_nested_dict(tensors)
 
     def transform(self, *transforms: InferenceTensorTransform) -> "Theta":
@@ -149,6 +151,9 @@ class Theta:
     @property
     def keys(self) -> Collection[str]:
         return self._tree.keys()
+
+    def __contains__(self, key) -> bool:
+        return key in self._tree
 
     @property
     def tensors(self) -> Collection[InferenceTensor]:
@@ -230,7 +235,8 @@ def flat_to_nested_dict(flat: dict[str, Any]) -> dict[str, Any]:
             assert isinstance(
                 current, dict
             ), f"Name collision in parameter dict: {name}"
-        current[parts[-1]] = value
+        if value is not None:
+            current[parts[-1]] = value
 
     for name, value in flat.items():
         add_to_dict(name, value)


### PR DESCRIPTION
This patch enables quantization activation fusion of either qkv (for MHA) or kv (for MCHA) attention layers.

In the model, this is selected based on the presence of either a `to_kv` or `to_qkv` theta on each attention layer. Normally, a LinearLayer handles all quantization inside of itself, but in this case, we decompose what the LinearLayer usually does by explicitly performing activation quantization using either qkv or kv shared input conditioning, then proceed with the normal computation and dequant.

The Brevitas import is a bit finnicky in this case because the current version of it concats the kv or qkv weights/scales/bias/zp in an attempt to only have one set of each. However, it is a more natural representation (and leaves less room for optimization failures) to simply populate the dataset with the data at rest how we intend to use it. So we reorganize into this structure:

```
attn0.to_qkv
  premul_input
  qinput
  to_q.weight
  to_q.bias
  to_k.weight
  to_k.bias
  to_v.weight
  to_v.bias
```

(to_kv is similar but does not include the q within it, leaving it at the top, unfused level)

We may want to switch the quantizer to a more natural (for us) representation.