### PR TITLE
Set use_hf attribute in LlamaConfig of `export_paged_llm_v1` to fix export error

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -56,6 +56,7 @@ def main():
 
     hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
     llama_config = LlamaModelConfig(hp)
+    llama_config.use_hf = False
     llama_config.static_tables = False  # Rely on the compiler for hoisting tables.
     llama_config.kv_cache_type = "direct" if args.bs == [1] else "paged"
     if llama_config.hp.expert_count:


### PR DESCRIPTION
We need to set the `use_hf` attribute for LlamaModelConfig when exporting the IR's because the params from gguf do not include the `use_hf` attribute. Fixes the export error below:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/avsharma/sharktank/sharktank/sharktank/examples/export_paged_llm_v1.py", line 226, in <module>
    main()
  File "/home/avsharma/sharktank/sharktank/sharktank/examples/export_paged_llm_v1.py", line 64, in main
    model = PagedLlamaModelV1(dataset.root_theta, llama_config)
  File "/home/avsharma/sharktank/sharktank/sharktank/models/llama/llama.py", line 130, in __init__
    self.use_hf = config.use_hf
AttributeError: 'LlamaModelConfig' object has no attribute 'use_hf'
```