### PR TITLE
Pin IREE to specific version

### DIFF
--- a/.github/workflows/ci_linux_x64-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64-libshortfin.yml
@@ -46,6 +46,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
+        ref: candidate-20240904.1006
 
     - name: Initalize IREE submodules
       run : |

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -96,6 +96,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
+        ref: candidate-20240904.1006
 
     - name: Initalize IREE submodules
       run : |
@@ -130,6 +131,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pip install -r ${{ env.LIBSHORTFIN_DIR }}/requirements-tests.txt
+        pip install -r ${{ env.LIBSHORTFIN_DIR }}/requirements-iree-compiler.txt
         pip freeze
 
     - name: Save Python dependencies cache

--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -130,7 +130,7 @@ if (NOT SHORTFIN_IREE_SOURCE_DIR AND SHORTFIN_BUNDLE_DEPS)
   FetchContent_Declare(
     iree
     GIT_REPOSITORY https://github.com/iree-org/iree.git
-    GIT_TAG candidate-20240821.992
+    GIT_TAG candidate-20240904.1006
     # TODO: We shouldn't have to pull googletest when we are not building tests.
     #       This needs to be fixed with IREE.
     GIT_SUBMODULES "third_party/benchmark third_party/cpuinfo third_party/flatcc third_party/hip-build-deps third_party/googletest"

--- a/libshortfin/requirements-iree-compiler.txt
+++ b/libshortfin/requirements-iree-compiler.txt
@@ -1,0 +1,3 @@
+# Keep in sync with IREE_REF in CI and GIT_TAG in CMakeLists.txt
+-f https://iree.dev/pip-release-links.html
+iree-compiler==20240904.1006


### PR DESCRIPTION
Pins IREE checkout in the CI or obtained via FetchContent to the same specified version. Furthermore, installs the iree-compiler in the CI.