### PR TITLE
[shortfin] Make TimelineResource hold scopes alive.

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Test libshortfin (full)
       run: |
         cd ${{ env.LIBSHORTFIN_DIR }}/build
-        cmake --build . --target test
+        ctest --timeout 30 --output-on-failure
         cd ${{ env.LIBSHORTFIN_DIR }}
         pytest -s -v -m "not requires_amd_gpu"
 

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -160,7 +160,7 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
       run: |
         cd ${{ env.LIBSHORTFIN_DIR }}/build
-        cmake --build . --target test
+        ctest --timeout 30 --output-on-failure
 
     - name: Run pytest
       if: ${{ !cancelled() }}

--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -46,6 +46,9 @@ option(SHORTFIN_ENABLE_ASAN "Enable ASAN" OFF)
 if(SHORTFIN_ENABLE_ASAN)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+
+  # Enable more ASAN checks.
+  add_compile_definitions(IREE_SANITIZER_ADDRESS)
 endif()
 
 option(SHORTFIN_SYSTEMS_AMDGPU "Builds for AMD GPU systems" ON)

--- a/libshortfin/bindings/python/array_binding.cc
+++ b/libshortfin/bindings/python/array_binding.cc
@@ -123,6 +123,7 @@ void BindArray(py::module_ &m) {
              PyBufferReleaser py_view_releaser(py_view);
              self.Fill(py_view.buf, py_view.len);
            })
+      .def("copy_from", [](storage &self, storage &src) { self.CopyFrom(src); })
       .def(
           "map",
           [](storage &self, bool read, bool write, bool discard) {
@@ -232,13 +233,12 @@ void BindArray(py::module_ &m) {
                         py::type<device_array>(), /*keep_alive=*/device.scope(),
                         device_array::for_host(device, shape, dtype));
                   })
-      .def_static("for_transfer",
-                  [](device_array &existing) {
-                    return custom_new_keep_alive<device_array>(
-                        py::type<device_array>(),
-                        /*keep_alive=*/existing.device().scope(),
-                        device_array::for_transfer(existing));
-                  })
+      .def("for_transfer",
+           [](device_array &self) {
+             return custom_new_keep_alive<device_array>(
+                 py::type<device_array>(),
+                 /*keep_alive=*/self.device().scope(), self.for_transfer());
+           })
       .def_prop_ro("device", &device_array::device,
                    py::rv_policy::reference_internal)
       .def_prop_ro("storage", &device_array::storage,

--- a/libshortfin/src/shortfin/array/array.h
+++ b/libshortfin/src/shortfin/array/array.h
@@ -80,10 +80,9 @@ class SHORTFIN_API device_array
         shape, dtype);
   }
 
