### PR TITLE
[libshortfin] Fix illegal nested lock access in Message destruction.

### DIFF
--- a/libshortfin/CMakeLists.txt
+++ b/libshortfin/CMakeLists.txt
@@ -57,6 +57,14 @@ else()
   set(SHORTFIN_LINK_LIBRARY_NAME "shortfin-static")
 endif()
 
+# Includes.
+list(APPEND CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
+)
+include(shortfin_library)
+include(CheckCXXCompilerFlag)
+include(FetchContent)
+
 # Enabling ASAN. Note that this will work best if building in a completely
 # bundled fashion and with an ASAN rigged CPython. Otherwise, various LD_PRELOAD
 # hacks are needed. This is merely a develope convenience: people are more
@@ -70,6 +78,13 @@ if(SHORTFIN_ENABLE_ASAN)
   add_compile_definitions(IREE_SANITIZER_ADDRESS)
 endif()
 
+# Thread safety annotations: Enabled if the compiler supports it.
+check_cxx_compiler_flag("-Wthread-safety" SHORTFIN_HAS_THREAD_SAFETY_ANNOTATIONS)
+if(SHORTFIN_HAS_THREAD_SAFETY)
+  add_compile_options(-Wthread-safety)
+  add_compile_definitions(SHORTFIN_HAS_THREAD_SAFETY_ANNOTATIONS)
+endif()
+
 option(SHORTFIN_SYSTEMS_AMDGPU "Builds for AMD GPU systems" ON)
 message(STATUS "libshortfin supported systems:")
 if(SHORTFIN_SYSTEMS_AMDGPU)
@@ -77,14 +92,6 @@ if(SHORTFIN_SYSTEMS_AMDGPU)
   add_compile_definitions("SHORTFIN_HAVE_AMDGPU")
 endif()
 message(STATUS "  - Host")
-
-include(FetchContent)
-
-# Includes.
-list(APPEND CMAKE_MODULE_PATH
-  ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
-)
-include(shortfin_library)
 
 # Dependencies.
 

--- a/libshortfin/src/shortfin/local/async.h
+++ b/libshortfin/src/shortfin/local/async.h
@@ -112,23 +112,25 @@ class SHORTFIN_API Future {
     virtual ~BaseState();
     iree::slim_mutex lock_;
     Worker *worker_;
-    int ref_count_ = 1;
-    iree::ignorable_status failure_status_;
-    bool done_ = false;
-    std::vector<FutureCallback> callbacks_;
+    int ref_count_ SHORTFIN_GUARDED_BY(lock_) = 1;
+    iree::ignorable_status failure_status_ SHORTFIN_GUARDED_BY(lock_);
+    bool done_ SHORTFIN_GUARDED_BY(lock_) = false;
+    std::vector<FutureCallback> callbacks_ SHORTFIN_GUARDED_BY(lock_);
   };
 
   Future(BaseState *state) : state_(state) {}
   void Retain() const;
   void Release() const;
   static Worker *GetRequiredWorker();
-  void set_success() { state_->done_ = true; }
+  void SetSuccessWithLockHeld() SHORTFIN_REQUIRES_LOCK(state_->lock_) {
+    state_->done_ = true;
+  }
   // Posts a message to the worker to issue callbacks. Lock must be held.
-  void IssueCallbacksWithLockHeld();
+  void IssueCallbacksWithLockHeld() SHORTFIN_REQUIRES_LOCK(state_->lock_);
   static iree_status_t RawHandleWorkerCallback(void *state_vp, iree_loop_t loop,
                                                iree_status_t status) noexcept;
   void HandleWorkerCallback();
-  void ThrowFailureWithLockHeld();
+  void ThrowFailureWithLockHeld() SHORTFIN_REQUIRES_LOCK(state_->lock_);
 
   mutable BaseState *state_;
 };
@@ -148,7 +150,10 @@ class SHORTFIN_API VoidFuture : public Future {
     return *this;
   }
 
