### PR TITLE
[libshortfin] Fix and Improve static build ergonomics

### DIFF
--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -43,10 +43,19 @@ set(SHORTFIN_IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 # Options for building static or dynamic libraries.
 option(SHORTFIN_BUILD_STATIC "Builds static libraries" OFF)
 option(SHORTFIN_BUILD_DYNAMIC "Builds dynamic libraries" ON)
-cmake_dependent_option(SHORTFIN_LINK_DYNAMIC "Links internal binaries against static libshortfin.a" ON "SHORTFIN_BUILD_DYNAMIC" OFF)
 if(NOT SHORTFIN_BUILD_STATIC AND NOT SHORTFIN_BUILD_DYNAMIC)
   message(FATAL_ERROR "One of SHORTFIN_BUILD_STATIC or SHORTFIN_BUILD_DYNAMIC must be ON")
 endif()
+# Since dynamic build is the default option, if someone specifies they want
+# a static build, and both options are on, we should build a static build.
+if (SHORTFIN_BUILD_STATIC)
+  if (SHORTFIN_BUILD_DYNAMIC)
+    message(STATUS "Both SHORTFIN_BUILD_DYNAMIC and SHORTFIN_BUILD_STATIC specified, choosing static build")
+  endif()
+  set(SHORTFIN_BUILD_DYNAMIC OFF)
+endif()
+# Link static/dynamic based on build type.
+cmake_dependent_option(SHORTFIN_LINK_DYNAMIC "Links internal binaries against static libshortfin.a" ON "SHORTFIN_BUILD_DYNAMIC" OFF)
 message(STATUS "Shortfin build static = ${SHORTFIN_BUILD_STATIC}, dynamic = ${SHORTFIN_BUILD_DYNAMIC}")
 if(SHORTFIN_LINK_DYNAMIC)
   message(STATUS "Dynamic linking to shortfin")

--- a/libshortfin/build_tools/cmake/shortfin_library.cmake
+++ b/libshortfin/build_tools/cmake/shortfin_library.cmake
@@ -27,9 +27,9 @@ function(shortfin_public_library)
   if(SHORTFIN_BUILD_STATIC)
     # Static library.
     shortfin_components_to_static_libs(_STATIC_COMPONENTS ${_RULE_COMPONENTS})
-    add_library("${_RULE_NAME}-static" STATIC)
+    add_library("${_RULE_NAME}" STATIC)
     target_link_libraries(
-      "${_RULE_NAME}-static" PUBLIC ${_STATIC_COMPONENTS}
+      "${_RULE_NAME}" PUBLIC ${_STATIC_COMPONENTS}
     )
   endif()
 

--- a/libshortfin/src/CMakeLists.txt
+++ b/libshortfin/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 shortfin_public_library(
   NAME
-    shortfin
+  ${SHORTFIN_LINK_LIBRARY_NAME}
   COMPONENTS
     shortfin_array
     shortfin_local
@@ -29,4 +29,7 @@ shortfin_public_library(
     ${_INIT_INTERNAL_DEPS}
 )
 
-set_target_properties(shortfin PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} SOVERSION ${SOVERSION})
+set_target_properties(${SHORTFIN_LINK_LIBRARY_NAME}
+                       PROPERTIES
+                       VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+                       SOVERSION ${SOVERSION})


### PR DESCRIPTION
Changes two things:

- Instead of changing the name of the rule in cmake magic, specify it explicitly in src/CMakeLists.txt . Without this, we cannot set target options and static build doesn't work, because the rule name is changed.
- If SHORTFIN_BUILD_STATIC and SHORTFIN_BUILD_DYNAMIC both are specified, choose SHORTFIN_BUILD_STATIC, since SHORTFIN_BUILD_DYNAMIC is default.