### PR TITLE
Add GH workflow to test libshortfin

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: CI - libshorthin
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci_linux_x64-libshortfin.yml'
+      - 'libshortfin/**'
+
+permissions:
+  contents: read
+
+env:
+  IREE_REPO_DIR: ${{ github.workspace }}/iree
+  BUILD_DIR: ${{ github.workspace }}/libshortfin/build
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install clang lld cmake ninja-build
+        sudo apt install libspdlog-dev libxtensor-dev
+
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        submodules: false
+
+    - name: Checkout IREE repo
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: iree-org/iree
+        path: ${{ env.IREE_REPO_DIR }}
+        submodules: false
+        depth: 1
+
+    - name: Initalize IREE submodules
+      run : |
+        cd ${{ env.IREE_REPO_DIR }}
+        git submodule update --init -- third_party/benchmark
+        git submodule update --init -- third_party/cpuinfo/
+        git submodule update --init -- third_party/flatcc
+        git submodule update --init -- third_party/googletest
+        git submodule update --init -- third_party/hip-build-deps/
+
+    - name: Build IREE runtime
+      run: |
+        mkdir ${{ env.IREE_REPO_DIR }}/build
+        cd ${{ env.IREE_REPO_DIR }}/build
+        cmake -GNinja \
+          -DCMAKE_C_COMPILER=clang-18 \
+          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DIREE_ENABLE_LLD=ON \
+          -DIREE_ERROR_ON_MISSING_SUBMODULES=OFF \
+          -DIREE_HAL_DRIVER_DEFAULTS=OFF \
+          -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
+          -DIREE_HAL_DRIVER_LOCAL_TASK=ON \
+          -DIREE_HAL_DRIVER_HIP=ON \
+          -DIREE_BUILD_COMPILER=OFF \
+          -DIREE_BUILD_SAMPLES=OFF \
+          -DIREE_BUILD_TESTS=OFF \
+          ..
+        cmake --build . --target all
+
+    - name: Setup Python
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+      with:
+        python-version: "3.11"
+        cache: "pip"
+    - name: Install Python packages
+      # TODO: Switch to `pip install -r requirements.txt -e libshortfin/`.
+      run: pip install nanobind typing_extensions
+
+    - name: Build libshortfin
+      run: |
+        mkdir ${{ env.BUILD_DIR }}
+        cd ${{ env.BUILD_DIR }}
+        cmake -GNinja \
+          -DCMAKE_C_COMPILER=clang-18 \
+          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DCMAKE_LINKER_TYPE=LLD \
+          -DCMAKE_PREFIX_PATH=${{ env.IREE_REPO_DIR }}/build/lib/cmake/IREE \
+          -DSHORTFIN_BUILD_PYTHON_BINDINGS=ON \
+          ..
+        cmake --build . --target all
+
+    - name: Test libshortfin
+      run: |
+        cd ${{ env.BUILD_DIR }}
+        cmake --build . --target test

--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: CI - libshorthin
+name: CI - libshortfin
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This adds a very basic GitHub action to

 * Build the IREE runtime from source (no caching, not using any of
   IREE's `build_tools/cmake/*.sh` scripts yet)
 * Build libshortfin
 * Run libshortfin tests via CMake