-  // Allocates a host array for transfer to/from the given device array.
-  static device_array for_transfer(device_array &with_device_array) {
-    return for_host(with_device_array.storage().device(),
-                    with_device_array.shape(), with_device_array.dtype());
+  // Allocates a host array for transfer to/from this array.
+  device_array for_transfer() {
+    return for_host(storage().device(), shape(), dtype());
   }
 
   // Untyped access to the backing data. The array must be mappable. Specific

--- a/libshortfin/src/shortfin/local/scope.cc
+++ b/libshortfin/src/shortfin/local/scope.cc
@@ -21,10 +21,11 @@ namespace shortfin::local {
 
 Scope::Scope(std::shared_ptr<System> system, Worker &worker,
              std::span<const std::pair<std::string_view, Device *>> devices)
-    : host_allocator_(system->host_allocator()),
-      scheduler_(*system),
-      system_(std::move(system)),
+    : system_(std::move(system)),
+      host_allocator_(system_->host_allocator()),
+      scheduler_(*system_),
       worker_(worker) {
+  logging::construct("Scope", this);
   for (auto &it : devices) {
     AddDevice(it.first, it.second);
   }
@@ -33,17 +34,18 @@ Scope::Scope(std::shared_ptr<System> system, Worker &worker,
 
 Scope::Scope(std::shared_ptr<System> system, Worker &worker,
              std::span<Device *const> devices)
-    : host_allocator_(system->host_allocator()),
-      scheduler_(*system),
-      system_(std::move(system)),
+    : system_(std::move(system)),
+      host_allocator_(system_->host_allocator()),
+      scheduler_(*system_),
       worker_(worker) {
+  logging::construct("Scope", this);
   for (auto *device : devices) {
     AddDevice(device->address().logical_device_class, device);
   }
   Initialize();
 }
 
-Scope::~Scope() = default;
+Scope::~Scope() { logging::destruct("Scope", this); }
 
 std::string Scope::to_s() const {
   return fmt::format("Scope(worker='{}', devices=[{}])", worker_.name(),

--- a/libshortfin/src/shortfin/local/scope.h
+++ b/libshortfin/src/shortfin/local/scope.h
@@ -91,6 +91,9 @@ class SHORTFIN_API Scope : public std::enable_shared_from_this<Scope> {
   // All scopes are created as shared pointers.
   std::shared_ptr<Scope> shared_ptr() { return shared_from_this(); }
 
+  // The host allocator.
+  iree_allocator_t host_allocator() { return host_allocator_; }
+
   // The worker that this scope is bound to.
   Worker &worker() { return worker_; }
 
@@ -126,7 +129,7 @@ class SHORTFIN_API Scope : public std::enable_shared_from_this<Scope> {
   }
   detail::Scheduler &scheduler() { return scheduler_; }
   detail::TimelineResource::Ref NewTimelineResource() {
-    return scheduler().NewTimelineResource(host_allocator_);
+    return scheduler().NewTimelineResource(shared_ptr());
   }
 
   // Loads a program from a list of modules onto the devices managed by this
@@ -141,19 +144,19 @@ class SHORTFIN_API Scope : public std::enable_shared_from_this<Scope> {
   void AddDevice(std::string_view device_class, Device *device);
   void Initialize();  // Called after all devices are added.
 
-  iree_allocator_t host_allocator_;
+  // Back reference to owning system.
+  std::shared_ptr<System> system_;
   string_interner interner_;
+  iree_allocator_t host_allocator_;
+  detail::Scheduler scheduler_;
+  Worker &worker_;
+
   // Map of `<device_class>` to the count of that class contained.
   std::unordered_map<std::string_view, int> device_class_count_;
   // Ordered devices.
   std::vector<Device *> devices_;
   // Map of `<device_class><index>` to Device.
   std::unordered_map<std::string_view, Device *> named_devices_;
-  detail::Scheduler scheduler_;
-
-  // Back reference to owning system.
-  std::shared_ptr<System> system_;
-  Worker &worker_;
 };
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/support/blocking_executor.cc
+++ b/libshortfin/src/shortfin/support/blocking_executor.cc
@@ -59,9 +59,18 @@ void BlockingExecutor::Kill(bool wait, iree_timeout_t warn_timeout) {
       iree::slim_mutex_lock_guard g(control_mu_);
       last_live_thread_count = live_thread_count_;
       total_thread_count = created_thread_count_;
+      // If transitioned to 0 live threads, there is a short period of time
+      // that can exist between the scan of the free list above and a task
+      // getting scheduled. Therefore, the first time we hit this condition,
+      // enter the inhibited state, which denies further scheduling. Then
+      // the next time we encounter no live threads, that will be a true
+      // count.
       if (live_thread_count_ == 0) {
-        inhibit_ = true;
-        break;
+        if (inhibit_) {
+          break;
+        } else {
+          inhibit_ = true;
+        }
       }
     }
 

--- a/libshortfin/src/shortfin/support/blocking_executor_test.cc
+++ b/libshortfin/src/shortfin/support/blocking_executor_test.cc
@@ -13,7 +13,13 @@
 
 namespace shortfin {
 
-TEST(BlockingExecutor, concurrent_tasks) {
+class BlockingExecutorTest : public testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override { iree::detail::LogLiveRefs(); }
+};
+
+TEST_F(BlockingExecutorTest, concurrent_tasks) {
   {
     std::atomic<int> tasks_run{0};
 
@@ -33,7 +39,7 @@ TEST(BlockingExecutor, concurrent_tasks) {
   }
 }
 
-TEST(BlockingExecutor, inhibit_when_shutdown) {
+TEST_F(BlockingExecutorTest, inhibit_when_shutdown) {
   {
     std::atomic<int> tasks_run{0};
 
@@ -46,6 +52,7 @@ TEST(BlockingExecutor, inhibit_when_shutdown) {
     }
 
     executor.Kill(/*wait=*/true);
+    logging::info("Killed");
 
     // New work should be inhibited.
     try {
@@ -57,7 +64,7 @@ TEST(BlockingExecutor, inhibit_when_shutdown) {
   }
 }
 
-TEST(BlockingExecutor, warn_deadline) {
+TEST_F(BlockingExecutorTest, warn_deadline) {
   {
     std::atomic<int> tasks_run{0};
 
@@ -75,7 +82,7 @@ TEST(BlockingExecutor, warn_deadline) {
   }
 }
 
-TEST(BlockingExecutor, threads_recycle) {
+TEST_F(BlockingExecutorTest, threads_recycle) {
   {
     std::atomic<int> tasks_run{0};
 

--- a/libshortfin/src/shortfin/support/iree_concurrency.h
+++ b/libshortfin/src/shortfin/support/iree_concurrency.h
@@ -18,8 +18,15 @@ namespace shortfin::iree {
 
 namespace detail {
 struct thread_ptr_helper {
-  static void retain(iree_thread_t *obj) { iree_thread_retain(obj); }
-  static void release(iree_thread_t *obj) { iree_thread_release(obj); }
+  static void steal(iree_thread_t *obj) { LogIREESteal("iree_thread_t", obj); }
+  static void retain(iree_thread_t *obj) {
+    LogIREERetain("iree_thread_t", obj);
+    iree_thread_retain(obj);
+  }
+  static void release(iree_thread_t *obj) {
+    LogIREERelease("iree_thread_t", obj);
+    iree_thread_release(obj);
+  }
 };
 };  // namespace detail
 

--- a/libshortfin/src/shortfin/support/iree_helpers.cc
+++ b/libshortfin/src/shortfin/support/iree_helpers.cc
@@ -6,7 +6,80 @@
 
 #include "shortfin/support/iree_helpers.h"
 
+#include <fmt/core.h>
+
+#include <atomic>
+#include <unordered_map>
+
+#include "shortfin/support/iree_concurrency.h"
+#include "shortfin/support/logging.h"
+
 namespace shortfin::iree {
+
+namespace detail {
+
+#if SHORTFIN_IREE_LOG_RC
+
+slim_mutex log_mutex;
+std::unordered_map<std::string, int> app_ref_counts;
+
+void LogIREERetain(const char *type_name, void *ptr) {
+  slim_mutex_lock_guard g(log_mutex);
+  std::string key = fmt::format("{}({})", type_name, ptr);
+  int &rc = app_ref_counts[key];
+  rc += 1;
+  if (rc == 1) {
+    logging::info("IREE new {}", key);
+  } else {
+    logging::info("IREE retain {} = {}", key, rc);
+  }
+}
+
+void LogIREERelease(const char *type_name, void *ptr) {
+  slim_mutex_lock_guard g(log_mutex);
+  std::string key = fmt::format("{}({})", type_name, ptr);
+  int &rc = app_ref_counts[key];
+  rc -= 1;
+  if (rc == 0) {
+    logging::info("IREE delete {}", key);
+  } else {
+    logging::info("IREE release {} = {}", key, rc);
+  }
+}
+
+void LogIREESteal(const char *type_name, void *ptr) {
+  slim_mutex_lock_guard g(log_mutex);
+  std::string key = fmt::format("{}({})", type_name, ptr);
+  int &rc = app_ref_counts[key];
+  rc += 1;
+  if (rc == 1) {
+    logging::info("IREE steal {}", key);
+  } else {
+    logging::info("IREE retain {} = {}", key, rc);
+  }
+}
+
+void SHORTFIN_API LogLiveRefs() {
+  slim_mutex_lock_guard g(log_mutex);
+  bool logged_banner = false;
+  for (auto &it : app_ref_counts) {
+    if (it.second == 0) continue;
+    if (it.second < 0) {
+      logging::error("Shortfin IREE negative reference count: {} = {}",
+                     it.first, it.second);
+      continue;
+    }
+    if (!logged_banner) {
+      logged_banner = true;
+      logging::warn("Shortfin visible live IREE refs remain:");
+    }
+    logging::warn("  Live IREE ref {} = {}", it.first, it.second);
+  }
+}
+
+#endif
+
+}  // namespace detail
 
 error::error(std::string message, iree_status_t failing_status)
     : message_(std::move(message)), failing_status_(failing_status) {
@@ -19,7 +92,7 @@ void error::AppendStatus() const noexcept {
   status_appended_ = false;
 
   iree_allocator_t allocator = iree_allocator_system();
-  char* status_buffer = nullptr;
+  char *status_buffer = nullptr;
   iree_host_size_t length = 0;
   if (iree_status_to_string(failing_status_, &allocator, &status_buffer,
                             &length)) {

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -17,6 +17,10 @@
 #include "iree/vm/api.h"
 #include "shortfin/support/api.h"
 
+#if !defined(SHORTFIN_IREE_LOG_RC)
+#define SHORTFIN_IREE_LOG_RC 0
+#endif
+
 namespace shortfin {
 
 // -------------------------------------------------------------------------- //
@@ -36,59 +40,142 @@ namespace iree {
 
 namespace detail {
 
+#if SHORTFIN_IREE_LOG_RC
+void SHORTFIN_API LogIREERetain(const char *type_name, void *ptr);
+void SHORTFIN_API LogIREERelease(const char *type_name, void *ptr);
+void SHORTFIN_API LogIREESteal(const char *type_name, void *ptr);
+void SHORTFIN_API LogLiveRefs();
+#else
+inline void LogIREERetain(const char *type_name, void *ptr) {}
+inline void LogIREERelease(const char *type_name, void *ptr) {}
+inline void LogIREESteal(const char *type_name, void *ptr) {}
+inline void LogLiveRefs() {}
+#endif
+
 struct hal_buffer_ptr_helper {
-  static void retain(iree_hal_buffer_t *obj) { iree_hal_buffer_retain(obj); }
-  static void release(iree_hal_buffer_t *obj) { iree_hal_buffer_release(obj); }
+  static void steal(iree_hal_buffer_t *obj) {
+    LogIREESteal("iree_hal_buffer_t", obj);
+  }
+  static void retain(iree_hal_buffer_t *obj) {
+    LogIREERetain("iree_hal_buffer_t", obj);
+    iree_hal_buffer_retain(obj);
+  }
+  static void release(iree_hal_buffer_t *obj) {
+    LogIREERelease("iree_hal_buffer_t", obj);
+    iree_hal_buffer_release(obj);
+  }
 };
 
 struct hal_command_buffer_helper {
+  static void steal(iree_hal_command_buffer_t *obj) {
+    LogIREESteal("iree_hal_command_buffer_t", obj);
+  }
   static void retain(iree_hal_command_buffer_t *obj) {
+    LogIREERetain("iree_hal_command_buffer_t", obj);
     iree_hal_command_buffer_retain(obj);
   }
   static void release(iree_hal_command_buffer_t *obj) {
+    LogIREERelease("iree_hal_command_buffer_t", obj);
     iree_hal_command_buffer_release(obj);
   }
 };
 
 struct hal_device_ptr_helper {
-  static void retain(iree_hal_device_t *obj) { iree_hal_device_retain(obj); }
-  static void release(iree_hal_device_t *obj) { iree_hal_device_release(obj); }
+  static void steal(iree_hal_device_t *obj) {
+    LogIREESteal("iree_hal_device_t", obj);
+  }
+  static void retain(iree_hal_device_t *obj) {
+    LogIREERetain("iree_hal_device_t", obj);
+    iree_hal_device_retain(obj);
+  }
+  static void release(iree_hal_device_t *obj) {
+    LogIREERelease("iree_hal_device_t", obj);
+    iree_hal_device_release(obj);
+  }
 };
 
 struct hal_driver_ptr_helper {
-  static void retain(iree_hal_driver_t *obj) { iree_hal_driver_retain(obj); }
-  static void release(iree_hal_driver_t *obj) { iree_hal_driver_release(obj); }
+  static void steal(iree_hal_driver_t *obj) {
+    LogIREESteal("iree_hal_driver_t", obj);
+  }
+  static void retain(iree_hal_driver_t *obj) {
+    LogIREERetain("iree_hal_driver_t", obj);
+    iree_hal_driver_retain(obj);
+  }
+  static void release(iree_hal_driver_t *obj) {
+    LogIREERelease("iree_hal_driver_t", obj);
+    iree_hal_driver_release(obj);
+  }
 };
 
 struct hal_fence_ptr_helper {
-  static void retain(iree_hal_fence_t *obj) { iree_hal_fence_retain(obj); }
-  static void release(iree_hal_fence_t *obj) { iree_hal_fence_release(obj); }
+  static void steal(iree_hal_fence_t *obj) {
+    LogIREESteal("iree_hal_fence_t", obj);
+  }
+  static void retain(iree_hal_fence_t *obj) {
+    LogIREERetain("iree_hal_fence_t", obj);
+    iree_hal_fence_retain(obj);
+  }
+  static void release(iree_hal_fence_t *obj) {
+    LogIREERelease("iree_hal_fence_t", obj);
+    iree_hal_fence_release(obj);
+  }
 };
 
 struct hal_semaphore_ptr_helper {
+  static void steal(iree_hal_semaphore_t *obj) {
+    LogIREESteal("iree_hal_semaphore_t", obj);
+  }
   static void retain(iree_hal_semaphore_t *obj) {
+    LogIREERetain("iree_hal_semaphore_t", obj);
     iree_hal_semaphore_retain(obj);
   }
   static void release(iree_hal_semaphore_t *obj) {
+    LogIREERelease("iree_hal_semaphore_t", obj);
     iree_hal_semaphore_release(obj);
   }
 };
 
 struct vm_context_ptr_helper {
-  static void retain(iree_vm_context_t *obj) { iree_vm_context_retain(obj); }
-  static void release(iree_vm_context_t *obj) { iree_vm_context_release(obj); }
+  static void steal(iree_vm_context_t *obj) {
+    LogIREESteal("iree_vm_context_t", obj);
+  }
+  static void retain(iree_vm_context_t *obj) {
+    LogIREERetain("iree_vm_context_t", obj);
+    iree_vm_context_retain(obj);
+  }
+  static void release(iree_vm_context_t *obj) {
+    LogIREERelease("iree_vm_context_t", obj);
+    iree_vm_context_release(obj);
+  }
 };
 
 struct vm_instance_ptr_helper {
-  static void retain(iree_vm_instance_t *obj) { iree_vm_instance_retain(obj); }
+  static void steal(iree_vm_instance_t *obj) {
+    LogIREESteal("iree_vm_instance_t", obj);
+  }
+  static void retain(iree_vm_instance_t *obj) {
+    LogIREERetain("iree_vm_instance_t", obj);
+    iree_vm_instance_retain(obj);
+  }
   static void release(iree_vm_instance_t *obj) {
+    LogIREERelease("iree_vm_instance_t", obj);
     iree_vm_instance_release(obj);
   }
 };
 
 struct vm_module_ptr_helper {
-  static void retain(iree_vm_module_t *obj) { iree_vm_module_retain(obj); }
-  static void release(iree_vm_module_t *obj) { iree_vm_module_release(obj); }
+  static void steal(iree_vm_module_t *obj) {
+    LogIREESteal("iree_vm_module_t", obj);
+  }
+  static void retain(iree_vm_module_t *obj) {
+    LogIREERetain("iree_vm_module_t", obj);
+    iree_vm_module_retain(obj);
+  }
+  static void release(iree_vm_module_t *obj) {
+    LogIREERelease("iree_vm_module_t", obj);
+    iree_vm_module_release(obj);
+  }
 };
 
 };  // namespace detail
@@ -105,41 +192,60 @@ class object_ptr {
     }
   }
   object_ptr(object_ptr &&other) : ptr(other.ptr) { other.ptr = nullptr; }
+  object_ptr &operator=(const object_ptr &other) = delete;
   object_ptr &operator=(object_ptr &&other) {
+    reset();
     ptr = other.ptr;
     other.ptr = nullptr;
     return *this;
   }
-  ~object_ptr() {
-    if (ptr) {
-      Helper::release(ptr);
-    }
-  }
+  ~object_ptr() { reset(); }
 
   // Constructs a new object_ptr by transferring ownership of a raw
   // pointer.
-  static object_ptr steal_reference(T *owned) { return object_ptr(owned); }
+  static object_ptr steal_reference(T *owned) {
+    Helper::steal(owned);
+    return object_ptr(owned);
+  }
+  // Constructs a new object_ptr by retaining a raw pointer.
   static object_ptr borrow_reference(T *owned) {
     Helper::retain(owned);
     return object_ptr(owned);
   }
   operator T *() const noexcept { return ptr; }
 
+  class Assignment {
+   public:
+    explicit Assignment(object_ptr *assign) : assign(assign) {}
+    ~Assignment() {
+      if (assign->ptr) {
+        Helper::steal(assign->ptr);
+      }
+    }
+
+    constexpr operator T **() noexcept {
+      return reinterpret_cast<T **>(&assign->ptr);
+    }
+
+   private:
+    object_ptr *assign = nullptr;
+  };
+
   // Releases any current reference held by this instance and returns a
   // pointer to the raw backing pointer. This is typically used for passing
   // to out parameters which are expected to store a new owned pointer directly.
-  T **for_output() {
+  constexpr Assignment for_output() noexcept {
     reset();
-    return &ptr;
+    return Assignment(this);
   }
 
   operator bool() const { return ptr != nullptr; }
   T *get() const { return ptr; }
-  void reset(T *other = nullptr) {
+  void reset() {
     if (ptr) {
       Helper::release(ptr);
     }
-    ptr = other;
+    ptr = nullptr;
   }
   T *release() {
     T *ret = ptr;
@@ -151,6 +257,8 @@ class object_ptr {
   // Assumes the reference count for owned_ptr.
   object_ptr(T *owned_ptr) : ptr(owned_ptr) {}
   T *ptr = nullptr;
+
+  friend class Assignment;
 };
 
 using hal_buffer_ptr =

--- a/libshortfin/src/shortfin/support/iree_helpers_test.cc
+++ b/libshortfin/src/shortfin/support/iree_helpers_test.cc
@@ -29,6 +29,7 @@ struct iree_dummy_t {
 };
 
 struct dummy_ptr_helper {
+  static void steal(iree_dummy_t *obj) {}
   static void retain(iree_dummy_t *obj) { obj->retain_count++; }
   static void release(iree_dummy_t *obj) { obj->release_count++; }
 };

--- a/libshortfin/src/shortfin/support/logging.h
+++ b/libshortfin/src/shortfin/support/logging.h
@@ -9,6 +9,10 @@
 
 #include "spdlog/spdlog.h"
 
+#if !defined(SHORTFIN_LOG_LIFETIMES)
+#define SHORTFIN_LOG_LIFETIMES 0
+#endif
+
 namespace shortfin::logging {
 
 // TODO: Re-export doesn't really work like this. Need to define API
@@ -17,6 +21,22 @@ using spdlog::debug;
 using spdlog::error;
 using spdlog::info;
 using spdlog::warn;
+
+#if SHORTFIN_LOG_LIFETIMES
+template <typename T>
+inline void construct(const char* type_name, T* inst) {
+  info("new {}({})", type_name, static_cast<void*>(inst));
+}
+template <typename T>
+inline void destruct(const char* type_name, T* inst) {
+  info("delete {}({})", type_name, static_cast<void*>(inst));
+}
+#else
+template <typename T>
+inline void construct(const char *type_name, T *) {}
+template <typename T>
+inline void destruct(const char *type_name, T *) {}
+#endif
 
 }  // namespace shortfin::logging
 


### PR DESCRIPTION
Prior to this, TimelineResource held a raw C++ reference to the scope but did not hold a shared_ptr ref to it. The storage class, which holds buffers alive, was keeping the raw IREE buffer and device alive but not the shortfin object hierarchy. On the happy path, this does not cause issues, but during abnormal termination and other race conditions, it can cause lifetime problems.

Here we:

* Make TimelineResource hold a std::shared_ptr<Scope>, which transitively keeps everything alive that can be accessed.
* Clean up incorrect ordering of fields in key classes, which could cause dependent objects to be destroyed out of order.
* Remove cases in iree::object_ptr which could have resulted in incorrect accounting in certain scenarios.
* Adds compile-time flags to perform verbose shortfin lifetime logging and application-side IREE reference checks.
* Change System::Shutdown() to not clear object references that still may be live (leave that for the destructor).
* Correct an issue where drivers could be retained forever, which was then masking another lifetime issue during abnormal termination.
* Find a low rate shutdown race triggering use-after-free in the BlockingExecutor and fix it (found by lifetime logging).
* Ensure that all tests are ASAN and LSAN clean, even with a new abnormal termination case added (see updates to include buffer copying, which is currently triggering a buffer permission exception, which set this whole triage session in motion).