### PR TITLE
[libshortfin] Only set (so)version on dynamic libs

### DIFF
--- a/libshortfin/build_tools/cmake/shortfin_library.cmake
+++ b/libshortfin/build_tools/cmake/shortfin_library.cmake
@@ -41,6 +41,10 @@ function(shortfin_public_library)
     target_link_libraries(
       "${_RULE_NAME}" PUBLIC ${_DYLIB_COMPONENTS}
     )
+    set_target_properties("${_RULE_NAME}" PROPERTIES
+      VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+      SOVERSION ${SOVERSION}
+    )
   endif()
 endfunction()
 

--- a/libshortfin/src/CMakeLists.txt
+++ b/libshortfin/src/CMakeLists.txt
@@ -28,5 +28,3 @@ shortfin_public_library(
     shortfin_systems_host
     ${_INIT_INTERNAL_DEPS}
 )
-
-set_target_properties(shortfin PROPERTIES VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} SOVERSION ${SOVERSION})


### PR DESCRIPTION
With this the static as well as the dynamic library can be build at the same time. However, the version / so version should only be set on the dynamic library and only if that library is build.

Supersedes #187.