### PR TITLE
Disable FA kernel for unquantized

### DIFF
--- a/sharktank/sharktank/ops/attention_impls.py
+++ b/sharktank/sharktank/ops/attention_impls.py
@@ -73,6 +73,6 @@ def flash_attention(q, k, v, a):
 
 
 if debugging.flags.use_custom_iree_kernels:
-    scaled_dot_product_attention.override(AnyTensor, AnyTensor, AnyTensor, NoneType)(
-        flash_attention
-    )
+    scaled_dot_product_attention.override(
+        PlanarQuantizedTensor, PlanarQuantizedTensor, PlanarQuantizedTensor, NoneType
+    )(flash_attention)


### PR DESCRIPTION
`iree-compile` needs to still catch up on compilation path. Reverting on
`f16` tensors until the feature fixes.