-  using Future::set_success;
+  void set_success() {
+    iree::slim_mutex_lock_guard g(state_->lock_);
+    SetSuccessWithLockHeld();
+  }
 };
 
 // Value containing Future.
@@ -183,7 +188,7 @@ class SHORTFIN_API TypedFuture : public Future {
           "Cannot 'set_failure' on a Future that is already done");
     }
     static_cast<TypedState *>(state_)->result_ = std::move(result);
-    set_success();
+    SetSuccessWithLockHeld();
     IssueCallbacksWithLockHeld();
   }
 

--- a/libshortfin/src/shortfin/local/messaging.cc
+++ b/libshortfin/src/shortfin/local/messaging.cc
@@ -16,8 +16,6 @@ namespace shortfin::local {
 
 template class TypedFuture<Message::Ref>;
 
-Message::~Message() = default;
-
 // -------------------------------------------------------------------------- //
 // Queue
 // -------------------------------------------------------------------------- //

--- a/libshortfin/src/shortfin/local/messaging.h
+++ b/libshortfin/src/shortfin/local/messaging.h
@@ -119,10 +119,6 @@ class SHORTFIN_API Message {
 
  protected:
   mutable iree::slim_mutex lock_;
-  // Guard a scope with the fine grained lock.
-  // iree::slim_mutex_lock_guard lock_guard() const {
-  //   return iree::slim_mutex_lock_guard(lock_);
-  // }
   // Manual retain and release. Callers must assume that the Message is no
   // longer valid after any call to Release() where they do not hold a known
   // reference.

--- a/libshortfin/src/shortfin/local/messaging.h
+++ b/libshortfin/src/shortfin/local/messaging.h
@@ -25,15 +25,29 @@ namespace shortfin::local {
 class Message;
 namespace detail {
 
-struct MessageRefOwner {
-  MessageRefOwner() : Control(nullptr) {}
+// Message lifetime by default is managed by an internal reference count
+// system. However, since Messages often need to be owned by some third
+// party system with its own notion of lifetime, it is possible to provide
+// a custom lifetime controller. This can only be done once, typically on
+// construction by a proxy system.
+struct MessageLifetimeController {
+  MessageLifetimeController() : Control(nullptr) {}
   enum class Request { RETAIN, RELEASE };
-  MessageRefOwner(void (*Control)(Request req, const Message &msg))
+  MessageLifetimeController(void (*Control)(Request req, const Message &msg))
       : Control(Control) {}
   void (*Control)(Request req, const Message &msg);
   operator bool() { return Control != nullptr; }
-  static intptr_t &access_ref_data(const Message &msg);
-  intptr_t set_owner(const Message &msg, intptr_t ref_data);
+  // Takes ownership of the Message using this ownership controller, providing
+  // new ref_data that will be stored in the message and accessed from then
+  // on without internal locking. Returns the existing reference count at the
+  // time of transfer.
+  intptr_t TakeOwnership(const Message &msg, intptr_t ref_data);
+  // Accessed the ref_data memory within the Message. This is only valid
+  // if ownership has been transferred to a lifetime controller, and it is
+  // accessed without locking. This method purely exists to add some static
+  // thread/access safety.
+  static intptr_t &AccessOwnedRefData(const Message &msg)
+      SHORTFIN_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis);
 };
 
 }  // namespace detail
@@ -58,7 +72,7 @@ class SHORTFIN_API Message {
   Message(const Message &) = delete;
   Message(Message &&) = delete;
   Message &operator=(const Message &) = delete;
-  virtual ~Message();
+  virtual ~Message() = default;
 
   // RAII class for holding a reference to a Message.
   class Ref {
@@ -104,10 +118,11 @@ class SHORTFIN_API Message {
   };
 
  protected:
+  mutable iree::slim_mutex lock_;
   // Guard a scope with the fine grained lock.
-  iree::slim_mutex_lock_guard lock_guard() const {
-    return iree::slim_mutex_lock_guard(lock_);
-  }
+  // iree::slim_mutex_lock_guard lock_guard() const {
+  //   return iree::slim_mutex_lock_guard(lock_);
+  // }
   // Manual retain and release. Callers must assume that the Message is no
   // longer valid after any call to Release() where they do not hold a known
   // reference.
@@ -121,10 +136,10 @@ class SHORTFIN_API Message {
   // sized field that the allocator can use at it sees fit. Both fields
   // are managed within a lock_ scope and are optimized for single threaded
   // access and cross-thread transfers with coarse references.
-  mutable iree::slim_mutex lock_;
-  mutable intptr_t ref_data_ = 1;
-  mutable detail::MessageRefOwner owner_;
-  friend struct detail::MessageRefOwner;
+  mutable intptr_t ref_data_ SHORTFIN_GUARDED_BY(lock_) = 1;
+  mutable detail::MessageLifetimeController lifetime_controller_
+      SHORTFIN_GUARDED_BY(lock_);
+  friend struct detail::MessageLifetimeController;
 };
 
 // Future specialization for Message::Ref.
@@ -227,37 +242,50 @@ class SHORTFIN_API QueueReader {
 // Message allocation detail
 // -------------------------------------------------------------------------- //
 
-inline intptr_t &detail::MessageRefOwner::access_ref_data(const Message &msg) {
+inline intptr_t &detail::MessageLifetimeController::AccessOwnedRefData(
+    const Message &msg) {
   return msg.ref_data_;
 }
 
-inline intptr_t detail::MessageRefOwner::set_owner(const Message &msg,
-                                                   intptr_t ref_data) {
-  auto g = msg.lock_guard();
-  assert(!msg.owner_ && "Message ref owner transfer more than once");
-  msg.owner_ = *this;
+inline intptr_t detail::MessageLifetimeController::TakeOwnership(
+    const Message &msg, intptr_t ref_data) {
+  iree::slim_mutex_lock_guard g(msg.lock_);
+  assert(!msg.lifetime_controller_ &&
+         "Message ref owner transfer more than once");
+  msg.lifetime_controller_ = *this;
   intptr_t orig_ref_data = msg.ref_data_;
   msg.ref_data_ = ref_data;
   return orig_ref_data;
 }
 
 inline void Message::Retain() const {
-  auto g = lock_guard();
-  if (owner_) {
-    owner_.Control(detail::MessageRefOwner::Request::RETAIN, *this);
+  iree::slim_mutex_lock_guard g(lock_);
+  if (lifetime_controller_) {
+    lifetime_controller_.Control(
+        detail::MessageLifetimeController::Request::RETAIN, *this);
   } else {
     ref_data_ += 1;
   }
 }
 
 inline void Message::Release() const {
-  auto g = lock_guard();
-  if (owner_) {
-    owner_.Control(detail::MessageRefOwner::Request::RELEASE, *this);
+  // Since the destructor of the lock asserts that it is not held, we must
+  // manually release the lock prior to an action that may result in
+  // destruction. As such, just manage lock manually/carefully vs using RAII.
+  lock_.Lock();
+  auto *local_controller = &lifetime_controller_;
+  if (*local_controller) {
+    lock_.Unlock();
+    local_controller->Control(
+        detail::MessageLifetimeController::Request::RELEASE, *this);
+    return;
+  } else if (--ref_data_ == 0) {
+    lock_.Unlock();
+    delete this;
+    return;
   } else {
-    if (--ref_data_ == 0) {
-      delete this;
-    }
+    lock_.Unlock();
+    return;
   }
 }
 

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -95,16 +95,14 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   // Topology access.
   std::span<const Node> nodes() { return {nodes_}; }
   std::span<Device *const> devices() { return {devices_}; }
-  const std::unordered_map<std::string_view, Device *> &named_devices() {
+  const std::unordered_map<std::string_view, Device *> named_devices() {
     return named_devices_;
   }
+  Device *FindDeviceByName(std::string_view name);
 
   // Queue access.
   Queue &CreateQueue(Queue::Options options);
   Queue &named_queue(std::string_view name);
-  const std::unordered_map<std::string_view, Queue *> named_queues() {
-    return queues_by_name_;
-  }
 
   // Access the system wide blocking executor thread pool. This can be used
   // to execute thunks that can block on a dedicated thread and is needed
@@ -141,14 +139,14 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   void FinishInitialization();
 
  private:
-  void AssertNotInitialized() {
+  void AssertNotInitialized() SHORTFIN_REQUIRES_LOCK(lock_) {
     if (initialized_) {
       throw std::logic_error(
           "System::Initialize* methods can only be called during "
           "initialization");
     }
   }
-  void AssertRunning() {
+  void AssertRunning() SHORTFIN_REQUIRES_LOCK(lock_) {
     if (!initialized_ || shutdown_) {
       throw std::logic_error(
           "System manipulation methods can only be called when initialized and "
@@ -180,7 +178,9 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   // after initialization, but mainly this is for keeping them alive.
   std::unordered_map<std::string_view, iree::hal_driver_ptr> hal_drivers_;
 
-  // Map of device name to a SystemDevice.
+  // Map of device name to a SystemDevice. Note that devices are immortal and
+  // enumerated at initialization time. As such, they are accessed without
+  // locking.
   std::vector<std::unique_ptr<Device>> retained_devices_;
   std::unordered_map<std::string_view, Device *> named_devices_;
   std::vector<Device *> devices_;
@@ -192,22 +192,25 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   BlockingExecutor blocking_executor_;
 
   // Queues.
-  std::vector<std::unique_ptr<Queue>> queues_;
-  std::unordered_map<std::string_view, Queue *> queues_by_name_;
+  std::vector<std::unique_ptr<Queue>> queues_ SHORTFIN_GUARDED_BY(lock_);
+  std::unordered_map<std::string_view, Queue *> queues_by_name_
+      SHORTFIN_GUARDED_BY(lock_);
 
   // Workers.
-  std::vector<std::unique_ptr<Worker>> workers_;
+  std::vector<std::unique_ptr<Worker>> workers_ SHORTFIN_GUARDED_BY(lock_);
   std::vector<std::function<void(Worker &)>> worker_initializers_;
-  std::unordered_map<std::string_view, Worker *> workers_by_name_;
+  std::unordered_map<std::string_view, Worker *> workers_by_name_
+      SHORTFIN_GUARDED_BY(lock_);
 
   // Process management.
-  int next_pid_ = 1;
-  std::unordered_map<int, detail::BaseProcess *> processes_by_pid_;
+  int next_pid_ SHORTFIN_GUARDED_BY(lock_) = 1;
+  std::unordered_map<int, detail::BaseProcess *> processes_by_pid_
+      SHORTFIN_GUARDED_BY(lock_);
 
   // Whether initialization is complete. If true, various low level
   // mutations are disallowed.
-  bool initialized_ = false;
-  bool shutdown_ = false;
+  bool initialized_ SHORTFIN_GUARDED_BY(lock_) = false;
+  bool shutdown_ SHORTFIN_GUARDED_BY(lock_) = false;
 
   friend class detail::BaseProcess;
 };


### PR DESCRIPTION
* When Message instances had lifetime management transferred to Python, destruction of the mutex would happen while it was held, causing an assert. I believe this was only happening in some process level GC scenarios before and was being masked. But it is also possible that it is the cause of our spurious crashes.
* While this fix made sense once I found it, I also took the change to get clang `-Wthread-safety` analysis working and wired up to a few of the trickiest pieces of thread safety code.
* This revealed real bugs and design issues that are now fixed.