### PR TITLE
[libshortfin] Build debug/asan

### DIFF
--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -1,0 +1,160 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: CI - libshortfin - ASan
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci_linux_x64_asan-libshortfin.yml'
+      - 'libshortfin/**'
+
+permissions:
+  contents: read
+
+env:
+  PYENV_ROOT: ${{ github.workspace }}/pyenv
+  PYENV_REF: 9ecd803bffaffb949fbdd8c70cb086227f6a3202 # v2.4.10
+  PYTHON_VER: 3.12.3
+  CACHE_ASAN_VER: 1
+  CACHE_DEPS_VER: 1
+  IREE_SOURCE_DIR: ${{ github.workspace }}/iree
+  LIBSHORTFIN_DIR: ${{ github.workspace }}/libshortfin/
+
+
+jobs:
+  setup-python-asan:
+    name: Setup Python ASan
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Cache Python ASan
+      id: cache-python-asan
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ${{ env.PYENV_ROOT }}
+        key: ${{ runner.os }}-python-asan-${{ env.PYENV_REF }}-${{ env.PYTHON_VER }}-v${{ env.CACHE_ASAN_VER }}
+        lookup-only: 'true'
+
+    - name: Install dependencies
+      if: steps.cache-python-asan.outputs.cache-hit != 'true'
+      run: |
+        sudo apt update
+        sudo apt install clang lld cmake ninja-build
+        sudo apt install build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+    - name: Checkout pyenv
+      if: steps.cache-python-asan.outputs.cache-hit != 'true'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: pyenv/pyenv
+        ref: ${{ env.PYENV_REF }}
+        path: ${{ env.PYENV_ROOT }}
+
+    - name: Install pyenv & Python
+      if: steps.cache-python-asan.outputs.cache-hit != 'true'
+      run: |
+        cd ${{ env.PYENV_ROOT }}
+        src/configure && make -C src
+        export PATH=${{ env.PYENV_ROOT }}/bin:$PATH && eval "$(pyenv init -)"
+        CC=clang-18 CXX=clang++-18 LDFLAGS="-lstdc++" PYTHON_CONFIGURE_OPTS="--with-address-sanitizer" pyenv install -v -g ${{ env.PYTHON_VER }}
+        pyenv global ${{ env.PYTHON_VER }}-debug
+
+
+  build-and-test:
+    name: Build and test libshortfin
+    needs: [setup-python-asan]
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install clang lld cmake ninja-build
+
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        submodules: false
+
+    - name: Checkout IREE repo
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: iree-org/iree
+        path: ${{ env.IREE_SOURCE_DIR }}
+        submodules: false
+
+    - name: Initalize IREE submodules
+      run : |
+        cd ${{ env.IREE_SOURCE_DIR }}
+        git submodule update --init --depth 1 -- third_party/benchmark
+        git submodule update --init --depth 1 -- third_party/cpuinfo/
+        git submodule update --init --depth 1 -- third_party/flatcc
+        git submodule update --init --depth 1 -- third_party/googletest
+        git submodule update --init --depth 1 -- third_party/hip-build-deps/
+
+    - name: Restore Python dependencies cache
+      id: cache-python-deps-restore
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ${{ env.PYENV_ROOT }}
+        key: ${{ runner.os }}-python-deps-${{ hashFiles('libshortfin/requirements-tests.txt') }}-v${{ env.CACHE_DEPS_VER }}
+
+    - name: Restore Python ASan cache
+      id: cache-python-asan
+      if: steps.cache-python-deps-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ${{ env.PYENV_ROOT }}
+        key: ${{ runner.os }}-python-asan-${{ env.PYENV_REF }}-${{ env.PYTHON_VER }}-v${{ env.CACHE_ASAN_VER }}
+
+    - name: Set path
+      run:
+        echo "${{ env.PYENV_ROOT }}/bin" >> $GITHUB_PATH
+
+    - name: Install Python dependencies
+      if: steps.cache-python-deps-restore.outputs.cache-hit != 'true'
+      run: |
+        eval "$(pyenv init -)"
+        pip install -r ${{ env.LIBSHORTFIN_DIR }}/requirements-tests.txt
+
+    - name: Save Python dependencies cache
+      if: steps.cache-python-deps-restore.outputs.cache-hit != 'true'
+      id: cache-python-deps-save
+      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: ${{ env.PYENV_ROOT }}
+        key: ${{ steps.cache-python-deps-restore.outputs.cache-primary-key }}
+
+    - name: Build libshortfin
+      run: |
+        eval "$(pyenv init -)"
+        mkdir ${{ env.LIBSHORTFIN_DIR }}/build
+        cd ${{ env.LIBSHORTFIN_DIR }}/build
+        cmake -GNinja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_COMPILER=clang-18 \
+          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DCMAKE_LINKER_TYPE=LLD \
+          -DSHORTFIN_BUNDLE_DEPS=ON \
+          -DSHORTFIN_IREE_SOURCE_DIR=${{ env.IREE_SOURCE_DIR }} \
+          -DSHORTFIN_BUILD_PYTHON_BINDINGS=ON \
+          -DSHORTFIN_ENABLE_ASAN=ON \
+          ..
+        cmake --build . --target all
+        pip install -v -e .
+
+    - name: Test libshortfin
+      run: |
+        eval "$(pyenv init -)"
+        cd ${{ env.LIBSHORTFIN_DIR }}/build
+        cmake --build . --target test
+        cd ${{ env.LIBSHORTFIN_DIR }}
+        pytest -m "not requires_amd_gpu"

--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -72,7 +72,6 @@ if(SHORTFIN_BUNDLE_DEPS)
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG        e69e5f977d458f2650bb346dadf2ad30c5320281 # 10.2.1 (sync with spdlog)
-    GIT_SHALLOW TRUE
   )
 
   ## spdlog
@@ -82,7 +81,6 @@ if(SHORTFIN_BUNDLE_DEPS)
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG        2d4acf8cc321d7783d8f2e22e17a794c6d0e9450 # v1.14.1
-    GIT_SHALLOW TRUE
   )
 
   ## xtl: required for xtensor
@@ -90,7 +88,6 @@ if(SHORTFIN_BUNDLE_DEPS)
     xtl
     GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git
     GIT_TAG        a7c1c5444dfc57f76620391af4c94785ff82c8d6 # v0.7.7
-    GIT_SHALLOW TRUE
   )
 
   ## xtensor
@@ -98,7 +95,6 @@ if(SHORTFIN_BUNDLE_DEPS)
     xtensor
     GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git
     GIT_TAG        3634f2ded19e0cf38208c8b86cea9e1d7c8e397d # v0.25.0
-    GIT_SHALLOW TRUE
   )
 
   FetchContent_MakeAvailable(fmt spdlog xtl xtensor)

--- a/libshortfin/requirements-tests.txt
+++ b/libshortfin/requirements-tests.txt
@@ -1,3 +1,4 @@
+nanobind==2.0.0
 pytest
 requests
 fastapi


### PR DESCRIPTION
This adds a GitHub action to build a debug/asan version of libshortfin. Shallow cloning of dependencies obtained via FetchContent is reverted as the dependencies cannot be fetched in the CI.

Depends on #148