### PR TITLE
[shortfin] Plumb through await handling to Python asyncio.

### DIFF
--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -24,6 +24,20 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_SCAN_FOR_MODULES 0)
 
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)
+option(SHORTFIN_BUILD_TESTS "Builds C++ tests" ON)
+
+if(SHORTFIN_BUILD_TESTS)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  )
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+  include(GoogleTest)
+  enable_testing()
+endif()
 
 # Includes.
 list(APPEND CMAKE_MODULE_PATH

--- a/libshortfin/bindings/python/lib_ext.cc
+++ b/libshortfin/bindings/python/lib_ext.cc
@@ -474,19 +474,19 @@ void BindLocal(py::module_ &m) {
       .def("__await__",
            [](PyProcess &self) {
              py::object future =
-                 py::cast(local::SingleWaitFuture(self.OnTermination()),
+                 py::cast(local::CompletionEvent(self.OnTermination()),
                           py::rv_policy::move);
              return future.attr("__await__")();
            })
       .def("__repr__", &PyProcess::to_s);
 
-  py::class_<local::SingleWaitFuture>(m, "SingleWaitFuture")
+  py::class_<local::CompletionEvent>(m, "CompletionEvent")
       .def(py::init<>())
-      .def("__await__", [refs](local::SingleWaitFuture &self) {
+      .def("__await__", [refs](local::CompletionEvent &self) {
         auto &worker = PyWorker::GetCurrent(*refs);
         struct State {
           py::object future;
-          local::SingleWaitFuture
+          local::CompletionEvent
               awaitable;  // Keeps the wait_source backer alive.
         };
         auto state = std::make_unique<State>();

--- a/libshortfin/bindings/python/lib_ext.cc
+++ b/libshortfin/bindings/python/lib_ext.cc
@@ -470,6 +470,7 @@ void BindLocal(py::module_ &m) {
             return custom_new<PyProcess>(py_type, std::move(scope), refs);
           },
           py::arg("type"), py::arg("args"), py::arg("scope"), py::arg("kwargs"))
+      .def_prop_ro("pid", &PyProcess::pid)
       .def_prop_ro("scope", &PyProcess::scope)
       .def("launch",
            [](py::object self_obj) {

--- a/libshortfin/bindings/python/shortfin/__init__.py
+++ b/libshortfin/bindings/python/shortfin/__init__.py
@@ -13,6 +13,7 @@ Node = _sfl.local.Node
 Process = _sfl.local.Process
 Scope = _sfl.local.Scope
 ScopedDevice = _sfl.local.ScopedDevice
+SingleWaitFuture = _sfl.local.SingleWaitFuture
 System = _sfl.local.System
 SystemBuilder = _sfl.local.SystemBuilder
 Worker = _sfl.local.Worker
@@ -29,6 +30,7 @@ __all__ = [
     "Node",
     "Scope",
     "ScopedDevice",
+    "SingleWaitFuture",
     "System",
     "SystemBuilder",
     "Worker",

--- a/libshortfin/bindings/python/shortfin/__init__.py
+++ b/libshortfin/bindings/python/shortfin/__init__.py
@@ -13,7 +13,7 @@ Node = _sfl.local.Node
 Process = _sfl.local.Process
 Scope = _sfl.local.Scope
 ScopedDevice = _sfl.local.ScopedDevice
-SingleWaitFuture = _sfl.local.SingleWaitFuture
+CompletionEvent = _sfl.local.CompletionEvent
 System = _sfl.local.System
 SystemBuilder = _sfl.local.SystemBuilder
 Worker = _sfl.local.Worker
@@ -30,7 +30,7 @@ __all__ = [
     "Node",
     "Scope",
     "ScopedDevice",
-    "SingleWaitFuture",
+    "CompletionEvent",
     "System",
     "SystemBuilder",
     "Worker",

--- a/libshortfin/build_tools/cmake/shortfin_library.cmake
+++ b/libshortfin/build_tools/cmake/shortfin_library.cmake
@@ -105,3 +105,26 @@ function(shortfin_components_to_dynamic_libs out_dynamic_libs)
   list(TRANSFORM _LIBS APPEND ".dylib.objects")
   set(${out_dynamic_libs} "${_LIBS}" PARENT_SCOPE)
 endfunction()
+
+function(shortfin_gtest_test)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DEPS"
+    ${ARGN}
+  )
+
+  if(NOT SHORTFIN_BUILD_TESTS)
+    return()
+  endif()
+
+  add_executable(${_RULE_NAME} ${_RULE_SRCS})
+  target_link_libraries(${_RULE_NAME} PRIVATE
+    ${_RULE_DEPS}
+    shortfin
+    GTest::gmock
+    GTest::gtest_main
+  )
+  gtest_discover_tests(${_RULE_NAME})
+endfunction()

--- a/libshortfin/examples/python/device_sync.py
+++ b/libshortfin/examples/python/device_sync.py
@@ -29,5 +29,6 @@ async def main():
     print("--- Process terminated")
 
 
-lsys = sf.host.CPUSystemBuilder().create_system()
+# lsys = sf.host.CPUSystemBuilder().create_system()
+lsys = sf.amdgpu.SystemBuilder().create_system()
 lsys.run(main())

--- a/libshortfin/examples/python/device_sync.py
+++ b/libshortfin/examples/python/device_sync.py
@@ -13,20 +13,16 @@ import shortfin.array as snp
 
 
 class MyProcess(sf.Process):
-    def __init__(self, name, **kwargs):
-        super().__init__(**kwargs)
-        self.name = name
-
     async def run(self):
         device = self.scope.device(0)
         ary1 = snp.device_array(device, [32, 1, 4], snp.int32)
         ary1.storage.fill(array.array("i", [0]))
-        print(f"[{self.name}] ARY1:", ary1)
+        print(f"[pid:{self.pid}] ARY1:", ary1)
         await device
-        print(f"[{self.name}] Device sync fill0")
+        print(f"[pid:{self.pid}] Device sync fill0")
         ary1.storage.fill(array.array("i", [1]))
         await device
-        print(f"[{self.name}] Device sync fill1")
+        print(f"[pid:{self.pid}] Device sync fill1")
 
 
 async def main():
@@ -34,8 +30,8 @@ async def main():
     scope = lsys.create_scope(worker)
     print("+++ Launching process")
     await asyncio.gather(
-        MyProcess("P0", scope=scope).launch(),
-        MyProcess("P1", scope=scope).launch(),
+        MyProcess(scope=scope).launch(),
+        MyProcess(scope=scope).launch(),
     )
     print("--- Process terminated")
 

--- a/libshortfin/examples/python/device_sync.py
+++ b/libshortfin/examples/python/device_sync.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import array
+import asyncio
+
+import shortfin as sf
+import shortfin.array as snp
+
+
+class MyProcess(sf.Process):
+    async def run(self):
+        device = self.scope.device(0)
+        ary1 = snp.device_array(device, [32, 1, 4], snp.int32)
+        ary1.storage.fill(array.array("i", [0]))
+        print("ARY1:", ary1)
+        await device
+
+
+async def main():
+    worker = lsys.create_worker("main")
+    scope = lsys.create_scope(worker)
+    print("+++ Launching process")
+    await MyProcess(scope).launch()
+    print("--- Process terminated")
+
+
+lsys = sf.host.CPUSystemBuilder().create_system()
+lsys.run(main())

--- a/libshortfin/examples/python/device_sync.py
+++ b/libshortfin/examples/python/device_sync.py
@@ -13,22 +13,33 @@ import shortfin.array as snp
 
 
 class MyProcess(sf.Process):
+    def __init__(self, name, **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+
     async def run(self):
         device = self.scope.device(0)
         ary1 = snp.device_array(device, [32, 1, 4], snp.int32)
         ary1.storage.fill(array.array("i", [0]))
-        print("ARY1:", ary1)
+        print(f"[{self.name}] ARY1:", ary1)
         await device
+        print(f"[{self.name}] Device sync fill0")
+        ary1.storage.fill(array.array("i", [1]))
+        await device
+        print(f"[{self.name}] Device sync fill1")
 
 
 async def main():
     worker = lsys.create_worker("main")
     scope = lsys.create_scope(worker)
     print("+++ Launching process")
-    await MyProcess(scope).launch()
+    await asyncio.gather(
+        MyProcess("P0", scope=scope).launch(),
+        MyProcess("P1", scope=scope).launch(),
+    )
     print("--- Process terminated")
 
 
-# lsys = sf.host.CPUSystemBuilder().create_system()
-lsys = sf.amdgpu.SystemBuilder().create_system()
+lsys = sf.host.CPUSystemBuilder().create_system()
+# lsys = sf.amdgpu.SystemBuilder().create_system()
 lsys.run(main())

--- a/libshortfin/examples/python/process.py
+++ b/libshortfin/examples/python/process.py
@@ -19,21 +19,27 @@ class MyProcess(sf.Process):
 
     async def run(self):
         print("Hello async:", self.arg, self)
+        processes = []
         if self.arg < 10:
             await asyncio.sleep(0.3)
-            MyProcess(self.scope, self.arg + 1).launch()
+            processes.append(MyProcess(self.scope, self.arg + 1).launch())
+        await asyncio.gather(*processes)
 
 
 async def main():
     worker = lsys.create_worker("main")
     scope = lsys.create_scope(worker)
+    processes = []
     for i in range(10):
-        MyProcess(scope, i).launch()
+        processes.append(MyProcess(scope, i).launch())
         await asyncio.sleep(0.1)
-        MyProcess(scope, i * 100).launch()
+        processes.append(MyProcess(scope, i * 100).launch())
         await asyncio.sleep(0.1)
-        MyProcess(scope, i * 1000).launch()
-    await asyncio.sleep(2.5)
+        processes.append(MyProcess(scope, i * 1000).launch())
+
+    print("<<MAIN WAITING>>")
+    await asyncio.gather(*processes)
+    print("** MAIN DONE **")
     return i
 
 

--- a/libshortfin/examples/python/process.py
+++ b/libshortfin/examples/python/process.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import asyncio
+import threading
 
 import shortfin as sf
 
@@ -18,7 +19,7 @@ class MyProcess(sf.Process):
         self.arg = arg
 
     async def run(self):
-        print("Hello async:", self.arg, self)
+        print(f"[{threading.get_ident()}] Hello async:", self.arg, self)
         processes = []
         if self.arg < 10:
             await asyncio.sleep(0.3)
@@ -32,10 +33,9 @@ async def main():
     processes = []
     for i in range(10):
         processes.append(MyProcess(scope, i).launch())
-        await asyncio.sleep(0.1)
         processes.append(MyProcess(scope, i * 100).launch())
-        await asyncio.sleep(0.1)
         processes.append(MyProcess(scope, i * 1000).launch())
+        await asyncio.sleep(0.1)
 
     print("<<MAIN WAITING>>")
     await asyncio.gather(*processes)

--- a/libshortfin/examples/python/process.py
+++ b/libshortfin/examples/python/process.py
@@ -14,8 +14,8 @@ lsys = sf.host.CPUSystemBuilder().create_system()
 
 
 class MyProcess(sf.Process):
-    def __init__(self, scope, arg):
-        super().__init__(scope)
+    def __init__(self, arg, **kwargs):
+        super().__init__(**kwargs)
         self.arg = arg
 
     async def run(self):
@@ -23,7 +23,7 @@ class MyProcess(sf.Process):
         processes = []
         if self.arg < 10:
             await asyncio.sleep(0.3)
-            processes.append(MyProcess(self.scope, self.arg + 1).launch())
+            processes.append(MyProcess(self.arg + 1, scope=self.scope).launch())
         await asyncio.gather(*processes)
 
 
@@ -32,9 +32,9 @@ async def main():
     scope = lsys.create_scope(worker)
     processes = []
     for i in range(10):
-        processes.append(MyProcess(scope, i).launch())
-        processes.append(MyProcess(scope, i * 100).launch())
-        processes.append(MyProcess(scope, i * 1000).launch())
+        processes.append(MyProcess(i, scope=scope).launch())
+        processes.append(MyProcess(i * 100, scope=scope).launch())
+        processes.append(MyProcess(i * 1000, scope=scope).launch())
         await asyncio.sleep(0.1)
 
     print("<<MAIN WAITING>>")

--- a/libshortfin/examples/python/process.py
+++ b/libshortfin/examples/python/process.py
@@ -36,9 +36,9 @@ async def main():
     workers = [create_worker(i) for i in range(3)]
     processes = []
     for i in range(10):
-        processes.append(MyProcess(i, scope=workers[0 % len(workers)]).launch())
-        processes.append(MyProcess(i * 100, scope=workers[1 % len(workers)]).launch())
-        processes.append(MyProcess(i * 1000, scope=workers[2 % len(workers)]).launch())
+        processes.append(MyProcess(i, scope=workers[i % len(workers)]).launch())
+        processes.append(MyProcess(i * 100, scope=workers[i % len(workers)]).launch())
+        processes.append(MyProcess(i * 1000, scope=workers[i % len(workers)]).launch())
         await asyncio.sleep(0.1)
 
     print("<<MAIN WAITING>>")

--- a/libshortfin/src/shortfin/array/storage.cc
+++ b/libshortfin/src/shortfin/array/storage.cc
@@ -74,7 +74,6 @@ storage storage::Subspan(iree_device_size_t byte_offset,
 void storage::Fill(const void *pattern, iree_host_size_t pattern_length) {
   device_.scope().scheduler().AppendCommandBuffer(
       device_, TransactionType::TRANSFER, [&](Account &account) {
-        logging::info("AppendCommandBuffer() CALLBACK");
         // Must depend on all of this buffer's use dependencies to avoid
         // write-after-read hazard.
         account.active_deps_extend(timeline_resource_->use_barrier());

--- a/libshortfin/src/shortfin/array/storage.cc
+++ b/libshortfin/src/shortfin/array/storage.cc
@@ -28,7 +28,7 @@ storage storage::AllocateDevice(ScopedDevice &device,
     throw std::invalid_argument("Cannot allocate with a null device affinity");
   }
   auto allocator = iree_hal_device_allocator(device.raw_device()->hal_device());
-  iree_hal_buffer_ptr buffer;
+  iree::hal_buffer_ptr buffer;
   iree_hal_buffer_params_t params = {
       .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       .access = IREE_HAL_MEMORY_ACCESS_ALL,
@@ -47,7 +47,7 @@ storage storage::AllocateHost(ScopedDevice &device,
     throw std::invalid_argument("Cannot allocate with a null device affinity");
   }
   auto allocator = iree_hal_device_allocator(device.raw_device()->hal_device());
-  iree_hal_buffer_ptr buffer;
+  iree::hal_buffer_ptr buffer;
   iree_hal_buffer_params_t params = {
       .usage = IREE_HAL_BUFFER_USAGE_MAPPING,
       .access = IREE_HAL_MEMORY_ACCESS_ALL,

--- a/libshortfin/src/shortfin/array/storage.h
+++ b/libshortfin/src/shortfin/array/storage.h
@@ -56,12 +56,12 @@ class SHORTFIN_API storage {
   std::string to_s() const;
 
  private:
-  storage(local::ScopedDevice device, iree_hal_buffer_ptr buffer,
+  storage(local::ScopedDevice device, iree::hal_buffer_ptr buffer,
           local::detail::TimelineResource::Ref timeline_resource)
       : buffer_(std::move(buffer)),
         device_(device),
         timeline_resource_(std::move(timeline_resource)) {}
-  iree_hal_buffer_ptr buffer_;
+  iree::hal_buffer_ptr buffer_;
   local::ScopedDevice device_;
   local::detail::TimelineResource::Ref timeline_resource_;
 };

--- a/libshortfin/src/shortfin/local/CMakeLists.txt
+++ b/libshortfin/src/shortfin/local/CMakeLists.txt
@@ -10,6 +10,7 @@ shortfin_cc_component(
   NAME
     shortfin_local
   HDRS
+    async.h
     device.h
     process.h
     worker.h
@@ -17,6 +18,7 @@ shortfin_cc_component(
     scope.h
     system.h
   SRCS
+    async.cc
     device.cc
     process.cc
     worker.cc

--- a/libshortfin/src/shortfin/local/async.cc
+++ b/libshortfin/src/shortfin/local/async.cc
@@ -1,0 +1,49 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/local/async.h"
+
+namespace shortfin::local {
+
+SingleWaitFuture::SingleWaitFuture()
+    : wait_source_(iree_wait_source_immediate()) {}
+
+SingleWaitFuture::SingleWaitFuture(iree_shared_event::ref event)
+    : wait_source_(event->await()) {
+  // It is sufficient to simply capture the event ref in the lambda. It
+  // will be lifetime extended for as long as the resource control
+  // or its copies are alive.
+  resource_control_ = [event](ResourceCommand) {};
+}
+
+SingleWaitFuture::SingleWaitFuture(iree_hal_semaphore_ptr sem, uint64_t payload)
+    : wait_source_(iree_hal_semaphore_await(sem, payload)) {
+  resource_control_ = [sem](ResourceCommand) {};
+}
+
+SingleWaitFuture::~SingleWaitFuture() {
+  if (resource_control_) {
+    resource_control_(ResourceCommand::RELEASE);
+  }
+}
+
+bool SingleWaitFuture::is_ready() {
+  iree_status_code_t status_code;
+  SHORTFIN_THROW_IF_ERROR(iree_wait_source_query(wait_source_, &status_code));
+  return status_code == IREE_STATUS_OK;
+}
+
+bool SingleWaitFuture::BlockingWait(iree_timeout_t timeout) {
+  auto status = iree_wait_source_wait_one(wait_source_, timeout);
+  if (iree_status_is_deadline_exceeded(status)) {
+    iree_status_ignore(status);
+    return false;
+  }
+  SHORTFIN_THROW_IF_ERROR(status);
+  return true;
+}
+
+}  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/async.cc
+++ b/libshortfin/src/shortfin/local/async.cc
@@ -8,36 +8,31 @@
 
 namespace shortfin::local {
 
-SingleWaitFuture::SingleWaitFuture()
+CompletionEvent::CompletionEvent()
     : wait_source_(iree_wait_source_immediate()) {}
 
-SingleWaitFuture::SingleWaitFuture(iree::shared_event::ref event)
+CompletionEvent::CompletionEvent(iree::shared_event::ref event)
     : wait_source_(event->await()) {
-  // It is sufficient to simply capture the event ref in the lambda. It
-  // will be lifetime extended for as long as the resource control
-  // or its copies are alive.
-  resource_control_ = [event](ResourceCommand) {};
+  // // It is sufficient to simply capture the event ref in the lambda. It
+  // // will be lifetime extended for as long as the resource control
+  // // or its copies are alive.
+  // resource_control_ = [event](ResourceCommand) {};
 }
 
-SingleWaitFuture::SingleWaitFuture(iree::hal_semaphore_ptr sem,
-                                   uint64_t payload)
+CompletionEvent::CompletionEvent(iree::hal_semaphore_ptr sem, uint64_t payload)
     : wait_source_(iree_hal_semaphore_await(sem, payload)) {
-  resource_control_ = [sem](ResourceCommand) {};
+  // resource_control_ = [sem](ResourceCommand) {};
 }
 
-SingleWaitFuture::~SingleWaitFuture() {
-  if (resource_control_) {
-    resource_control_(ResourceCommand::RELEASE);
-  }
-}
+CompletionEvent::~CompletionEvent() {}
 
-bool SingleWaitFuture::is_ready() {
+bool CompletionEvent::is_ready() {
   iree_status_code_t status_code;
   SHORTFIN_THROW_IF_ERROR(iree_wait_source_query(wait_source_, &status_code));
   return status_code == IREE_STATUS_OK;
 }
 
-bool SingleWaitFuture::BlockingWait(iree_timeout_t timeout) {
+bool CompletionEvent::BlockingWait(iree_timeout_t timeout) {
   auto status = iree_wait_source_wait_one(wait_source_, timeout);
   if (iree_status_is_deadline_exceeded(status)) {
     iree_status_ignore(status);

--- a/libshortfin/src/shortfin/local/async.cc
+++ b/libshortfin/src/shortfin/local/async.cc
@@ -11,7 +11,7 @@ namespace shortfin::local {
 SingleWaitFuture::SingleWaitFuture()
     : wait_source_(iree_wait_source_immediate()) {}
 
-SingleWaitFuture::SingleWaitFuture(iree_shared_event::ref event)
+SingleWaitFuture::SingleWaitFuture(iree::shared_event::ref event)
     : wait_source_(event->await()) {
   // It is sufficient to simply capture the event ref in the lambda. It
   // will be lifetime extended for as long as the resource control
@@ -19,7 +19,8 @@ SingleWaitFuture::SingleWaitFuture(iree_shared_event::ref event)
   resource_control_ = [event](ResourceCommand) {};
 }
 
-SingleWaitFuture::SingleWaitFuture(iree_hal_semaphore_ptr sem, uint64_t payload)
+SingleWaitFuture::SingleWaitFuture(iree::hal_semaphore_ptr sem,
+                                   uint64_t payload)
     : wait_source_(iree_hal_semaphore_await(sem, payload)) {
   resource_control_ = [sem](ResourceCommand) {};
 }

--- a/libshortfin/src/shortfin/local/async.cc
+++ b/libshortfin/src/shortfin/local/async.cc
@@ -12,17 +12,11 @@ CompletionEvent::CompletionEvent()
     : wait_source_(iree_wait_source_immediate()) {}
 
 CompletionEvent::CompletionEvent(iree::shared_event::ref event)
-    : wait_source_(event->await()) {
-  // // It is sufficient to simply capture the event ref in the lambda. It
-  // // will be lifetime extended for as long as the resource control
-  // // or its copies are alive.
-  // resource_control_ = [event](ResourceCommand) {};
-}
+    : wait_source_(event->await()), resource_baton_(std::move(event)) {}
 
 CompletionEvent::CompletionEvent(iree::hal_semaphore_ptr sem, uint64_t payload)
-    : wait_source_(iree_hal_semaphore_await(sem, payload)) {
-  // resource_control_ = [sem](ResourceCommand) {};
-}
+    : wait_source_(iree_hal_semaphore_await(sem, payload)),
+      resource_baton_(std::move(sem)) {}
 
 CompletionEvent::~CompletionEvent() {}
 

--- a/libshortfin/src/shortfin/local/async.h
+++ b/libshortfin/src/shortfin/local/async.h
@@ -29,8 +29,8 @@ class SHORTFIN_API SingleWaitFuture {
   using ResourceControl = std::function<void(ResourceCommand)>;
 
   SingleWaitFuture();
-  SingleWaitFuture(iree_shared_event::ref event);
-  SingleWaitFuture(iree_hal_semaphore_ptr sem, uint64_t payload);
+  SingleWaitFuture(iree::shared_event::ref event);
+  SingleWaitFuture(iree::hal_semaphore_ptr sem, uint64_t payload);
   SingleWaitFuture(SingleWaitFuture &&other)
       : wait_source_(other.wait_source_),
         resource_control_(std::move(other.resource_control_)) {

--- a/libshortfin/src/shortfin/local/async.h
+++ b/libshortfin/src/shortfin/local/async.h
@@ -56,7 +56,7 @@ class SHORTFIN_API CompletionEvent {
   bool BlockingWait(iree_timeout_t timeout = iree_infinite_timeout());
 
   // Access the raw wait source.
-  const iree_wait_source_t &wait_source() { return wait_source_; }
+  operator const iree_wait_source_t &() { return wait_source_; }
 
  private:
   iree_wait_source_t wait_source_;

--- a/libshortfin/src/shortfin/local/async.h
+++ b/libshortfin/src/shortfin/local/async.h
@@ -1,0 +1,75 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SHORTFIN_LOCAL_ASYNC_H
+#define SHORTFIN_LOCAL_ASYNC_H
+
+#include <functional>
+
+#include "shortfin/support/api.h"
+#include "shortfin/support/iree_concurrency.h"
+#include "shortfin/support/iree_helpers.h"
+
+namespace shortfin::local {
+
+// Encapsulates an IREE wait source and combines it with additional plumbing
+// to support resource management. On move, the source of the move is reset
+// to an immediate wait source and it's resource controller is cleared.
+class SHORTFIN_API SingleWaitFuture {
+ public:
+  // The SingleWaitFuture can contain a ResourceControl function. If present,
+  // then it is called to retain/release a backing resource.
+  enum class ResourceCommand {
+    RETAIN,
+    RELEASE,
+  };
+  using ResourceControl = std::function<void(ResourceCommand)>;
+
+  SingleWaitFuture();
+  SingleWaitFuture(iree_shared_event::ref event);
+  SingleWaitFuture(iree_hal_semaphore_ptr sem, uint64_t payload);
+  SingleWaitFuture(SingleWaitFuture &&other)
+      : wait_source_(other.wait_source_),
+        resource_control_(std::move(other.resource_control_)) {
+    other.wait_source_ = iree_wait_source_immediate();
+  }
+  SingleWaitFuture(const SingleWaitFuture &other)
+      : wait_source_(other.wait_source_),
+        resource_control_(other.resource_control_) {
+    resource_control_(ResourceCommand::RETAIN);
+  }
+  SingleWaitFuture &operator=(const SingleWaitFuture &other) {
+    if (other.resource_control_) {
+      other.resource_control_(ResourceCommand::RETAIN);
+    }
+    if (resource_control_) {
+      resource_control_(ResourceCommand::RELEASE);
+    }
+    wait_source_ = other.wait_source_;
+    resource_control_ = other.resource_control_;
+    return *this;
+  }
+  ~SingleWaitFuture();
+
+  // Returns true if this SingleWaitFuture is ready.
+  bool is_ready();
+  // Block the current thread for up to |timeout|. If a non-infinite timeout
+  // was given and the timeout expires while waiting, returns false. In all
+  // other cases, returns true.
+  // This should not be used in worker loops.
+  bool BlockingWait(iree_timeout_t timeout = iree_infinite_timeout());
+
+  // Access the raw wait source.
+  const iree_wait_source_t &wait_source() { return wait_source_; }
+
+ private:
+  iree_wait_source_t wait_source_;
+  ResourceControl resource_control_;
+};
+
+}  // namespace shortfin::local
+
+#endif  // SHORTFIN_LOCAL_ASYNC_H

--- a/libshortfin/src/shortfin/local/device.cc
+++ b/libshortfin/src/shortfin/local/device.cc
@@ -54,7 +54,7 @@ std::string DeviceAffinity::to_s() const {
 // Device
 // -------------------------------------------------------------------------- //
 
-Device::Device(DeviceAddress address, iree_hal_device_ptr hal_device,
+Device::Device(DeviceAddress address, iree::hal_device_ptr hal_device,
                int node_affinity, bool node_locked)
     : address_(std::move(address)),
       hal_device_(std::move(hal_device)),

--- a/libshortfin/src/shortfin/local/device.h
+++ b/libshortfin/src/shortfin/local/device.h
@@ -123,7 +123,7 @@ struct SHORTFIN_API DeviceAddress {
 // A device attached to the LocalSystem.
 class SHORTFIN_API Device {
  public:
-  Device(DeviceAddress address, iree_hal_device_ptr hal_device,
+  Device(DeviceAddress address, iree::hal_device_ptr hal_device,
          int node_affinity, bool node_locked);
   virtual ~Device();
 
@@ -142,7 +142,7 @@ class SHORTFIN_API Device {
 
  private:
   DeviceAddress address_;
-  iree_hal_device_ptr hal_device_;
+  iree::hal_device_ptr hal_device_;
   int node_affinity_;
   bool node_locked_;
 };

--- a/libshortfin/src/shortfin/local/process.cc
+++ b/libshortfin/src/shortfin/local/process.cc
@@ -18,14 +18,14 @@ detail::BaseProcess::BaseProcess(std::shared_ptr<Scope> scope)
 detail::BaseProcess::~BaseProcess() {}
 
 int64_t detail::BaseProcess::pid() const {
-  iree_slim_mutex_lock_guard g(lock_);
+  iree::slim_mutex_lock_guard g(lock_);
   return pid_;
 }
 
 std::string detail::BaseProcess::to_s() const {
   int pid;
   {
-    iree_slim_mutex_lock_guard g(lock_);
+    iree::slim_mutex_lock_guard g(lock_);
     pid = pid_;
   }
 
@@ -44,7 +44,7 @@ std::string detail::BaseProcess::to_s() const {
 void detail::BaseProcess::Launch() {
   Scope* scope = scope_.get();
   {
-    iree_slim_mutex_lock_guard g(lock_);
+    iree::slim_mutex_lock_guard g(lock_);
     if (pid_ != 0) {
       throw std::logic_error("Process can only be launched a single time");
     }
@@ -62,7 +62,7 @@ void detail::BaseProcess::ScheduleOnWorker() {
 void detail::BaseProcess::Terminate() {
   int deallocate_pid;
   {
-    iree_slim_mutex_lock_guard g(lock_);
+    iree::slim_mutex_lock_guard g(lock_);
     deallocate_pid = pid_;
     pid_ = -1;
     if (terminated_event_) {
@@ -77,9 +77,9 @@ void detail::BaseProcess::Terminate() {
 }
 
 SingleWaitFuture detail::BaseProcess::OnTermination() {
-  iree_slim_mutex_lock_guard g(lock_);
+  iree::slim_mutex_lock_guard g(lock_);
   if (!terminated_event_) {
-    terminated_event_ = iree_shared_event::create(pid_ < 0);
+    terminated_event_ = iree::shared_event::create(pid_ < 0);
   }
   return SingleWaitFuture(terminated_event_);
 }

--- a/libshortfin/src/shortfin/local/process.cc
+++ b/libshortfin/src/shortfin/local/process.cc
@@ -76,12 +76,12 @@ void detail::BaseProcess::Terminate() {
   }
 }
 
-SingleWaitFuture detail::BaseProcess::OnTermination() {
+CompletionEvent detail::BaseProcess::OnTermination() {
   iree::slim_mutex_lock_guard g(lock_);
   if (!terminated_event_) {
     terminated_event_ = iree::shared_event::create(pid_ < 0);
   }
-  return SingleWaitFuture(terminated_event_);
+  return CompletionEvent(terminated_event_);
 }
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/process.h
+++ b/libshortfin/src/shortfin/local/process.h
@@ -36,7 +36,7 @@ class SHORTFIN_API BaseProcess {
   std::shared_ptr<Scope> &scope() { return scope_; }
 
   // Returns a future that can be waited on for termination.
-  SingleWaitFuture OnTermination();
+  CompletionEvent OnTermination();
 
  protected:
   // Launches the process.

--- a/libshortfin/src/shortfin/local/process.h
+++ b/libshortfin/src/shortfin/local/process.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "shortfin/local/async.h"
 #include "shortfin/local/scope.h"
 #include "shortfin/local/worker.h"
 #include "shortfin/support/api.h"
@@ -34,6 +35,9 @@ class SHORTFIN_API BaseProcess {
   std::string to_s() const;
   std::shared_ptr<Scope> &scope() { return scope_; }
 
+  // Returns a future that can be waited on for termination.
+  SingleWaitFuture OnTermination();
+
  protected:
   // Launches the process.
   void Launch();
@@ -56,6 +60,10 @@ class SHORTFIN_API BaseProcess {
   // Pid is 0 if not yet started, -1 if terminated, and a postive value if
   // running.
   int64_t pid_ = 0;
+
+  // Must be accessed within a lock. Will be null if no one has called
+  // Termination().
+  iree_shared_event::ref terminated_event_;
 };
 
 }  // namespace detail

--- a/libshortfin/src/shortfin/local/process.h
+++ b/libshortfin/src/shortfin/local/process.h
@@ -56,14 +56,14 @@ class SHORTFIN_API BaseProcess {
   // Process control state. Since this can be accessed by multiple threads,
   // it is protected by a lock. Most process state can only be accessed on
   // the worker thread and is unprotected.
-  mutable iree_slim_mutex lock_;
+  mutable iree::slim_mutex lock_;
   // Pid is 0 if not yet started, -1 if terminated, and a postive value if
   // running.
   int64_t pid_ = 0;
 
   // Must be accessed within a lock. Will be null if no one has called
   // Termination().
-  iree_shared_event::ref terminated_event_;
+  iree::shared_event::ref terminated_event_;
 };
 
 }  // namespace detail

--- a/libshortfin/src/shortfin/local/scheduler.cc
+++ b/libshortfin/src/shortfin/local/scheduler.cc
@@ -116,13 +116,11 @@ void Scheduler::AppendCommandBuffer(ScopedDevice &device,
                                     TransactionType tx_type,
                                     std::function<void(Account &)> callback) {
   Account &account = GetDefaultAccount(device);
-  logging::info("AppendCommandBuffer({})", static_cast<void *>(&account));
 
   auto needed_affinity_bits = device.affinity().queue_affinity();
 
   // Initialize a fresh command buffer if needed.
   if (!account.active_command_buffer_) {
-    logging::info("Create command buffer");
     // Map to a command buffer category.
     iree_hal_command_category_t category;
     switch (tx_type) {
@@ -171,7 +169,6 @@ void Scheduler::AppendCommandBuffer(ScopedDevice &device,
 }
 
 void Scheduler::Flush() {
-  logging::info("Flush");
   // This loop is optimized for a small number of accounts, where it is
   // fine to just linearly probe. If this ever becomes cumbersome, we can
   // maintain a dirty list which is appended to when an account transitions

--- a/libshortfin/src/shortfin/local/scheduler.cc
+++ b/libshortfin/src/shortfin/local/scheduler.cc
@@ -117,8 +117,8 @@ void Scheduler::AppendCommandBuffer(ScopedDevice &device,
     }
 
     // Set up the command buffer.
-    iree_hal_command_buffer_ptr new_cb;
-    iree_hal_fence_ptr new_active_deps;
+    iree::hal_command_buffer_ptr new_cb;
+    iree::hal_fence_ptr new_active_deps;
     SHORTFIN_THROW_IF_ERROR(iree_hal_fence_create(
         semaphore_count_, host_allocator_, new_active_deps.for_output()));
     SHORTFIN_THROW_IF_ERROR(iree_hal_command_buffer_create(

--- a/libshortfin/src/shortfin/local/scheduler.cc
+++ b/libshortfin/src/shortfin/local/scheduler.cc
@@ -36,6 +36,10 @@ void Account::active_deps_extend(iree_hal_semaphore_list_t sem_list) {
   }
 }
 
+SingleWaitFuture Account::OnSync() {
+  return SingleWaitFuture(sem_, idle_timepoint_);
+}
+
 // -------------------------------------------------------------------------- //
 // TimelineResource
 // -------------------------------------------------------------------------- //

--- a/libshortfin/src/shortfin/local/scheduler.h
+++ b/libshortfin/src/shortfin/local/scheduler.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <span>
 
+#include "shortfin/local/async.h"
 #include "shortfin/local/device.h"
 #include "shortfin/support/iree_helpers.h"
 
@@ -158,6 +159,11 @@ class SHORTFIN_API Account {
   // Queue timeline.
   iree_hal_semaphore_t *timeline_sem() { return sem_; }
   uint64_t timeline_idle_timepoint() { return idle_timepoint_; }
+
+  // Returns a future that is satisfied when the timeline of this account
+  // reaches its current idle timepoint (i.e. all currently pending work
+  // is complete).
+  SingleWaitFuture OnSync();
 
  private:
   void Initialize();

--- a/libshortfin/src/shortfin/local/scheduler.h
+++ b/libshortfin/src/shortfin/local/scheduler.h
@@ -134,7 +134,7 @@ class SHORTFIN_API TimelineResource {
 
   // Use barrier fence. The fact that this is a fence object with a fixed
   // capacity is an implementation detail.
-  iree_hal_fence_ptr use_barrier_fence_;
+  iree::hal_fence_ptr use_barrier_fence_;
   friend class Scheduler;
 };
 
@@ -171,8 +171,8 @@ class SHORTFIN_API Account {
   Device *device_;
   iree_hal_device_t *hal_device_;
   TransactionType active_tx_type_ = TransactionType::NONE;
-  iree_hal_fence_ptr active_deps_;
-  iree_hal_command_buffer_ptr active_command_buffer_;
+  iree::hal_fence_ptr active_deps_;
+  iree::hal_command_buffer_ptr active_command_buffer_;
   iree_hal_queue_affinity_t active_queue_affinity_bits_;
 
   // Timepoint at which this device is considered idle, inclusive of any
@@ -190,7 +190,7 @@ class SHORTFIN_API Account {
   // an eventual submission would submit a duplicate timepoint). This
   // timepoint is only valid for the local sem_.
   uint64_t idle_timepoint_ = 0;
-  iree_hal_semaphore_ptr sem_;
+  iree::hal_semaphore_ptr sem_;
   friend class Scheduler;
 };
 

--- a/libshortfin/src/shortfin/local/scheduler.h
+++ b/libshortfin/src/shortfin/local/scheduler.h
@@ -18,10 +18,12 @@ namespace shortfin::local {
 
 class SHORTFIN_API Scope;
 class SHORTFIN_API ScopedDevice;
+class SHORTFIN_API System;
 
 namespace detail {
 
 class SHORTFIN_API Account;
+class SHORTFIN_API Scheduler;
 
 // Transactions are accumulated into a command buffer by type and in
 // auto-flush mode, the command buffer is submitted upon a change of type.
@@ -142,7 +144,7 @@ class SHORTFIN_API TimelineResource {
 // means that each addressable queue gets its own Account.
 class SHORTFIN_API Account {
  public:
-  Account(Device *device);
+  Account(Scheduler &scheduler, Device *device);
   Device *device() const { return device_; }
   iree_hal_device_t *hal_device() { return hal_device_; }
   size_t semaphore_count() const { return 1; }
@@ -163,11 +165,12 @@ class SHORTFIN_API Account {
   // Returns a future that is satisfied when the timeline of this account
   // reaches its current idle timepoint (i.e. all currently pending work
   // is complete).
-  SingleWaitFuture OnSync();
+  CompletionEvent OnSync();
 
  private:
   void Initialize();
   void Reset();
+  Scheduler &scheduler_;
   Device *device_;
   iree_hal_device_t *hal_device_;
   TransactionType active_tx_type_ = TransactionType::NONE;
@@ -197,8 +200,7 @@ class SHORTFIN_API Account {
 // Handles scheduling state for a scope.
 class SHORTFIN_API Scheduler {
  public:
-  Scheduler(iree_allocator_t host_allocator)
-      : host_allocator_(host_allocator) {}
+  Scheduler(System &system) : system_(system) {}
 
   TransactionMode transaction_mode() const { return tx_mode_; }
 
@@ -227,9 +229,12 @@ class SHORTFIN_API Scheduler {
         new TimelineResource(host_allocator, semaphore_count_));
   }
 
+  System &system() { return system_; }
+
  private:
   void Initialize(std::span<Device *const> devices);
-  iree_allocator_t host_allocator_;
+  System &system_;
+
   // Each distinct hal device gets an account.
   std::vector<Account> accounts_;
   // Accounts indexed by DeviceAddress::device_id().

--- a/libshortfin/src/shortfin/local/scope.cc
+++ b/libshortfin/src/shortfin/local/scope.cc
@@ -21,7 +21,7 @@ namespace shortfin::local {
 Scope::Scope(std::shared_ptr<System> system, Worker &worker,
              std::span<const std::pair<std::string_view, Device *>> devices)
     : host_allocator_(system->host_allocator()),
-      scheduler_(system->host_allocator()),
+      scheduler_(*system),
       system_(std::move(system)),
       worker_(worker) {
   for (auto &it : devices) {
@@ -33,7 +33,7 @@ Scope::Scope(std::shared_ptr<System> system, Worker &worker,
 Scope::Scope(std::shared_ptr<System> system, Worker &worker,
              std::span<Device *const> devices)
     : host_allocator_(system->host_allocator()),
-      scheduler_(system->host_allocator()),
+      scheduler_(*system),
       system_(std::move(system)),
       worker_(worker) {
   for (auto *device : devices) {
@@ -86,7 +86,7 @@ std::vector<std::string_view> Scope::device_names() const {
 // ScopedDevice
 // -------------------------------------------------------------------------- //
 
-SingleWaitFuture ScopedDevice::OnSync(bool flush) {
+CompletionEvent ScopedDevice::OnSync(bool flush) {
   if (flush) {
     scope().scheduler().Flush();
   }

--- a/libshortfin/src/shortfin/local/scope.cc
+++ b/libshortfin/src/shortfin/local/scope.cc
@@ -82,4 +82,16 @@ std::vector<std::string_view> Scope::device_names() const {
   return names;
 }
 
+// -------------------------------------------------------------------------- //
+// ScopedDevice
+// -------------------------------------------------------------------------- //
+
+SingleWaitFuture ScopedDevice::OnSync(bool flush) {
+  if (flush) {
+    scope().scheduler().Flush();
+  }
+  auto &default_account = scope().scheduler().GetDefaultAccount(*this);
+  return default_account.OnSync();
+}
+
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/scope.h
+++ b/libshortfin/src/shortfin/local/scope.h
@@ -45,7 +45,7 @@ class SHORTFIN_API ScopedDevice {
   // Returns a future which will be satisfied when the primary device timeline
   // of this affinity set progresses to "now". This will be true when all
   // currently queued work on the device has been completed.
-  SingleWaitFuture OnSync(bool flush = true);
+  CompletionEvent OnSync(bool flush = true);
 
  private:
   Scope &scope_;

--- a/libshortfin/src/shortfin/local/scope.h
+++ b/libshortfin/src/shortfin/local/scope.h
@@ -11,6 +11,7 @@
 #include <span>
 #include <unordered_map>
 
+#include "shortfin/local/async.h"
 #include "shortfin/local/device.h"
 #include "shortfin/local/scheduler.h"
 #include "shortfin/support/stl_extras.h"
@@ -40,6 +41,11 @@ class SHORTFIN_API ScopedDevice {
   bool operator==(const ScopedDevice &other) const {
     return (&scope_ == &other.scope_) && affinity_ == other.affinity_;
   }
+
+  // Returns a future which will be satisfied when the primary device timeline
+  // of this affinity set progresses to "now". This will be true when all
+  // currently queued work on the device has been completed.
+  SingleWaitFuture OnSync(bool flush = true);
 
  private:
   Scope &scope_;

--- a/libshortfin/src/shortfin/local/system.cc
+++ b/libshortfin/src/shortfin/local/system.cc
@@ -27,7 +27,7 @@ System::System(iree_allocator_t host_allocator)
 System::~System() {
   bool needs_shutdown = false;
   {
-    iree_slim_mutex_lock_guard guard(lock_);
+    iree::slim_mutex_lock_guard guard(lock_);
     if (initialized_ && !shutdown_) {
       needs_shutdown = true;
     }
@@ -45,7 +45,7 @@ std::unique_ptr<Worker> System::DefaultWorkerFactory(Worker::Options options) {
 }
 
 void System::set_worker_factory(Worker::Factory factory) {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   worker_factory_ = std::move(factory);
 }
 
@@ -53,7 +53,7 @@ void System::Shutdown() {
   // Stop workers.
   std::vector<std::unique_ptr<Worker>> local_workers;
   {
-    iree_slim_mutex_lock_guard guard(lock_);
+    iree::slim_mutex_lock_guard guard(lock_);
     if (!initialized_ || shutdown_) return;
     shutdown_ = true;
     workers_by_name_.clear();
@@ -85,13 +85,13 @@ void System::Shutdown() {
 }
 
 std::shared_ptr<Scope> System::CreateScope(Worker &worker) {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   return std::make_shared<Scope>(shared_ptr(), worker, devices());
 }
 
 std::shared_ptr<Scope> System::CreateScope() {
   Worker &w = init_worker();
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   return std::make_shared<Scope>(shared_ptr(), w, devices());
 }
 
@@ -109,7 +109,7 @@ void System::InitializeNodes(int node_count) {
 Worker &System::CreateWorker(Worker::Options options) {
   Worker *unowned_worker;
   {
-    iree_slim_mutex_lock_guard guard(lock_);
+    iree::slim_mutex_lock_guard guard(lock_);
     if (options.name == std::string_view("__init__")) {
       throw std::invalid_argument(
           "Cannot create worker '__init__' (reserved name)");
@@ -130,7 +130,7 @@ Worker &System::CreateWorker(Worker::Options options) {
 }
 
 Worker &System::init_worker() {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   auto found_it = workers_by_name_.find("__init__");
   if (found_it != workers_by_name_.end()) {
     return *found_it->second;
@@ -147,7 +147,7 @@ Worker &System::init_worker() {
 }
 
 void System::InitializeHalDriver(std::string_view moniker,
-                                 iree_hal_driver_ptr driver) {
+                                 iree::hal_driver_ptr driver) {
   AssertNotInitialized();
   auto &slot = hal_drivers_[moniker];
   if (slot) {
@@ -170,20 +170,20 @@ void System::InitializeHalDevice(std::unique_ptr<Device> device) {
 }
 
 void System::FinishInitialization() {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   AssertNotInitialized();
   initialized_ = true;
 }
 
 int64_t System::AllocateProcess(detail::BaseProcess *p) {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   int pid = next_pid_++;
   processes_by_pid_[pid] = p;
   return pid;
 }
 
 void System::DeallocateProcess(int64_t pid) {
-  iree_slim_mutex_lock_guard guard(lock_);
+  iree::slim_mutex_lock_guard guard(lock_);
   processes_by_pid_.erase(pid);
 }
 

--- a/libshortfin/src/shortfin/local/system.cc
+++ b/libshortfin/src/shortfin/local/system.cc
@@ -69,6 +69,8 @@ void System::Shutdown() {
       worker->WaitForShutdown();
     }
   }
+  blocking_executor_.Kill();
+
   local_workers.clear();
 
   // Orderly destruction of heavy-weight objects.

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -94,7 +94,7 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   // ------------------------------------------------------------------------ //
   void InitializeNodes(int node_count);
   void InitializeHalDriver(std::string_view moniker,
-                           iree_hal_driver_ptr driver);
+                           iree::hal_driver_ptr driver);
   void InitializeHalDevice(std::unique_ptr<Device> device);
   void FinishInitialization();
 
@@ -119,7 +119,7 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   const iree_allocator_t host_allocator_;
 
   string_interner interner_;
-  iree_slim_mutex lock_;
+  iree::slim_mutex lock_;
 
   // NUMA nodes relevant to this system.
   std::vector<Node> nodes_;
@@ -127,7 +127,7 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   // Map of retained hal drivers. These will be released as one of the
   // last steps of destruction. There are some ancillary uses for drivers
   // after initialization, but mainly this is for keeping them alive.
-  std::unordered_map<std::string_view, iree_hal_driver_ptr> hal_drivers_;
+  std::unordered_map<std::string_view, iree::hal_driver_ptr> hal_drivers_;
 
   // Map of device name to a SystemDevice.
   std::vector<std::unique_ptr<Device>> retained_devices_;
@@ -135,7 +135,7 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   std::vector<Device *> devices_;
 
   // VM management.
-  iree_vm_instance_ptr vm_instance_;
+  iree::vm_instance_ptr vm_instance_;
 
   // Workers.
   Worker::Factory worker_factory_ = System::DefaultWorkerFactory;

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -17,6 +17,7 @@
 #include "shortfin/local/device.h"
 #include "shortfin/local/worker.h"
 #include "shortfin/support/api.h"
+#include "shortfin/support/blocking_executor.h"
 #include "shortfin/support/iree_concurrency.h"
 #include "shortfin/support/iree_helpers.h"
 #include "shortfin/support/stl_extras.h"
@@ -70,6 +71,11 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   const std::unordered_map<std::string_view, Device *> &named_devices() {
     return named_devices_;
   }
+
+  // Access the system wide blocking executor thread pool. This can be used
+  // to execute thunks that can block on a dedicated thread and is needed
+  // to bridge APIs that cannot be used in a non-blocking context.
+  BlockingExecutor &blocking_executor() { return blocking_executor_; }
 
   // Scopes.
   // Creates a new Scope bound to this System (it will internally
@@ -136,6 +142,9 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
 
   // VM management.
   iree::vm_instance_ptr vm_instance_;
+
+  // Global blocking executor.
+  BlockingExecutor blocking_executor_;
 
   // Workers.
   Worker::Factory worker_factory_ = System::DefaultWorkerFactory;

--- a/libshortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/libshortfin/src/shortfin/local/systems/amdgpu.cc
@@ -63,7 +63,8 @@ void AMDGPUSystemBuilder::Enumerate() {
 
   // Get available devices and filter into visible_devices_.
   iree_host_size_t available_devices_count = 0;
-  allocated_ptr<iree_hal_device_info_t> raw_available_devices(host_allocator());
+  iree::allocated_ptr<iree_hal_device_info_t> raw_available_devices(
+      host_allocator());
   SHORTFIN_THROW_IF_ERROR(iree_hal_driver_query_available_devices(
       hip_hal_driver_, host_allocator(), &available_devices_count,
       raw_available_devices.for_output()));
@@ -87,7 +88,7 @@ SystemPtr AMDGPUSystemBuilder::CreateSystem() {
   // Initialize all visible GPU devices.
   for (size_t i = 0; i < visible_devices_.size(); ++i) {
     auto &it = visible_devices_[i];
-    iree_hal_device_ptr device;
+    iree::hal_device_ptr device;
     SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
         hip_hal_driver_, it.device_id, 0, nullptr, host_allocator(),
         device.for_output()));

--- a/libshortfin/src/shortfin/local/systems/amdgpu.h
+++ b/libshortfin/src/shortfin/local/systems/amdgpu.h
@@ -59,7 +59,7 @@ class SHORTFIN_API AMDGPUSystemBuilder : public HostCPUSystemBuilder {
   iree_hal_hip_device_params_t default_device_params_;
 
   // Valid post enumeration.
-  iree_hal_driver_ptr hip_hal_driver_;
+  iree::hal_driver_ptr hip_hal_driver_;
   std::vector<iree_hal_device_info_t> visible_devices_;
 };
 

--- a/libshortfin/src/shortfin/local/systems/host.cc
+++ b/libshortfin/src/shortfin/local/systems/host.cc
@@ -68,7 +68,7 @@ iree_hal_driver_t *HostCPUSystemBuilder::InitializeHostCPUDriver(System &lsys) {
                                 host_allocator(), &host_cpu_deps_.executor));
 
   // Create the driver and save it in the System.
-  iree_hal_driver_ptr driver;
+  iree::hal_driver_ptr driver;
   iree_hal_driver_t *unowned_driver;
   SHORTFIN_THROW_IF_ERROR(iree_hal_task_driver_create(
       IREE_SV("local-task"), &host_cpu_deps_.task_params, /*queue_count=*/1,
@@ -83,12 +83,12 @@ iree_hal_driver_t *HostCPUSystemBuilder::InitializeHostCPUDriver(System &lsys) {
 void HostCPUSystemBuilder::InitializeHostCPUDevices(System &lsys,
                                                     iree_hal_driver_t *driver) {
   iree_host_size_t device_info_count = 0;
-  allocated_ptr<iree_hal_device_info_t> device_infos(host_allocator());
+  iree::allocated_ptr<iree_hal_device_info_t> device_infos(host_allocator());
   SHORTFIN_THROW_IF_ERROR(iree_hal_driver_query_available_devices(
       driver, host_allocator(), &device_info_count, &device_infos));
 
   for (iree_host_size_t i = 0; i < device_info_count; ++i) {
-    iree_hal_device_ptr device;
+    iree::hal_device_ptr device;
     iree_hal_device_info_t *it = &device_infos.get()[i];
     SHORTFIN_THROW_IF_ERROR(iree_hal_driver_create_device_by_id(
         driver, it->device_id, 0, nullptr, host_allocator(),

--- a/libshortfin/src/shortfin/local/worker.cc
+++ b/libshortfin/src/shortfin/local/worker.cc
@@ -52,7 +52,7 @@ iree_status_t Worker::TransactLoop(iree_status_t signal_status) {
     // An outside thread cannot change the state we are managing without
     // entering this critical section, so it is safe to reset the event
     // here (it is not possible for it to be spurious reset).
-    iree_slim_mutex_lock_guard guard(mu_);
+    iree::slim_mutex_lock_guard guard(mu_);
     signal_transact_.reset();
     if (kill_) {
       // TODO: Do we want to somehow hard abort loop in flight work (vs
@@ -86,7 +86,7 @@ int Worker::RunOnThread() {
     IREE_RETURN_IF_ERROR(ScheduleExternalTransactEvent());
     for (;;) {
       {
-        iree_slim_mutex_lock_guard guard(mu_);
+        iree::slim_mutex_lock_guard guard(mu_);
         if (kill_) break;
       }
       IREE_RETURN_IF_ERROR(iree_loop_drain(loop_, options_.quantum));
@@ -134,7 +134,7 @@ void Worker::Kill() {
     throw std::logic_error("Cannot kill a Worker that was not started");
   }
   {
-    iree_slim_mutex_lock_guard guard(mu_);
+    iree::slim_mutex_lock_guard guard(mu_);
     kill_ = true;
   }
   signal_transact_.set();
@@ -167,7 +167,7 @@ void Worker::RunOnCurrentThread() {
         "Cannot RunOnCurrentThread if worker was configured for owned_thread");
   }
   {
-    iree_slim_mutex_lock_guard guard(mu_);
+    iree::slim_mutex_lock_guard guard(mu_);
     if (has_run_) {
       throw std::logic_error("Cannot RunOnCurrentThread if already finished");
     }
@@ -178,7 +178,7 @@ void Worker::RunOnCurrentThread() {
 
 void Worker::CallThreadsafe(std::function<void()> callback) {
   {
-    iree_slim_mutex_lock_guard guard(mu_);
+    iree::slim_mutex_lock_guard guard(mu_);
     pending_thunks_.push_back(std::move(callback));
   }
   signal_transact_.set();

--- a/libshortfin/src/shortfin/local/worker.h
+++ b/libshortfin/src/shortfin/local/worker.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "iree/base/loop_sync.h"
+#include "shortfin/local/async.h"
 #include "shortfin/support/api.h"
 #include "shortfin/support/iree_concurrency.h"
 

--- a/libshortfin/src/shortfin/local/worker.h
+++ b/libshortfin/src/shortfin/local/worker.h
@@ -76,6 +76,13 @@ class SHORTFIN_API Worker {
                                 iree_status_t status) noexcept,
       void *user_data);
 
+  // Calls back once a wait_source is satisfied.
+  iree_status_t WaitOneLowLevel(
+      iree_wait_source_t wait_source, iree_timeout_t timeout,
+      iree_status_t (*callback)(void *user_data, iree_loop_t loop,
+                                iree_status_t status) noexcept,
+      void *user_data);
+
   // Time management.
   // Returns the current absolute time in nanoseconds.
   iree_time_t now();

--- a/libshortfin/src/shortfin/local/worker.h
+++ b/libshortfin/src/shortfin/local/worker.h
@@ -98,10 +98,10 @@ class SHORTFIN_API Worker {
   iree_status_t TransactLoop(iree_status_t signal_status);
 
   const Options options_;
-  iree_slim_mutex mu_;
-  iree_thread_ptr thread_;
-  iree_event signal_transact_;
-  iree_event signal_ended_;
+  iree::slim_mutex mu_;
+  iree::thread_ptr thread_;
+  iree::event signal_transact_;
+  iree::event signal_ended_;
 
   // State management. These are all manipulated both on and off the worker
   // thread.

--- a/libshortfin/src/shortfin/support/CMakeLists.txt
+++ b/libshortfin/src/shortfin/support/CMakeLists.txt
@@ -27,3 +27,11 @@ shortfin_cc_component(
     iree_modules_hal_types
     spdlog::spdlog
 )
+
+shortfin_gtest_test(
+  NAME support_test
+  SRCS
+    iree_concurrency_test.cc
+    iree_helpers_test.cc
+    stl_extras_test.cc
+)

--- a/libshortfin/src/shortfin/support/CMakeLists.txt
+++ b/libshortfin/src/shortfin/support/CMakeLists.txt
@@ -9,12 +9,14 @@ shortfin_cc_component(
     shortfin_support
   HDRS
     api.h
+    blocking_executor.h
     globals.h
     iree_helpers.h
     iree_concurrency.h
     logging.h
     stl_extras.h
   SRCS
+    blocking_executor.cc
     globals.cc
     iree_helpers.cc
     logging.cc
@@ -31,7 +33,9 @@ shortfin_cc_component(
 shortfin_gtest_test(
   NAME support_test
   SRCS
-    iree_concurrency_test.cc
+    # Order is specific: lower level tests before higher level.
     iree_helpers_test.cc
+    iree_concurrency_test.cc
+    blocking_executor_test.cc
     stl_extras_test.cc
 )

--- a/libshortfin/src/shortfin/support/blocking_executor.cc
+++ b/libshortfin/src/shortfin/support/blocking_executor.cc
@@ -75,7 +75,9 @@ void BlockingExecutor::Kill(bool wait, iree_timeout_t warn_timeout) {
     }
 
     // Short spin delay to signal/wait.
-    iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(250)));
+    // TODO: Introduce iree_thread_try_join and refactor the shutdown sequence
+    // to be based on thread joining with a warn deadline.
+    iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(50)));
   }
 }
 

--- a/libshortfin/src/shortfin/support/blocking_executor.cc
+++ b/libshortfin/src/shortfin/support/blocking_executor.cc
@@ -1,0 +1,162 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/blocking_executor.h"
+
+#include "fmt/core.h"
+#include "shortfin/support/logging.h"
+
+namespace shortfin {
+
+BlockingExecutor::BlockingExecutor(iree_allocator_t allocator)
+    : allocator_(allocator) {}
+BlockingExecutor::~BlockingExecutor() { Kill(/*wait=*/true); }
+
+bool BlockingExecutor::has_free_threads() {
+  iree::slim_mutex_lock_guard g(control_mu_);
+  return free_threads_ != nullptr;
+}
+
+void BlockingExecutor::Kill(bool wait, iree_timeout_t warn_timeout) {
+  {
+    iree::slim_mutex_lock_guard g(control_mu_);
+    kill_ = true;
+  }
+
+  // Because there can be some asynchronicity in terms of the kill signal and
+  // additional scheduling, we loop on a short delay, sending kill signals,
+  // issuing a warning if waiting for a long time. Once the number of
+  // live threads drops to zero, we set the inhibit flag, causing no more
+  // work to be accepted and exit.
+  iree_time_t report_deadline = iree_timeout_as_deadline_ns(warn_timeout);
+  for (;;) {
+    // Wake up all free threads, leaving their task null. This will cause them
+    // to loop once and ask the executor to add them back to the free list
+    // (at which point, they will be told to shutdown).
+    {
+      iree::slim_mutex_lock_guard g(control_mu_);
+      for (;;) {
+        ThreadInstance *current = free_threads_;
+        if (!current) break;
+        current->signal_transact.set();
+        free_threads_ = current->next;
+        current->next = nullptr;
+      }
+    }
+
+    // If not asked to wait, just exit.
+    if (!wait) {
+      break;
+    }
+
+    // Check if still alive.
+    int last_live_thread_count;
+    int total_thread_count;
+    {
+      iree::slim_mutex_lock_guard g(control_mu_);
+      last_live_thread_count = live_thread_count_;
+      total_thread_count = created_thread_count_;
+      if (live_thread_count_ == 0) {
+        inhibit_ = true;
+        break;
+      }
+    }
+
+    // Report if over the reporting deadling.
+    if (iree_time_now() > report_deadline) {
+      logging::warn(
+          "Still waiting for blocking executor threads to terminate (live "
+          "threads = {}, total created = {}).",
+          last_live_thread_count, total_thread_count);
+      report_deadline = iree_timeout_as_deadline_ns(warn_timeout);
+    }
+
+    // Short spin delay to signal/wait.
+    iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(250)));
+  }
+}
+
+void BlockingExecutor::Schedule(Task task) {
+  ThreadInstance *target;
+  bool target_is_new = false;
+  {
+    iree::slim_mutex_lock_guard g(control_mu_);
+    if (inhibit_) {
+      throw std::logic_error(
+          "BlockingExecutor has shut down and new work cannot be scheduled");
+    }
+    target = free_threads_;
+    if (target) {
+      // Edit out of free list.
+      free_threads_ = target->next;
+      target->next = nullptr;
+    } else {
+      // Create new.
+      std::string name = fmt::format("blocking-{}", created_thread_count_++);
+      iree_thread_create_params_t params = {
+          .name = {name.data(), name.size()},
+          .create_suspended = true,
+      };
+      target = new ThreadInstance(this);
+      auto EntryFunction = +[](void *self) noexcept {
+        return static_cast<ThreadInstance *>(self)->RunOnThread();
+      };
+      auto status = iree_thread_create(EntryFunction, target, params,
+                                       allocator_, target->thread.for_output());
+      if (!iree_status_is_ok(status)) {
+        delete target;
+        SHORTFIN_THROW_IF_ERROR(status);
+      }
+      target_is_new = true;
+      live_thread_count_ += 1;
+    }
+    target->current_task = std::move(task);
+  }
+
+  // Out of lock, continue dispatch.
+  target->signal_transact.set();
+  if (target_is_new) {
+    iree_thread_resume(target->thread);
+  }
+}
+
+bool BlockingExecutor::LockAndMoveToFreeList(ThreadInstance *inst) {
+  iree::slim_mutex_lock_guard g(control_mu_);
+  // If still running, add to free list. Else delete.
+  if (kill_) {
+    inst->executor = nullptr;
+    live_thread_count_ -= 1;
+    return false;
+  } else {
+    inst->next = free_threads_;
+    free_threads_ = inst;
+    inst->signal_transact.reset();
+    return true;
+  }
+}
+
+BlockingExecutor::ThreadInstance::ThreadInstance(BlockingExecutor *executor)
+    : executor(executor), signal_transact(false), next(nullptr) {}
+
+int BlockingExecutor::ThreadInstance::RunOnThread() noexcept {
+  for (;;) {
+    auto status = iree_wait_source_wait_one(signal_transact.await(),
+                                            iree_infinite_timeout());
+    IREE_CHECK_OK(status);
+    Task exec_task = std::move(current_task);
+    if (exec_task) {
+      exec_task();
+    }
+    if (!executor->LockAndMoveToFreeList(this)) {
+      break;
+    }
+  }
+
+  delete this;
+  return 0;
+}
+
+}  // namespace shortfin

--- a/libshortfin/src/shortfin/support/blocking_executor.h
+++ b/libshortfin/src/shortfin/support/blocking_executor.h
@@ -1,0 +1,72 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef SHORTFIN_SUPPORT_BLOCKING_EXECUTOR_H
+#define SHORTFIN_SUPPORT_BLOCKING_EXECUTOR_H
+
+#include <functional>
+
+#include "shortfin/support/iree_concurrency.h"
+
+namespace shortfin {
+
+// An executor for offloading potentially blocking operations from event loops
+// and contexts which must not block. This uses a simple pool of threads,
+// creating a new one whenever starvation would occur. Since it is explicitly
+// meant for offloading blocking operations, we can make no further assumptions
+// about it being legal to run with a more limited number of threads.
+class SHORTFIN_API BlockingExecutor {
+ public:
+  using Task = std::function<void()>;
+  BlockingExecutor(iree_allocator_t allocator);
+  BlockingExecutor() : BlockingExecutor(iree_allocator_system()) {}
+  ~BlockingExecutor();
+
+  // Send a kill signal, optionally waiting indefinitely for shutdown.
+  void Kill(bool wait = true,
+            iree_timeout_t warn_timeout = iree_make_timeout_ms(5000));
+
+  // Schedule task to run at some point in the future (which may be before
+  // this function returns). The task must not throw any exceptions (or the
+  // program will terminate).
+  void Schedule(Task task);
+
+  // Total number of threads created over the lifetime of this instance.
+  // This may not be the same as the count of those currently alive.
+  int created_thread_count() const { return created_thread_count_; }
+
+  // Returns whether there are any free threads. This is generally only
+  // used for testing.
+  bool has_free_threads();
+
+ private:
+  // Free thread instances are managed in a simple linked list.
+  struct ThreadInstance {
+    ThreadInstance(BlockingExecutor *executor);
+    BlockingExecutor *executor;
+    iree::thread_ptr thread;
+    iree::event signal_transact;
+    Task current_task;
+    ThreadInstance *next = nullptr;
+
+    int RunOnThread() noexcept;
+  };
+  // Returns whether the thread should keep running. If false, the caller
+  // must immediately deallocate and exit. It must not assume that
+  // inst->executor is valid.
+  bool LockAndMoveToFreeList(ThreadInstance *inst);
+  iree_allocator_t allocator_;
+  iree::slim_mutex control_mu_;
+  ThreadInstance *free_threads_ = nullptr;
+  int created_thread_count_ = 0;
+  int live_thread_count_ = 0;
+  bool kill_ = false;
+  bool inhibit_ = false;
+};
+
+}  // namespace shortfin
+
+#endif  // SHORTFIN_SUPPORT_BLOCKING_EXECUTOR_H

--- a/libshortfin/src/shortfin/support/blocking_executor_test.cc
+++ b/libshortfin/src/shortfin/support/blocking_executor_test.cc
@@ -1,0 +1,103 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/blocking_executor.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "shortfin/support/logging.h"
+
+namespace shortfin {
+
+TEST(BlockingExecutor, concurrent_tasks) {
+  {
+    std::atomic<int> tasks_run{0};
+
+    BlockingExecutor executor;
+    for (int i = 0; i < 10; ++i) {
+      executor.Schedule([&tasks_run, i]() {
+        iree_wait_until(
+            iree_timeout_as_deadline_ns(iree_make_timeout_ms(1500)));
+        logging::info("TASK {} COMPLETE", i);
+        tasks_run.fetch_add(1);
+      });
+    }
+
+    executor.Kill(/*wait=*/true);
+    EXPECT_EQ(tasks_run.load(), 10);
+    logging::info("KILL RETURNED");
+  }
+}
+
+TEST(BlockingExecutor, inhibit_when_shutdown) {
+  {
+    std::atomic<int> tasks_run{0};
+
+    BlockingExecutor executor;
+    for (int i = 0; i < 10; ++i) {
+      executor.Schedule([&tasks_run, i]() {
+        iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(150)));
+        tasks_run.fetch_add(1);
+      });
+    }
+
+    executor.Kill(/*wait=*/true);
+
+    // New work should be inhibited.
+    try {
+      executor.Schedule([&tasks_run]() { tasks_run.fetch_add(1); });
+      FAIL();
+    } catch (std::logic_error &) {
+    }
+    EXPECT_EQ(tasks_run.load(), 10);
+  }
+}
+
+TEST(BlockingExecutor, warn_deadline) {
+  {
+    std::atomic<int> tasks_run{0};
+
+    BlockingExecutor executor;
+    for (int i = 0; i < 10; ++i) {
+      executor.Schedule([&tasks_run, i]() {
+        iree_wait_until(
+            iree_timeout_as_deadline_ns(iree_make_timeout_ms(1000)));
+        tasks_run.fetch_add(1);
+      });
+    }
+
+    executor.Kill(/*wait=*/true, /*warn_timeout=*/iree_make_timeout_ms(200));
+    EXPECT_EQ(tasks_run.load(), 10);
+  }
+}
+
+TEST(BlockingExecutor, threads_recycle) {
+  {
+    std::atomic<int> tasks_run{0};
+
+    BlockingExecutor executor;
+    for (int i = 0; i < 10; ++i) {
+      executor.Schedule([&tasks_run, i]() {
+        iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(10)));
+        tasks_run.fetch_add(1);
+        logging::info("Task {} done", i);
+      });
+      // Make sure the task is done before scheduling another.
+      while (!executor.has_free_threads()) {
+        iree_wait_until(iree_timeout_as_deadline_ns(iree_make_timeout_ms(50)));
+      }
+    }
+
+    executor.Kill(/*wait=*/true);
+    EXPECT_EQ(tasks_run.load(), 10);
+    // If we only submitted work serially, then there must have only been
+    // one thread created to service it.
+    EXPECT_EQ(executor.created_thread_count(), 1);
+  }
+}
+
+}  // namespace shortfin

--- a/libshortfin/src/shortfin/support/iree_concurrency.h
+++ b/libshortfin/src/shortfin/support/iree_concurrency.h
@@ -74,6 +74,7 @@ class shared_event : private event {
   class ref {
    public:
     ref() = default;
+    explicit ref(bool initial_state) : inst_(new shared_event(initial_state)) {}
     ref(const ref &other) : inst_(other.inst_) {
       if (inst_) {
         inst_->ref_count_.fetch_add(1);
@@ -93,7 +94,7 @@ class shared_event : private event {
     ~ref() { reset(); }
 
     operator bool() const { return inst_ != nullptr; }
-    iree::event *operator->() { return inst_; }
+    iree::event *operator->() const { return inst_; }
     void reset() {
       if (inst_) {
         manual_release();
@@ -101,7 +102,7 @@ class shared_event : private event {
       }
     }
 
-    int ref_count() { return inst_->ref_count_.load(); }
+    int ref_count() const { return inst_->ref_count_.load(); }
 
     // Manually retain the event. Must be matched by a call to release().
     void manual_retain() { inst_->ref_count_.fetch_add(1); }

--- a/libshortfin/src/shortfin/support/iree_concurrency.h
+++ b/libshortfin/src/shortfin/support/iree_concurrency.h
@@ -88,7 +88,7 @@ class shared_event : private event {
     ref(ref &&other) : inst_(other.inst_) { other.inst_ = nullptr; }
     ~ref() { reset(); }
 
-    operator bool() { return inst_ != nullptr; }
+    operator bool() const { return inst_ != nullptr; }
     iree::event *operator->() { return inst_; }
     void reset() {
       if (inst_) {
@@ -96,6 +96,8 @@ class shared_event : private event {
         inst_ = nullptr;
       }
     }
+
+    int ref_count() { return inst_->ref_count_.load(); }
 
     // Manually retain the event. Must be matched by a call to release().
     void manual_retain() { inst_->ref_count_.fetch_add(1); }

--- a/libshortfin/src/shortfin/support/iree_concurrency.h
+++ b/libshortfin/src/shortfin/support/iree_concurrency.h
@@ -29,6 +29,8 @@ using thread_ptr = object_ptr<iree_thread_t, detail::thread_ptr_helper>;
 class slim_mutex {
  public:
   slim_mutex() { iree_slim_mutex_initialize(&mu_); }
+  slim_mutex(const slim_mutex &) = delete;
+  slim_mutex &operator=(const slim_mutex &) = delete;
   ~slim_mutex() { iree_slim_mutex_deinitialize(&mu_); }
 
   operator iree_slim_mutex_t *() { return &mu_; }
@@ -44,7 +46,7 @@ class slim_mutex_lock_guard {
   ~slim_mutex_lock_guard() { iree_slim_mutex_unlock(mu_); }
 
  private:
-  slim_mutex mu_;
+  slim_mutex &mu_;
 };
 
 // Wrapper around an iree::event_t.
@@ -53,6 +55,8 @@ class event {
   event(bool initial_state) {
     SHORTFIN_THROW_IF_ERROR(iree_event_initialize(initial_state, &event_));
   }
+  event(const event &) = delete;
+  event &operator=(const event &) = delete;
   ~event() { iree_event_deinitialize(&event_); }
 
   void set() { iree_event_set(&event_); }

--- a/libshortfin/src/shortfin/support/iree_concurrency_test.cc
+++ b/libshortfin/src/shortfin/support/iree_concurrency_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/iree_concurrency.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace shortfin {
+
+TEST(iree_shared_event, copy) {
+  auto se1 = iree::shared_event::create(true);
+  EXPECT_EQ(se1.ref_count(), 1);
+  EXPECT_TRUE(se1);
+  {
+    iree::shared_event::ref se2 = se1;
+    EXPECT_EQ(se1.ref_count(), 2);
+    EXPECT_EQ(se2.ref_count(), 2);
+    EXPECT_TRUE(se2);
+  }
+  EXPECT_EQ(se1.ref_count(), 1);
+}
+
+TEST(iree_shared_event, move) {
+  auto se1 = iree::shared_event::create(true);
+  EXPECT_EQ(se1.ref_count(), 1);
+  EXPECT_TRUE(se1);
+  {
+    iree::shared_event::ref se2 = std::move(se1);
+    EXPECT_FALSE(se1);
+    EXPECT_EQ(se2.ref_count(), 1);
+    EXPECT_TRUE(se2);
+  }
+}
+
+}  // namespace shortfin

--- a/libshortfin/src/shortfin/support/iree_helpers.cc
+++ b/libshortfin/src/shortfin/support/iree_helpers.cc
@@ -8,6 +8,10 @@
 
 namespace shortfin::iree {
 
+error::error(std::string message, iree_status_t failing_status)
+    : message_(std::move(message)), failing_status_(failing_status) {
+  message_.append(": ");
+}
 error::error(iree_status_t failing_status) : failing_status_(failing_status) {}
 
 void error::AppendStatus() const noexcept {
@@ -19,7 +23,6 @@ void error::AppendStatus() const noexcept {
   iree_host_size_t length = 0;
   if (iree_status_to_string(failing_status_, &allocator, &status_buffer,
                             &length)) {
-    message_.append(": ");
     message_.append(status_buffer, length);
     iree_allocator_free(allocator, status_buffer);
   } else {

--- a/libshortfin/src/shortfin/support/iree_helpers.cc
+++ b/libshortfin/src/shortfin/support/iree_helpers.cc
@@ -6,12 +6,11 @@
 
 #include "shortfin/support/iree_helpers.h"
 
-namespace shortfin {
+namespace shortfin::iree {
 
-iree_error::iree_error(iree_status_t failing_status)
-    : failing_status_(failing_status) {}
+error::error(iree_status_t failing_status) : failing_status_(failing_status) {}
 
-void iree_error::AppendStatus() const noexcept {
+void error::AppendStatus() const noexcept {
   if (status_appended_) return;
   status_appended_ = false;
 
@@ -28,4 +27,4 @@ void iree_error::AppendStatus() const noexcept {
   }
 }
 
-}  // namespace shortfin
+}  // namespace shortfin::iree

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -112,7 +112,7 @@ class object_ptr {
     Helper::retain(owned);
     return object_ptr(owned);
   }
-  operator T *() noexcept { return ptr; }
+  operator T *() const noexcept { return ptr; }
 
   // Releases any current reference held by this instance and returns a
   // pointer to the raw backing pointer. This is typically used for passing

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -19,25 +19,28 @@
 namespace shortfin {
 
 // -------------------------------------------------------------------------- //
-// Type conversion
+// Type conversion from C types.
+// These are in the global shortfin namespace.
 // -------------------------------------------------------------------------- //
 
 inline std::string_view to_string_view(iree_string_view_t isv) {
   return std::string_view(isv.data, isv.size);
 }
 
+namespace iree {
+
 // -------------------------------------------------------------------------- //
 // RAII wrappers
 // -------------------------------------------------------------------------- //
 
-namespace iree_type_detail {
+namespace detail {
 
-struct iree_hal_buffer_ptr_helper {
+struct hal_buffer_ptr_helper {
   static void retain(iree_hal_buffer_t *obj) { iree_hal_buffer_retain(obj); }
   static void release(iree_hal_buffer_t *obj) { iree_hal_buffer_release(obj); }
 };
 
-struct iree_hal_command_buffer_ptr_helper {
+struct hal_command_buffer_helper {
   static void retain(iree_hal_command_buffer_t *obj) {
     iree_hal_command_buffer_retain(obj);
   }
@@ -46,22 +49,22 @@ struct iree_hal_command_buffer_ptr_helper {
   }
 };
 
-struct iree_hal_device_ptr_helper {
+struct hal_device_ptr_helper {
   static void retain(iree_hal_device_t *obj) { iree_hal_device_retain(obj); }
   static void release(iree_hal_device_t *obj) { iree_hal_device_release(obj); }
 };
 
-struct iree_hal_driver_ptr_helper {
+struct hal_driver_ptr_helper {
   static void retain(iree_hal_driver_t *obj) { iree_hal_driver_retain(obj); }
   static void release(iree_hal_driver_t *obj) { iree_hal_driver_release(obj); }
 };
 
-struct iree_hal_fence_ptr_helper {
+struct hal_fence_ptr_helper {
   static void retain(iree_hal_fence_t *obj) { iree_hal_fence_retain(obj); }
   static void release(iree_hal_fence_t *obj) { iree_hal_fence_release(obj); }
 };
 
-struct iree_hal_semaphore_ptr_helper {
+struct hal_semaphore_ptr_helper {
   static void retain(iree_hal_semaphore_t *obj) {
     iree_hal_semaphore_retain(obj);
   }
@@ -70,45 +73,41 @@ struct iree_hal_semaphore_ptr_helper {
   }
 };
 
-struct iree_vm_instance_ptr_helper {
+struct vm_instance_ptr_helper {
   static void retain(iree_vm_instance_t *obj) { iree_vm_instance_retain(obj); }
   static void release(iree_vm_instance_t *obj) {
     iree_vm_instance_release(obj);
   }
 };
 
-};  // namespace iree_type_detail
+};  // namespace detail
 
 // Wraps an IREE retain/release style object pointer in a smart-pointer
 // like wrapper.
 template <typename T, typename Helper>
-class iree_object_ptr {
+class object_ptr {
  public:
-  iree_object_ptr() : ptr(nullptr) {}
-  iree_object_ptr(const iree_object_ptr &other) : ptr(other.ptr) {
+  object_ptr() : ptr(nullptr) {}
+  object_ptr(const object_ptr &other) : ptr(other.ptr) {
     if (ptr) {
       Helper::retain(ptr);
     }
   }
-  iree_object_ptr(iree_object_ptr &&other) : ptr(other.ptr) {
-    other.ptr = nullptr;
-  }
-  iree_object_ptr &operator=(iree_object_ptr &&other) {
+  object_ptr(object_ptr &&other) : ptr(other.ptr) { other.ptr = nullptr; }
+  object_ptr &operator=(object_ptr &&other) {
     ptr = other.ptr;
     other.ptr = nullptr;
     return *this;
   }
-  ~iree_object_ptr() {
+  ~object_ptr() {
     if (ptr) {
       Helper::release(ptr);
     }
   }
 
-  // Constructs a new iree_object_ptr by transferring ownership of a raw
+  // Constructs a new object_ptr by transferring ownership of a raw
   // pointer.
-  static iree_object_ptr steal_reference(T *owned) {
-    return iree_object_ptr(owned);
-  }
+  static object_ptr steal_reference(T *owned) { return object_ptr(owned); }
 
   operator T *() noexcept { return ptr; }
 
@@ -136,31 +135,24 @@ class iree_object_ptr {
 
  private:
   // Assumes the reference count for owned_ptr.
-  iree_object_ptr(T *owned_ptr) : ptr(owned_ptr) {}
+  object_ptr(T *owned_ptr) : ptr(owned_ptr) {}
   T *ptr = nullptr;
 };
 
-using iree_hal_buffer_ptr =
-    iree_object_ptr<iree_hal_buffer_t,
-                    iree_type_detail::iree_hal_buffer_ptr_helper>;
-using iree_hal_command_buffer_ptr =
-    iree_object_ptr<iree_hal_command_buffer_t,
-                    iree_type_detail::iree_hal_command_buffer_ptr_helper>;
-using iree_hal_driver_ptr =
-    iree_object_ptr<iree_hal_driver_t,
-                    iree_type_detail::iree_hal_driver_ptr_helper>;
-using iree_hal_device_ptr =
-    iree_object_ptr<iree_hal_device_t,
-                    iree_type_detail::iree_hal_device_ptr_helper>;
-using iree_hal_fence_ptr =
-    iree_object_ptr<iree_hal_fence_t,
-                    iree_type_detail::iree_hal_fence_ptr_helper>;
-using iree_hal_semaphore_ptr =
-    iree_object_ptr<iree_hal_semaphore_t,
-                    iree_type_detail::iree_hal_semaphore_ptr_helper>;
-using iree_vm_instance_ptr =
-    iree_object_ptr<iree_vm_instance_t,
-                    iree_type_detail::iree_vm_instance_ptr_helper>;
+using hal_buffer_ptr =
+    object_ptr<iree_hal_buffer_t, detail::hal_buffer_ptr_helper>;
+using hal_command_buffer_ptr =
+    object_ptr<iree_hal_command_buffer_t, detail::hal_command_buffer_helper>;
+using hal_driver_ptr =
+    object_ptr<iree_hal_driver_t, detail::hal_driver_ptr_helper>;
+using hal_device_ptr =
+    object_ptr<iree_hal_device_t, detail::hal_device_ptr_helper>;
+using hal_fence_ptr =
+    object_ptr<iree_hal_fence_t, detail::hal_fence_ptr_helper>;
+using hal_semaphore_ptr =
+    object_ptr<iree_hal_semaphore_t, detail::hal_semaphore_ptr_helper>;
+using vm_instance_ptr =
+    object_ptr<iree_vm_instance_t, detail::vm_instance_ptr_helper>;
 
 // Holds a pointer allocated by some allocator, deleting it if still owned
 // at destruction time.
@@ -200,18 +192,18 @@ struct allocated_ptr {
 };
 
 // -------------------------------------------------------------------------- //
-// iree_error and status handling
+// error and status handling
 // -------------------------------------------------------------------------- //
 
 // Captures an iree_status_t as an exception. The intent is that this is
-// only used for failing statuses and the iree_error instance will be
+// only used for failing statuses and the error instance will be
 // immediately thrown.
-class SHORTFIN_API iree_error : public std::exception {
+class SHORTFIN_API error : public std::exception {
  public:
-  iree_error(iree_status_t failing_status);
-  iree_error(const iree_error &) = delete;
-  iree_error &operator=(const iree_error &) = delete;
-  ~iree_error() { iree_status_ignore(failing_status_); }
+  error(iree_status_t failing_status);
+  error(const error &) = delete;
+  error &operator=(const error &) = delete;
+  ~error() { iree_status_ignore(failing_status_); }
   const char *what() const noexcept override {
     if (!status_appended_) {
       AppendStatus();
@@ -230,15 +222,17 @@ class SHORTFIN_API iree_error : public std::exception {
   iree_status_t var = (IREE_STATUS_IMPL_IDENTITY_(                           \
       IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_GET_EXPR_)(__VA_ARGS__))); \
   if (IREE_UNLIKELY(var)) {                                                  \
-    throw iree_error(IREE_STATUS_IMPL_ANNOTATE_SWITCH_(var, __VA_ARGS__));   \
+    throw ::shortfin::iree::error(                                           \
+        IREE_STATUS_IMPL_ANNOTATE_SWITCH_(var, __VA_ARGS__));                \
   }
 
-// Similar to IREE_RETURN_IF_ERROR but throws an iree_error exception instead.
+// Similar to IREE_RETURN_IF_ERROR but throws an error exception instead.
 #define SHORTFIN_THROW_IF_ERROR(...)                    \
   SHORTFIN_IMPL_HANDLE_IF_API_ERROR(                    \
       IREE_STATUS_IMPL_CONCAT_(__status_, __COUNTER__), \
       IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_IDENTITY_(__VA_ARGS__)))
 
+}  // namespace iree
 }  // namespace shortfin
 
 #endif  // SHORTFIN_SUPPORT_IREE_HELPERS_H

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -108,7 +108,10 @@ class object_ptr {
   // Constructs a new object_ptr by transferring ownership of a raw
   // pointer.
   static object_ptr steal_reference(T *owned) { return object_ptr(owned); }
-
+  static object_ptr borrow_reference(T *owned) {
+    Helper::retain(owned);
+    return object_ptr(owned);
+  }
   operator T *() noexcept { return ptr; }
 
   // Releases any current reference held by this instance and returns a
@@ -200,6 +203,7 @@ struct allocated_ptr {
 // immediately thrown.
 class SHORTFIN_API error : public std::exception {
  public:
+  error(std::string message, iree_status_t failing_status);
   error(iree_status_t failing_status);
   error(const error &) = delete;
   error &operator=(const error &) = delete;

--- a/libshortfin/src/shortfin/support/iree_helpers_test.cc
+++ b/libshortfin/src/shortfin/support/iree_helpers_test.cc
@@ -1,0 +1,148 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/iree_helpers.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "shortfin/support/iree_concurrency.h"
+
+namespace shortfin {
+
+TEST(iree_string_view, to_string_view) {
+  iree_string_view_t isv = iree_make_cstring_view("Hello");
+  std::string_view sv = to_string_view(isv);
+  EXPECT_EQ(sv, "Hello");
+}
+
+namespace {
+
+struct iree_dummy_t {
+  ~iree_dummy_t() { dtor_count++; }
+  int retain_count = 0;
+  int release_count = 0;
+  int dtor_count = 0;
+};
+
+struct dummy_ptr_helper {
+  static void retain(iree_dummy_t *obj) { obj->retain_count++; }
+  static void release(iree_dummy_t *obj) { obj->release_count++; }
+};
+
+using dummy_ptr = iree::object_ptr<iree_dummy_t, dummy_ptr_helper>;
+
+}  // namespace
+
+TEST(iree_object_ptr, steal) {
+  auto raw = std::make_unique<iree_dummy_t>();
+  dummy_ptr p1 = dummy_ptr::steal_reference(raw.get());
+  EXPECT_EQ(raw->retain_count, 0);
+  EXPECT_EQ(raw->release_count, 0);
+  p1.reset();
+  EXPECT_EQ(raw->release_count, 1);
+}
+
+TEST(iree_object_ptr, borrow) {
+  auto raw = std::make_unique<iree_dummy_t>();
+  dummy_ptr p1 = dummy_ptr::borrow_reference(raw.get());
+  EXPECT_EQ(raw->retain_count, 1);
+  EXPECT_EQ(raw->release_count, 0);
+  p1.reset();
+  EXPECT_EQ(raw->release_count, 1);
+}
+
+TEST(iree_object_ptr, copy) {
+  auto raw = std::make_unique<iree_dummy_t>();
+  dummy_ptr p1 = dummy_ptr::steal_reference(raw.get());
+  dummy_ptr p2 = p1;
+  EXPECT_EQ(raw->retain_count, 1);
+  EXPECT_EQ(raw->release_count, 0);
+  p1.reset();
+  EXPECT_EQ(raw->release_count, 1);
+  p2.reset();
+  EXPECT_EQ(raw->release_count, 2);
+}
+
+TEST(iree_object_ptr, move) {
+  auto raw = std::make_unique<iree_dummy_t>();
+  dummy_ptr p1 = dummy_ptr::steal_reference(raw.get());
+  dummy_ptr p2 = std::move(p1);
+  EXPECT_EQ(raw->retain_count, 0);
+  EXPECT_EQ(raw->release_count, 0);
+  p1.reset();
+  EXPECT_EQ(raw->release_count, 0);
+  p2.reset();
+  EXPECT_EQ(raw->release_count, 1);
+}
+
+TEST(iree_object_ptr, for_output) {
+  auto raw = std::make_unique<iree_dummy_t>();
+  dummy_ptr p1 = dummy_ptr::steal_reference(raw.get());
+  p1.for_output();
+  EXPECT_EQ(raw->retain_count, 0);
+  EXPECT_EQ(raw->release_count, 1);
+  EXPECT_EQ(p1.get(), nullptr);
+  p1.reset();
+  EXPECT_EQ(raw->release_count, 1);
+}
+
+TEST(iree_error, user_message) {
+  try {
+    throw iree::error(
+        "Something went wrong",
+        iree_make_status(IREE_STATUS_CANCELLED, "because I said so"));
+  } catch (iree::error &e) {
+    EXPECT_THAT(
+        std::string(e.what()),
+        testing::MatchesRegex(
+            "^Something went wrong: .*: CANCELLED; because I said so$"));
+  }
+}
+
+TEST(iree_error, no_user_message) {
+  try {
+    throw iree::error(
+        iree_make_status(IREE_STATUS_CANCELLED, "because I said so"));
+  } catch (iree::error &e) {
+    EXPECT_THAT(std::string(e.what()),
+                testing::MatchesRegex("^.*: CANCELLED; because I said so$"));
+  }
+}
+
+TEST(iree_error, throw_if_error_ok) {
+  try {
+    SHORTFIN_THROW_IF_ERROR(iree_ok_status());
+  } catch (iree::error &e) {
+    FAIL();
+  }
+}
+
+TEST(iree_error, throw_if_error) {
+  try {
+    SHORTFIN_THROW_IF_ERROR(
+        iree_make_status(IREE_STATUS_CANCELLED, "because I said so"));
+    FAIL();
+  } catch (iree::error &e) {
+    EXPECT_THAT(std::string(e.what()),
+                testing::MatchesRegex("^.*: CANCELLED; because I said so$"));
+  }
+}
+
+TEST(iree_error, throw_if_error_addl_message) {
+  try {
+    SHORTFIN_THROW_IF_ERROR(
+        iree_make_status(IREE_STATUS_CANCELLED, "because I said so"),
+        "oops: %d", 1);
+    FAIL();
+  } catch (iree::error &e) {
+    EXPECT_THAT(
+        std::string(e.what()),
+        testing::MatchesRegex("^.*: CANCELLED; because I said so; oops: 1$"));
+  }
+}
+
+}  // namespace shortfin

--- a/libshortfin/src/shortfin/support/stl_extras_test.cc
+++ b/libshortfin/src/shortfin/support/stl_extras_test.cc
@@ -1,0 +1,24 @@
+// Copyright 2024 Advanced Micro Devices, Inc
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "shortfin/support/stl_extras.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace shortfin {
+
+TEST(string_interner, basics) {
+  string_interner si;
+
+  std::string_view s1("One");
+  std::string_view s1_intern = si.intern(s1);
+  EXPECT_NE(s1.data(), s1_intern.data());
+  std::string_view s2_intern = si.intern(s1);
+  EXPECT_EQ(s1_intern.data(), s2_intern.data());
+}
+
+}  // namespace shortfin


### PR DESCRIPTION
* Stubs are in place that can be adapted for C++ coroutines but left for later.
* Makes `Process` awaitable (for termination).
* Makes `ScopedDevice` awaitable (for sync).
* There's substantial room to profile/optimize this on the Python side, but focusing on getting everything to connect first.

Handful of other changes:

* Adds CTest tests for some of the native support library.
* Adds a thread local to track the current native worker (saves a lot of Python jumping).
* Introduces a CompletionEvent C++ class and associated Python binding. This supports basic signaling and will be enhanced later with value producing async objects.
* Namespaces the `iree_` support stuff under `iree::`
* Adds a BlockingExecutor to the system which can run arbitrary blocking thunks. Uses this to workaround an issue with exporting hal semaphores to wait_sources (this will get attention this week to remove the hack).
* Fixes a bad copy vs ref of slim_mutex, rendering mutexes all unique (caught by unit tests). Deleted copy constructors from all classes not meant to be copyable.
* Added a shared_event class which heap allocated and reference counts an event. This is useful for various situations where an event producer and consumer are separated in terms of object ownership.
* Added a device_sync example which demonstrates interleaved fills/syncs.