### PR TITLE
Add flag use_custom_iree_kernels (default True).

### DIFF
--- a/sharktank/integration/models/punet/integration_test.py
+++ b/sharktank/integration/models/punet/integration_test.py
@@ -246,8 +246,7 @@ def test_punet_eager_int8_emulated_validation(
     print("Using torch device:", device)
     with testing.override_debug_flags(
         {
-            "use_custom_int_conv_kernel": False,
-            "use_custom_int_mm_kernel": False,
+            "use_custom_iree_kernels": False,
         }
     ):
         run_punet.main(

--- a/sharktank/sharktank/ops/attention_impls.py
+++ b/sharktank/sharktank/ops/attention_impls.py
@@ -72,6 +72,7 @@ def flash_attention(q, k, v, a):
     return atten
 
 
-scaled_dot_product_attention.override(AnyTensor, AnyTensor, AnyTensor, NoneType)(
-    flash_attention
-)
+if debugging.flags.use_custom_iree_kernels:
+    scaled_dot_product_attention.override(AnyTensor, AnyTensor, AnyTensor, NoneType)(
+        flash_attention
+    )

--- a/sharktank/sharktank/ops/qconv_impls.py
+++ b/sharktank/sharktank/ops/qconv_impls.py
@@ -203,7 +203,7 @@ def _invoke_int32_conv2d(input, weight, bias, stride, dilation, *, accum_dtype):
     It is advantageous in some situations to use fp emulation of an int kernel
     so we fork here.
     """
-    if debugging.flags.use_custom_int_conv_kernel:
+    if debugging.flags.use_custom_iree_kernels:
         # True int kernel.
         if bias is None:
             # We don't have any non-test use of convs without bias, so just
@@ -237,7 +237,7 @@ def _invoke_int32_pooling_sum(input, kernel_size, stride, dilation, *, accum_dty
     """Invokes either a custom integer pooling sum or the built-in fp avg_pool2d
     kernel on an explicitly padded input.
     """
-    if debugging.flags.use_custom_int_conv_kernel:
+    if debugging.flags.use_custom_iree_kernels:
         output = kernels.pooling_nchw_sum(
             input,
             kernel_size,

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -167,7 +167,7 @@ linear.override(Tensor, QuantizedTensor, AnyTensor)(linear_quantized_weight)
 
 
 def _invoke_int32_mmt(lhs, rhs, *, accum_dtype):
-    if debugging.flags.use_custom_int_mm_kernel:
+    if debugging.flags.use_custom_iree_kernels:
         # The custom kernel requires that the lhs and rhs be the same
         # rank. Broadcast the rhs to match.
         lhs_rank = len(lhs.shape)

--- a/sharktank/sharktank/utils/debugging.py
+++ b/sharktank/sharktank/utils/debugging.py
@@ -33,8 +33,11 @@ class DebugFlags:
     golden_sequence_value: int = 0
 
     # Feature flags.
-    use_custom_int_conv_kernel: bool = True
-    use_custom_int_mm_kernel: bool = True
+    # Enables use of custom IREE kernels in lieu of PyTorch general
+    # for certain low level operations. We'd like to remove this flag but
+    # certain eager use cases are still having problems with these custom
+    # kernels, so keeping it to unblock progress.
+    use_custom_iree_kernels: bool = True
 
     def set(self, part: str):
         m = re.match(SETTING_PART_PATTERN, part)
@@ -51,10 +54,8 @@ class DebugFlags:
             self.enable_nan_checks = logical_sense
         elif name == "save_goldens_path":
             self.save_goldens_path = Path(value)
-        elif name == "use_custom_int_conv_kernel":
-            self.use_custom_int_conv_kernel = logical_sense
-        elif name == "use_custom_int_mm_kernel":
-            self.use_custom_int_mm_kernel = logical_sense
+        elif name == "use_custom_iree_kernels":
+            self.use_custom_iree_kernels = logical_sense
         else:
             logger.warn("Unrecognized %s flag: '%s'", FLAGS_ENV_NAME, name)
 


### PR DESCRIPTION
Gates integer mm/conv and custom attention impl.

Subsumes the individual use_custom_int_conv_kernel and use_custom_int_mm_kernel flags.

I would like to remove this flag entirely as it is unsound, but also we are still working out bugs in our eager interop and need to have an escape hatch.