### PR TITLE
[libshortfin] Shallow clone git repositories

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -47,16 +47,15 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        depth: 1
 
     - name: Initalize IREE submodules
       run : |
         cd ${{ env.IREE_REPO_DIR }}
-        git submodule update --init -- third_party/benchmark
-        git submodule update --init -- third_party/cpuinfo/
-        git submodule update --init -- third_party/flatcc
-        git submodule update --init -- third_party/googletest
-        git submodule update --init -- third_party/hip-build-deps/
+        git submodule update --init --depth 1 -- third_party/benchmark
+        git submodule update --init --depth 1 -- third_party/cpuinfo/
+        git submodule update --init --depth 1 -- third_party/flatcc
+        git submodule update --init --depth 1 -- third_party/googletest
+        git submodule update --init --depth 1 -- third_party/hip-build-deps/
 
     - name: Build IREE runtime
       run: |

--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -70,6 +70,7 @@ if(SHORTFIN_BUNDLE_DEPS)
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG        e69e5f977d458f2650bb346dadf2ad30c5320281 # 10.2.1 (sync with spdlog)
+    GIT_SHALLOW TRUE
   )
 
   ## spdlog
@@ -79,6 +80,7 @@ if(SHORTFIN_BUNDLE_DEPS)
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG        2d4acf8cc321d7783d8f2e22e17a794c6d0e9450 # v1.14.1
+    GIT_SHALLOW TRUE
   )
 
   ## xtl: required for xtensor
@@ -86,6 +88,7 @@ if(SHORTFIN_BUNDLE_DEPS)
     xtl
     GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git
     GIT_TAG        a7c1c5444dfc57f76620391af4c94785ff82c8d6 # v0.7.7
+    GIT_SHALLOW TRUE
   )
 
   ## xtensor
@@ -93,6 +96,7 @@ if(SHORTFIN_BUNDLE_DEPS)
     xtensor
     GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git
     GIT_TAG        3634f2ded19e0cf38208c8b86cea9e1d7c8e397d # v0.25.0
+    GIT_SHALLOW TRUE
   )
 
   FetchContent_MakeAvailable(fmt spdlog xtl xtensor)
@@ -111,6 +115,7 @@ if (NOT SHORTFIN_IREE_SOURCE_DIR AND SHORTFIN_BUNDLE_DEPS)
     # TODO: We shouldn't have to pull googletest when we are not building tests.
     #       This needs to be fixed with IREE.
     GIT_SUBMODULES "third_party/benchmark third_party/cpuinfo third_party/flatcc third_party/hip-build-deps third_party/googletest"
+    GIT_SHALLOW TRUE
   )
   FetchContent_GetProperties(iree)
   if(NOT iree_POPULATED)


### PR DESCRIPTION
Only get shallow copies of all repositories cloned as bundeled dep or in the CI. For `actions/checkout` the fetch depth defaults to `1`.