### PR TITLE
Fixes TypeError in `dump_gguf` when converting Q4_1 gguf to irpa

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -433,7 +433,9 @@ class QuantizedTensor(InferenceTensor, Generic[QuantizedLayoutT]):
         it should override this method to implement properly or raise
         NotImplementedError.
         """
-        return PlanarQuantizedTensor(self.name, self.shape, self.unpack())
+        return PlanarQuantizedTensor(
+            name=self.name, shape=self.shape, layout=self.unpack()
+        )
 
     def add_to_archive(self, builder: ShardedArchiveBuilder) -> InferenceTensorMetadata:
         """By default all QuantizedTensors serialize as a generic PlanarQuantizedTensor.


### PR DESCRIPTION
Fixes this error from `dump_gguf` when converting gguf to irpa for llama3 8B Q4_1. Currently the to_planar function returns a PlanarQuantizedTensor without keyword arguments, but the PlanarQuantizedTensor __init__ method expects only keyword arguments.
```
Saving to: ../llama8b_q4_1.irpa
Save: Add PrimitiveTensor(rope_freqs.weight, [64], torch.float32)
Save: Add Q4_1(token_embd.weight, [128256, 4096])
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/avsharma/sharktank/sharktank/sharktank/tools/dump_gguf.py", line 91, in <module>
    main()
  File "/home/avsharma/sharktank/sharktank/sharktank/tools/dump_gguf.py", line 40, in main
    config.save(args.save, io_report_callback=report)
  File "/home/avsharma/sharktank/sharktank/sharktank/types/theta.py", line 324, in save
    _dataset_save_helper(self, path, io_report_callback=io_report_callback)
  File "/home/avsharma/sharktank/sharktank/sharktank/types/theta.py", line 498, in _dataset_save_helper
    dataset.root_theta.add_tensors_to_archive(
  File "/home/avsharma/sharktank/sharktank/sharktank/types/theta.py", line 196, in add_tensors_to_archive
    meta = inference_tensor.add_to_archive(irpa)
  File "/home/avsharma/sharktank/sharktank/sharktank/types/tensors.py", line 443, in add_to_archive
    return self.to_planar().add_to_archive(builder)
  File "/home/avsharma/sharktank/sharktank/sharktank/types/tensors.py", line 436, in to_planar
    return PlanarQuantizedTensor(self.name, self.shape, self.unpack())
TypeError: PlanarQuantizedTensor.__init__() takes 1 positional argument but 4 were given
```