### PR TITLE
Place args for all gather/reduce on devices before the op to avoid CSE and excessive copying

### DIFF
--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -114,7 +114,8 @@ class AllOfExprsVariadic(BoolTypeExpr):
                 return False
             exprs = self._exprs
             if len(types) > len(exprs):
-                exprs = exprs + [exprs[-1]] * (len(types) - len(self._exprs))
+                # pad with the trailing expression.
+                exprs = exprs + ([exprs[-1]] * (len(types) - len(self._exprs)))
             return all([e(t) for e, t in zip(exprs, types)])
 
         super().__init__(expr)

--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -18,6 +18,7 @@ from ..types import PrimitiveTensor, QuantizedTensor
 
 __all__ = [
     "AllOfExprs",
+    "AllOfExprsVariadic",
     "AllOfType",
     "AnyOfType",
     "IsOfType",
@@ -65,7 +66,8 @@ class BoolTypeExpr:
 
 
 class AllOfExprs(BoolTypeExpr):
-    """Returns True if all types match their respective boolean type expression.
+    """Returns True if all type arguments match their respective boolean type
+    expression.
 
     ```python
     # True. int == int and str in (float, str).
@@ -83,6 +85,37 @@ class AllOfExprs(BoolTypeExpr):
             if len(types) < len(self._exprs):
                 return False
             return all([e(t) for e, t in zip(self._exprs, types)])
+
+        super().__init__(expr)
+
+
+class AllOfExprsVariadic(BoolTypeExpr):
+    """Returns True if all type arguments match their respective boolean type
+    expression and any remaining trailing arguments match the last type expression.
+
+    ```python
+    # True. int == int
+    # str in (float, str).
+    # float in (float, str).
+    AllOfExprsVariadic(IsOfType(int), IsOfType(float, str))(int, str, float)
+
+     # False. str is not in (int, float).
+    AllOfExprsVariadic(IsOfType(int), IsOfType(int, float))(int, float, str, int)
+    ```
+    """
+
+    def __init__(self, *exprs: BoolTypeExpr):
+        if len(exprs) == 0:
+            raise ValueError("At least one expression is required.")
+        self._exprs = list(exprs)
+
+        def expr(*types: type):
+            if len(types) < len(self._exprs):
+                return False
+            exprs = self._exprs
+            if len(types) > len(exprs):
+                exprs = exprs + [exprs[-1]] * (len(types) - len(self._exprs))
+            return all([e(t) for e, t in zip(exprs, types)])
 
         super().__init__(expr)
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -88,11 +88,30 @@ def elementwise_binary(operator, x, y):
         IsOfType(Tensor, InferenceTensor, Number),
     )
 )
-def elementwise_multi_args(operator, x, y, *args):
-    x = unbox_tensor(x)
-    if isinstance(y, PrimitiveTensor):
-        y = unbox_tensor(y)
-    return elementwise(operator, elementwise(operator, x, y), *args)
+def elementwise_variadic(operator, x, y, *args):
+    """Folds by successively applying the binary operator from left to right until
+    exhaustion.
+
+    Match a variable number of tensor/number arguments with at least 3 such arguments.
+
+    Example matches
+    ```
+    (Tensor, Tensor, Tensor)
+    (Tensor, DefaultPrimitiveTensor, float),
+    (SplitPrimitiveTensor, ReplicatedTensor, int, Tensor)
+    ```
+
+    Will not match
+    ```
+    (Tensor)
+    (Tensor, Tensor)
+    (int, Tensor, Tensor)
+    ```
+    """
+    res = elementwise(operator, x, y)
+    for arg in args:
+        res = elementwise(operator, res, arg)
+    return res
 
 
 # Embedding Lookup

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -30,7 +30,6 @@ from ..utils.math import ceildiv
 from shark_turbine.aot import (
     ExternalTensorTrait,
 )
-from shark_turbine.ops.iree import transfer_to_logical_device
 from ..utils import tree as tree_utils
 
 from ..utils.io import ShardedArchiveBuilder
@@ -618,13 +617,15 @@ class ShardedTensorBase(ShardedTensor):
         name: str = UnnamedTensorName,
         shape: Optional[list[int]],
     ):
+        from ..ops import transfer_to_logical_device
+
         assert len(ts) > 0
         assert shard_dim is None or len(ts[0].shape) > shard_dim
         super().__init__(name=name, shape=shape, shard_dim=shard_dim)
         self._shards: tuple[DefaultPrimitiveTensor] = tuple(
             DefaultPrimitiveTensor(
                 name=f"{name}.shard.{i}",
-                data=transfer_to_logical_device(f"{i}", unbox_tensor(t)),
+                data=transfer_to_logical_device(t, i),
             )
             for i, t in enumerate(ts)
         )
@@ -867,6 +868,8 @@ class ReplicatedTensor(ShardedTensor):
         will be replicated that many times.
         """
 
+        from ..ops import transfer_to_logical_device
+
         if isinstance(ts, torch.Tensor):
             assert shard_count is not None
             ts = [ts] * shard_count
@@ -884,7 +887,7 @@ class ReplicatedTensor(ShardedTensor):
         self._shards: tuple[DefaultPrimitiveTensor] = tuple(
             DefaultPrimitiveTensor(
                 name=f"{name}.shard.{i}",
-                data=transfer_to_logical_device(f"{i}", unbox_tensor(t)),
+                data=transfer_to_logical_device(t, i),
             )
             for i, t in enumerate(ts)
         )

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -8,6 +8,7 @@ import unittest
 
 import torch
 import torch.nn.functional as F
+from parameterized import parameterized
 
 from sharktank import ops
 from sharktank.types import *
@@ -32,6 +33,26 @@ class BroadcastDimsTest(unittest.TestCase):
         res = ops.broadcast_dims(dims, tensors)
         assert res[0] == 0
         assert res[1] == 2
+
+
+class ElementwiseTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (torch.add,),
+            (torch.div,),
+            (torch.fmin,),
+            (torch.fmax,),
+            (torch.sub),
+        ]
+    )
+    def testMultiArgOperators(self, operator):
+        a = torch.rand(2, 3, 4, dtype=torch.float32)
+        b = torch.rand(2, 3, 4, dtype=torch.float32)
+        c = torch.rand(2, 3, 4, dtype=torch.float32)
+        d = torch.rand(2, 3, 4, dtype=torch.float32)
+        expected_result = operator(operator(operator(a, b), c), d)
+        actual_result = ops.elementwise(operator, a, b, c, d)
+        torch.testing.assert_close(actual_result, expected_result)
 
 
 class EqualTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -15,6 +15,40 @@ from sharktank.types import sharding
 from sharktank.layers import Conv2DLayer
 
 
+class AllGatherTest(unittest.TestCase):
+    def testAllGather(self):
+        shard_count = 3
+        shard_shape = [3, 4]
+        shard_dim = 1
+        shards = [
+            torch.rand(shard_shape, dtype=torch.float32) for i in range(shard_count)
+        ]
+        expected_result = torch.cat(shards, dim=shard_dim)
+
+        sharded = SplitPrimitiveTensor(shard_dim=shard_dim, ts=shards)
+        actual_result = ops.all_gather(sharded)
+
+        for shard in actual_result.shards:
+            torch.testing.assert_close(shard.as_torch(), expected_result)
+
+
+class AllReduceTest(unittest.TestCase):
+    def testAllReduce(self):
+        shard_count = 3
+        shard_shape = [3, 4]
+        shard_dim = 1
+        shards = [
+            torch.rand(shard_shape, dtype=torch.float32) for i in range(shard_count)
+        ]
+        expected_result = torch.add(torch.add(shards[0], shards[1]), shards[2])
+
+        sharded = SplitPrimitiveTensor(shard_dim=shard_dim, ts=shards)
+        actual_result = ops.all_reduce(sharded)
+
+        for shard in actual_result.shards:
+            torch.testing.assert_close(shard.as_torch(), expected_result)
+
+
 class CatTest(unittest.TestCase):
     def testCatSplitDim(self):
         """Concatenation along the sharded split dimension."""
@@ -50,21 +84,6 @@ class CatTest(unittest.TestCase):
 
 
 class ConvTest(unittest.TestCase):
-    def testAllGather(self):
-        shard_count = 3
-        shard_shape = [3, 4]
-        shard_dim = 1
-        shards = [
-            torch.rand(shard_shape, dtype=torch.float32) for i in range(shard_count)
-        ]
-        expected_result = torch.cat(shards, dim=shard_dim)
-
-        sharded = SplitPrimitiveTensor(shard_dim=shard_dim, ts=shards)
-        actual_result = ops.all_gather(sharded)
-
-        for shard in actual_result.shards:
-            torch.testing.assert_close(shard.as_torch(), expected_result)
-
     def testConv2dShardedInputAndOutputChannelsOneGroup(self):
         batches = 2
         in_channels = 6


### PR DESCRIPTION
We are encoding the device/shard information in the flow.tensor.transfer/transfer_to_logical_device
operation. Then if we do an all-gather or an all-reduce, CSE is happy to collapse the expressions into one. This would result in the all-gather/all-reduce being performed on one device and then the result is copied to the rest. We want each device to do the all-gather/all-reduce.

There is no easy way to test the desired effect, but at least we test for correctness on the PyTorch level.

This change adds the all_reduce op that is currently not used anywhere.
Here is expanded the elementwise op to support a variable number of tensor arguments.