### PR TITLE
[libshortfin] Remove env var

### DIFF
--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -164,8 +164,6 @@ jobs:
 
     - name: Run ctest
       if: ${{ !cancelled() }}
-      env:
-        CTEST_OUTPUT_ON_FAILURE: 1
       run: |
         cd ${{ env.LIBSHORTFIN_DIR }}/build
         ctest --timeout 30 --output-on-failure


### PR DESCRIPTION
With the change to call ctest directly, `--output-on-failure` was added as a command line argument.