### PR TITLE
[libshortfin] Introduce `SHORTFIN_SYSTEMS_AMDGPU`

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   IREE_REPO_DIR: ${{ github.workspace }}/iree
-  BUILD_DIR: ${{ github.workspace }}/libshortfin/build
+  LIBSHORTFIN_DIR: ${{ github.workspace }}/libshortfin/
 
 jobs:
   build-and-test:
@@ -86,10 +86,10 @@ jobs:
       # TODO: Switch to `pip install -r requirements.txt -e libshortfin/`.
       run: pip install nanobind typing_extensions
 
-    - name: Build libshortfin
+    - name: Build libshortfin (full)
       run: |
-        mkdir ${{ env.BUILD_DIR }}
-        cd ${{ env.BUILD_DIR }}
+        mkdir ${{ env.LIBSHORTFIN_DIR }}/build
+        cd ${{ env.LIBSHORTFIN_DIR }}/build
         cmake -GNinja \
           -DCMAKE_C_COMPILER=clang-18 \
           -DCMAKE_CXX_COMPILER=clang++-18 \
@@ -99,7 +99,21 @@ jobs:
           ..
         cmake --build . --target all
 
-    - name: Test libshortfin
+    - name: Test libshortfin (full)
       run: |
-        cd ${{ env.BUILD_DIR }}
+        cd ${{ env.LIBSHORTFIN_DIR }}/build
         cmake --build . --target test
+
+    - name: Build libshortfin (host-only)
+      run: |
+        mkdir ${{ env.LIBSHORTFIN_DIR }}/build-host-only
+        cd ${{ env.LIBSHORTFIN_DIR }}/build-host-only
+        cmake -GNinja \
+          -DCMAKE_C_COMPILER=clang-18 \
+          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DCMAKE_LINKER_TYPE=LLD \
+          -DCMAKE_PREFIX_PATH=${{ env.IREE_REPO_DIR }}/build/lib/cmake/IREE \
+          -DSHORTFIN_BUILD_PYTHON_BINDINGS=ON \
+          -DSHORTFIN_HAVE_AMDGPU=OFF \
+          ..
+        cmake --build . --target all

--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)
 option(SHORTFIN_BUILD_TESTS "Builds C++ tests" ON)
 option(SHORTFIN_BUNDLE_DEPS "Download dependencies instead of using system libraries" OFF)
+
 set(SHORTFIN_IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Enabling ASAN. Note that this will work best if building in a completely
@@ -44,6 +45,14 @@ if(SHORTFIN_ENABLE_ASAN)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
 endif()
+
+option(SHORTFIN_SYSTEMS_AMDGPU "Builds for AMD GPU systems" ON)
+message(STATUS "libshortfin supported systems:")
+if(SHORTFIN_SYSTEMS_AMDGPU)
+  message(STATUS "  - AMD GPU")
+  add_compile_definitions("SHORTFIN_HAVE_AMDGPU")
+endif()
+message(STATUS "  - Host")
 
 include(FetchContent)
 
@@ -120,7 +129,9 @@ if(SHORTFIN_IREE_SOURCE_DIR)
   set(IREE_HAL_DRIVER_DEFAULTS OFF)
   set(IREE_HAL_DRIVER_LOCAL_SYNC ON)
   set(IREE_HAL_DRIVER_LOCAL_TASK ON)
-  set(IREE_HAL_DRIVER_HIP ON)
+  if(SHORTFIN_SYSTEMS_AMDGPU)
+    set(IREE_HAL_DRIVER_HIP ON)
+  endif()
   add_subdirectory(${SHORTFIN_IREE_SOURCE_DIR} shortfin_iree SYSTEM EXCLUDE_FROM_ALL)
 else()
   # Try to find iree using find_package

--- a/libshortfin/bindings/python/lib_ext.cc
+++ b/libshortfin/bindings/python/lib_ext.cc
@@ -13,7 +13,9 @@
 #include "shortfin/local/program.h"
 #include "shortfin/local/scope.h"
 #include "shortfin/local/system.h"
+#if defined(SHORTFIN_HAVE_AMDGPU)
 #include "shortfin/local/systems/amdgpu.h"
+#endif  // SHORTFIN_HAVE_AMDGPU
 #include "shortfin/local/systems/host.h"
 #include "shortfin/support/globals.h"
 #include "shortfin/support/logging.h"
@@ -239,7 +241,9 @@ NB_MODULE(lib, m) {
   auto local_m = m.def_submodule("local");
   BindLocal(local_m);
   BindHostSystem(local_m);
+#if defined(SHORTFIN_HAVE_AMDGPU)
   BindAMDGPUSystem(local_m);
+#endif  // SHORTFIN_HAVE_AMDGPU
 
   auto array_m = m.def_submodule("array");
   BindArray(array_m);
@@ -712,6 +716,7 @@ void BindHostSystem(py::module_ &global_m) {
   py::class_<local::systems::HostCPUDevice, local::Device>(m, "HostCPUDevice");
 }
 
+#if defined(SHORTFIN_HAVE_AMDGPU)
 void BindAMDGPUSystem(py::module_ &global_m) {
   auto m = global_m.def_submodule("amdgpu", "AMDGPU system config");
   py::class_<local::systems::AMDGPUSystemBuilder,
@@ -721,5 +726,6 @@ void BindAMDGPUSystem(py::module_ &global_m) {
               &local::systems::AMDGPUSystemBuilder::cpu_devices_enabled);
   py::class_<local::systems::AMDGPUDevice, local::Device>(m, "AMDGPUDevice");
 }
+#endif  // SHORTFIN_HAVE_AMDGPU
 
 }  // namespace shortfin::python

--- a/libshortfin/src/CMakeLists.txt
+++ b/libshortfin/src/CMakeLists.txt
@@ -13,6 +13,11 @@ target_include_directories(
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 
+set(_INIT_INTERNAL_DEPS)
+if(SHORTFIN_SYSTEMS_AMDGPU)
+  list(APPEND _INIT_INTERNAL_DEPS shortfin_systems_amdgpu)
+endif()
+
 shortfin_public_library(
   NAME
     shortfin
@@ -20,6 +25,6 @@ shortfin_public_library(
     shortfin_array
     shortfin_local
     shortfin_support
-    shortfin_systems_amdgpu
     shortfin_systems_host
+    ${_INIT_INTERNAL_DEPS}
 )


### PR DESCRIPTION
Introduces an `SHORTFIN_SYSTEMS_AMDGPU` option to allow building
libshortfin for host-only systems. The option defaults to ON.