### PR TITLE
[libshortfin] Rollup of API changes and fixes to support the LLM server.

### DIFF
--- a/libshortfin/examples/python/async/queue.py
+++ b/libshortfin/examples/python/async/queue.py
@@ -55,7 +55,8 @@ class ReaderProcess(sf.Process):
 
 
 async def main():
-    queue = lsys.create_queue("infeed")
+    # queue = lsys.create_queue("infeed")
+    queue = sf.Queue()
     main_scope = lsys.create_scope()
     w1 = lsys.create_worker("w1")
     w1_scope = lsys.create_scope(w1)

--- a/libshortfin/examples/python/async/queue.py
+++ b/libshortfin/examples/python/async/queue.py
@@ -55,9 +55,10 @@ class ReaderProcess(sf.Process):
 
 
 async def main():
-    # queue = lsys.create_queue("infeed")
     queue = sf.Queue()
     main_scope = lsys.create_scope()
+    # TODO: Also test named queues.
+    # queue = lsys.create_queue("infeed")
     w1 = lsys.create_worker("w1")
     w1_scope = lsys.create_scope(w1)
     await asyncio.gather(

--- a/libshortfin/examples/python/async/queue.py
+++ b/libshortfin/examples/python/async/queue.py
@@ -55,7 +55,7 @@ class ReaderProcess(sf.Process):
 
 
 async def main():
-    queue = sf.Queue()
+    queue = lsys.create_queue()
     main_scope = lsys.create_scope()
     # TODO: Also test named queues.
     # queue = lsys.create_queue("infeed")

--- a/libshortfin/examples/python/fastapi/server.py
+++ b/libshortfin/examples/python/fastapi/server.py
@@ -67,9 +67,10 @@ class System:
                         )
                         await asyncio.sleep(0.01)
                     responder.stream_part(None)
-            except Exception as e:
-                responder.close_with_error()
+            except:
                 traceback.print_exc()
+            finally:
+                responder.ensure_response()
 
 
 @asynccontextmanager

--- a/libshortfin/python/_shortfin/asyncio_bridge.py
+++ b/libshortfin/python/_shortfin/asyncio_bridge.py
@@ -48,6 +48,13 @@ class PyWorkerEventLoop(asyncio.AbstractEventLoop):
         w.delay_call(deadline, handle._sf_maybe_run)
         return handle
 
+    def call_at(self, when, callback, *args, context=None) -> asyncio.TimerHandle:
+        w = self._worker
+        deadline = int(when * 1e9)
+        handle = _TimerHandle(when, callback, args, self, context)
+        w.delay_call(deadline, handle._sf_maybe_run)
+        return handle
+
     def call_exception_handler(self, context) -> None:
         # TODO: Should route this to the central exception handler. Should
         # also play with ergonomics of how the errors get reported in
@@ -62,7 +69,7 @@ class PyWorkerEventLoop(asyncio.AbstractEventLoop):
 
     def _timer_handle_cancelled(self, handle):
         # We don't do anything special: just skip it if it comes up.
-        pass
+        ...
 
 
 class _Handle(asyncio.Handle):

--- a/libshortfin/python/array_binding.cc
+++ b/libshortfin/python/array_binding.cc
@@ -195,6 +195,7 @@ void BindArray(py::module_ &m) {
   auto refs = std::make_shared<Refs>();
 
   py::class_<DType>(m, "DType")
+      .def_prop_ro("name", &DType::name)
       .def_prop_ro("is_boolean", &DType::is_boolean)
       .def_prop_ro("is_integer", &DType::is_integer)
       .def_prop_ro("is_float", &DType::is_float)
@@ -203,6 +204,7 @@ void BindArray(py::module_ &m) {
       .def_prop_ro("is_byte_aligned", &DType::is_byte_aligned)
       .def_prop_ro("dense_byte_count", &DType::dense_byte_count)
       .def("is_integer_bitwidth", &DType::is_integer_bitwidth)
+      .def("compute_dense_nd_size", &DType::compute_dense_nd_size)
       .def(py::self == py::self)
       .def("__repr__", &DType::name);
 
@@ -375,7 +377,6 @@ void BindArray(py::module_ &m) {
                    py::rv_policy::reference_internal)
       .def_prop_ro("storage", &device_array::storage,
                    py::rv_policy::reference_internal)
-
       .def(
           "fill",
           [](py::handle_t<device_array> self, py::handle buffer) {

--- a/libshortfin/python/lib_ext.cc
+++ b/libshortfin/python/lib_ext.cc
@@ -142,9 +142,17 @@ class PyWorkerExtension : public local::Worker::Extension {
 
 class PyProcess : public local::detail::BaseProcess {
  public:
-  PyProcess(std::shared_ptr<local::Scope> scope, std::shared_ptr<Refs> refs)
-      : BaseProcess(std::move(scope)), refs_(std::move(refs)) {}
+  PyProcess(std::shared_ptr<Refs> refs)
+      : BaseProcess(), refs_(std::move(refs)) {}
+  using BaseProcess::Initialize;
+  using BaseProcess::is_initialized;
   using BaseProcess::Launch;
+
+  void AssertInitialized() {
+    if (!is_initialized()) {
+      throw std::logic_error("Process.__init__ not called in constructor");
+    }
+  }
 
   void ScheduleOnWorker() override {
     // This is tricky: We need to retain the object reference across the
@@ -314,6 +322,19 @@ py::object RunInForeground(std::shared_ptr<Refs> refs, local::System &self,
 }  // namespace
 
 NB_MODULE(lib, m) {
+// Tragically, debug builds of Python do the right thing and don't immortalize
+// many identifiers and such. This makes the last chance leak checking that
+// nanobind does somewhat unreliable since the reports it prints may be
+// to identifiers that are no longer live (at a time in process shutdown
+// where it is expected that everything left just gets dropped on the floor).
+// This causes segfaults or ASAN violations in the leak checker on exit in
+// certain scenarios where we have spurious "leaks" of global objects.
+#if defined(Py_DEBUG)
+  py::set_leak_warnings(false);
+#endif
+
+  logging::InitializeFromEnv();
+
   py::register_exception_translator(
       [](const std::exception_ptr &p, void * /*unused*/) {
         try {
@@ -412,12 +433,15 @@ void BindLocal(py::module_ &m) {
           py::rv_policy::reference_internal)
       .def(
           "create_queue",
-          [](local::System &self, std::string name) -> local::Queue & {
+          [](local::System &self,
+             std::optional<std::string> name) -> std::shared_ptr<local::Queue> {
             local::Queue::Options options;
-            options.name = std::move(name);
+            if (name) {
+              options.name = std::move(*name);
+            }
             return self.CreateQueue(std::move(options));
           },
-          py::arg("name"), py::rv_policy::reference_internal)
+          py::arg("name") = py::none(), py::rv_policy::reference_internal)
       .def("named_queue", &local::System::named_queue, py::arg("name"),
            py::rv_policy::reference_internal)
       .def(
@@ -512,7 +536,18 @@ void BindLocal(py::module_ &m) {
       .def_prop_ro("exports", &local::ProgramModule::exports)
       .def("__repr__", &local::ProgramModule::to_s)
       .def_static("load", &local::ProgramModule::Load, py::arg("system"),
-                  py::arg("path"), py::arg("mmap") = true);
+                  py::arg("path"), py::arg("mmap") = true)
+      .def_static(
+          "parameter_provider",
+          [](local::System &system, py::args params) {
+            std::vector<local::BaseProgramParameters *> c_params;
+            c_params.reserve(params.size());
+            for (py::handle h : params) {
+              c_params.push_back(py::cast<local::BaseProgramParameters *>(h));
+            }
+            return local::ProgramModule::ParameterProvider(system, c_params);
+          },
+          py::arg("system"), py::arg("params"));
   py::class_<local::ProgramInvocation::Ptr>(m, "ProgramInvocation")
       .def("invoke",
            [](local::ProgramInvocation::Ptr &self) {
@@ -559,11 +594,39 @@ void BindLocal(py::module_ &m) {
             }
             return PyRehydrateRef(self.get(), std::move(ref));
           },
-          "Gets the i'th result");
+          "Gets the i'th result")
+      .def("__repr__", [](local::ProgramInvocation::Ptr &self) {
+        if (!self) return std::string("ProgramInvocation(INVALID)");
+        return self->to_s();
+      });
+
+  py::class_<local::BaseProgramParameters>(m, "BaseProgramParameters");
+  py::class_<local::StaticProgramParameters, local::BaseProgramParameters>(
+      m, "StaticProgramParameters")
+      .def(
+          py::init<local::System &, std::string_view, iree_host_size_t>(),
+          py::arg("system"), py::arg("parameter_scope"),
+          py::arg("max_concurrent_operations") =
+              IREE_IO_PARAMETER_INDEX_PROVIDER_DEFAULT_MAX_CONCURRENT_OPERATIONS)
+      .def(
+          "load",
+          [](local::StaticProgramParameters &self,
+             std::filesystem::path file_path, std::string_view format,
+             bool readable, bool writable, bool mmap) {
+            local::StaticProgramParameters::LoadOptions options;
+            options.format = format;
+            options.readable = readable;
+            options.writable = writable;
+            options.mmap = mmap;
+            self.Load(file_path, options);
+          },
+          py::arg("file_path"), py::arg("format") = std::string_view(),
+          py::arg("readable") = true, py::arg("writable") = false,
+          py::arg("mmap") = true);
 
   struct DevicesSet {
-    DevicesSet(local::Scope &scope) : scope(scope) {}
-    local::Scope &scope;
+    DevicesSet(py::dict devices_dict) : devices_dict(std::move(devices_dict)) {}
+    py::dict devices_dict;
   };
   py::class_<local::Scope>(m, "Scope")
       .def("__repr__", &local::Scope::to_s)
@@ -579,12 +642,24 @@ void BindLocal(py::module_ &m) {
             return self.raw_device(name);
           },
           py::rv_policy::reference_internal)
-      .def_prop_ro(
-          "devices", [](local::Scope &self) { return DevicesSet(self); },
-          py::rv_policy::reference_internal)
+      .def_prop_ro("devices",
+                   [](py::handle self_obj) {
+                     return DevicesSet(self_obj.attr("devices_dict"));
+                   })
+      .def_prop_ro("devices_dict",
+                   [](py::handle self_obj) {
+                     local::Scope &self = py::cast<local::Scope &>(self_obj);
+                     py::dict d;
+                     for (auto &it : self.raw_devices()) {
+                       py::object scoped_device =
+                           py::cast(self.device(it.second));
+                       py::detail::keep_alive(/*nurse=*/scoped_device.ptr(),
+                                              /*patient=*/self_obj.ptr());
+                       d[py::cast(it.first)] = scoped_device;
+                     }
+                     return d;
+                   })
       .def_prop_ro("device_names", &local::Scope::device_names)
-      .def_prop_ro("named_devices", &local::Scope::named_devices,
-                   py::rv_policy::reference_internal)
       .def(
           "device",
           [](local::Scope &self, py::args args) {
@@ -608,24 +683,22 @@ void BindLocal(py::module_ &m) {
       .def("__repr__", &local::ScopedDevice::to_s);
 
   py::class_<DevicesSet>(m, "_ScopeDevicesSet")
-      .def("__len__",
-           [](DevicesSet &self) { return self.scope.raw_devices().size(); })
-      .def(
-          "__getitem__",
-          [](DevicesSet &self, int index) { return self.scope.device(index); },
-          py::rv_policy::reference_internal)
-      .def(
-          "__getitem__",
-          [](DevicesSet &self, std::string_view name) {
-            return self.scope.device(name);
-          },
-          py::rv_policy::reference_internal)
-      .def(
-          "__getattr__",
-          [](DevicesSet &self, std::string_view name) {
-            return self.scope.device(name);
-          },
-          py::rv_policy::reference_internal);
+      .def("__iter__",
+           [](DevicesSet &self) {
+             return self.devices_dict.attr("values")().attr("__iter__")();
+           })
+      .def("__len__", [](DevicesSet &self) { return self.devices_dict.size(); })
+      .def("__getitem__",
+           [](DevicesSet &self, py::handle key) {
+             if (py::isinstance<py::str>(key)) {
+               return self.devices_dict[key];
+             } else {
+               return self.devices_dict.attr("values")()[key];
+             }
+           })
+      .def("__getattr__", [](DevicesSet &self, py::handle key) {
+        return self.devices_dict[key];
+      });
 
   py::class_<local::Worker>(m, "Worker", py::is_weak_referenceable())
       .def_prop_ro("loop",
@@ -688,30 +761,51 @@ void BindLocal(py::module_ &m) {
       .def("__repr__", &local::Worker::to_s);
 
   py::class_<PyProcess>(m, "Process")
-      .def("__init__", [](py::args, py::kwargs) {})
+      .def(
+          "__init__",
+          [](py::handle self_obj, std::shared_ptr<local::Scope> scope) {
+            PyProcess &self = py::cast<PyProcess &>(self_obj);
+            self.Initialize(std::move(scope));
+          },
+          py::kw_only(), py::arg("scope"))
       .def_static(
           "__new__",
-          [refs](py::handle py_type, py::args,
-                 std::shared_ptr<local::Scope> scope, py::kwargs) {
-            return custom_new<PyProcess>(py_type, std::move(scope), refs);
+          [refs](py::handle py_type, py::args, py::kwargs) {
+            return custom_new<PyProcess>(py_type, refs);
           },
-          py::arg("type"), py::arg("args"), py::arg("scope"), py::arg("kwargs"))
+          py::arg("type"), py::arg("args"), py::arg("kwargs"))
       .def_prop_ro("pid", &PyProcess::pid)
-      .def_prop_ro("scope", &PyProcess::scope)
+      .def_prop_ro("scope",
+                   [](PyProcess &self) -> std::shared_ptr<local::Scope> {
+                     self.AssertInitialized();
+                     return self.scope();
+                   })
+      .def_prop_ro("system",
+                   [](PyProcess &self) {
+                     self.AssertInitialized();
+                     return self.scope()->system().shared_ptr();
+                   })
       .def("launch",
            [](py::object self_obj) {
              PyProcess &self = py::cast<PyProcess &>(self_obj);
+             self.AssertInitialized();
              self.Launch();
              return self_obj;
            })
       .def("__await__",
            [](PyProcess &self) {
+             self.AssertInitialized();
              py::object future =
                  py::cast(local::CompletionEvent(self.OnTermination()),
                           py::rv_policy::move);
              return future.attr("__await__")();
            })
-      .def("__repr__", &PyProcess::to_s);
+      .def("__repr__", [](PyProcess &self) {
+        if (!self.is_initialized()) {
+          return std::string("Process(UNINITIALIZED)");
+        }
+        return self.to_s();
+      });
 
   py::class_<local::CompletionEvent>(m, "CompletionEvent")
       .def(py::init<>())
@@ -800,10 +894,15 @@ void BindLocal(py::module_ &m) {
                  py::type<local::QueueWriter>(),
                  /*keep_alive=*/self, /*queue=*/self);
            })
-      .def("reader", [](local::Queue &self) {
-        return custom_new_keep_alive<local::QueueReader>(
-            py::type<local::QueueReader>(),
-            /*keep_alive=*/self, /*queue=*/self);
+      .def("reader",
+           [](local::Queue &self) {
+             return custom_new_keep_alive<local::QueueReader>(
+                 py::type<local::QueueReader>(),
+                 /*keep_alive=*/self, /*queue=*/self);
+           })
+      .def_prop_ro("closed", &local::Queue::is_closed)
+      .def("write_nodelay", [](local::Queue &self, local::Message &message) {
+        self.WriteNoDelay(local::Message::Ref(message));
       });
   py::class_<local::QueueWriter>(m, "QueueWriter")
       .def("__call__",
@@ -864,7 +963,9 @@ void BindLocal(py::module_ &m) {
             });
         return iter_ret;
       });
-  py::class_<local::VoidFuture, local::Future>(m, "VoidFuture");
+  py::class_<local::VoidFuture, local::Future>(m, "VoidFuture")
+      .def(py::init<>())
+      .def("set_success", [](local::VoidFuture &self) { self.set_success(); });
   py::class_<local::ProgramInvocation::Future, local::Future>(
       m, "ProgramInvocationFuture")
       .def("result", [](local::ProgramInvocation::Future &self) {

--- a/libshortfin/python/lib_ext.h
+++ b/libshortfin/python/lib_ext.h
@@ -11,6 +11,7 @@
 #include <nanobind/operators.h>
 #include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/function.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>

--- a/libshortfin/python/shortfin/__init__.py
+++ b/libshortfin/python/shortfin/__init__.py
@@ -6,8 +6,12 @@
 
 from _shortfin import lib as _sfl
 
+# Set up logging.
+import shortfin.support.logging_setup as _logging_setup
+
 # Most classes from the native "local" namespace are aliased to the top
 # level of the public API.
+BaseProgramParameters = _sfl.local.BaseProgramParameters
 CompletionEvent = _sfl.local.CompletionEvent
 Device = _sfl.local.Device
 Message = _sfl.local.Message
@@ -23,8 +27,10 @@ QueueReader = _sfl.local.QueueReader
 QueueWriter = _sfl.local.QueueWriter
 Scope = _sfl.local.Scope
 ScopedDevice = _sfl.local.ScopedDevice
+StaticProgramParameters = _sfl.local.StaticProgramParameters
 System = _sfl.local.System
 SystemBuilder = _sfl.local.SystemBuilder
+VoidFuture = _sfl.local.VoidFuture
 Worker = _sfl.local.Worker
 
 # Array is auto-imported.
@@ -35,6 +41,7 @@ from . import amdgpu
 from . import host
 
 __all__ = [
+    "BaseProgramParameters",
     "CompletionEvent",
     "Device",
     "Message",
@@ -49,8 +56,10 @@ __all__ = [
     "QueueWriter",
     "Scope",
     "ScopedDevice",
+    "StaticProgramParameters",
     "System",
     "SystemBuilder",
+    "VoidFuture",
     "Worker",
     # System namespaces.
     "amdgpu",

--- a/libshortfin/python/shortfin/support/deps.py
+++ b/libshortfin/python/shortfin/support/deps.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Utilities for managing dependencies.
+
+The overall shortfin namespace contains components with optional dependencies.
+This module provides support for reacting to dependcy issues.
+"""
+
+
+class ShortfinDepNotFoundError(Exception):
+    """Raised from a ModuleNotFoundError for a missing or incorrect dep."""
+
+    def __init__(
+        self, caller_name: str, package_name: str, extras_name: str | None = None
+    ):
+        super().__init__()
+        self.caller_name = caller_name.removesuffix("._deps")
+        self.package_name = package_name
+        self.extras_name = extras_name
+
+    def __str__(self):
+        msg = (
+            f"Shortfin is missing a dependency to use {self.caller_name}. "
+            f"This is typically available via `pip install {self.package_name}`"
+        )
+        if self.extras_name:
+            msg += (
+                f" (or by installing with an extra like "
+                f"`pip install shortfin[{self.extras_name}])"
+            )
+        return msg
+
+
+ShortfinDepNotFoundError.__name__ = "ShortfinDepNotFoundError"

--- a/libshortfin/python/shortfin/support/logging_setup.py
+++ b/libshortfin/python/shortfin/support/logging_setup.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import sys
+
+from _shortfin import lib as _sfl
+
+_LOG_FUNCTIONS = {
+    logging.DEBUG: _sfl.log_debug,
+    logging.INFO: _sfl.log_info,
+    logging.WARNING: _sfl.log_warn,
+    logging.ERROR: _sfl.log_error,
+    logging.CRITICAL: _sfl.log_error,
+}
+
+logger = logging.getLogger("shortfin")
+logger.propagate = False
+
+
+class NativeHandler(logging.Handler):
+    def emit(self, record):
+        formatted = self.format(record)
+        f = _LOG_FUNCTIONS.get(record.levelno)
+        if f is not None:
+            f(formatted)
+
+
+class NativeFormatter(logging.Formatter):
+    def __init__(self):
+        super().__init__("[%(filename)s:%(lineno)d] %(message)s")
+
+
+native_handler = NativeHandler()
+native_handler.setFormatter(NativeFormatter())
+
+# TODO: Source from env vars.
+logger.setLevel(logging.DEBUG)
+logger.addHandler(native_handler)
+
+
+def configure_main_logger(module_suffix: str = "__main__") -> logging.Logger:
+    """Configures logging from a main entrypoint.
+
+    Returns a logger that can be used for the main module itself.
+    """
+    logging.root.addHandler(native_handler)
+    logging.root.setLevel(logging.DEBUG)  # TODO: source from env vars
+    main_module = sys.modules["__main__"]
+    return logging.getLogger(f"{main_module.__package__}.{module_suffix}")

--- a/libshortfin/src/shortfin/array/array.cc
+++ b/libshortfin/src/shortfin/array/array.cc
@@ -11,6 +11,7 @@
 #include "fmt/core.h"
 #include "fmt/ranges.h"
 #include "shortfin/array/xtensor_bridge.h"
+#include "shortfin/support/logging.h"
 
 namespace shortfin::array {
 

--- a/libshortfin/src/shortfin/local/CMakeLists.txt
+++ b/libshortfin/src/shortfin/local/CMakeLists.txt
@@ -35,6 +35,8 @@ shortfin_cc_component(
     iree_base_base
     iree_base_loop_sync
     iree_hal_hal
+    iree_io_formats_parser_registry
+    iree_modules_io_parameters_parameters
     iree_modules_hal_hal
     iree_vm_vm
     iree_vm_bytecode_module

--- a/libshortfin/src/shortfin/local/async.h
+++ b/libshortfin/src/shortfin/local/async.h
@@ -153,6 +153,7 @@ class SHORTFIN_API VoidFuture : public Future {
   void set_success() {
     iree::slim_mutex_lock_guard g(state_->lock_);
     SetSuccessWithLockHeld();
+    IssueCallbacksWithLockHeld();
   }
 };
 

--- a/libshortfin/src/shortfin/local/messaging.cc
+++ b/libshortfin/src/shortfin/local/messaging.cc
@@ -20,10 +20,52 @@ template class TypedFuture<Message::Ref>;
 // Queue
 // -------------------------------------------------------------------------- //
 
+namespace {
+
+struct QueueCreator : public Queue {
+  QueueCreator(Options options) : Queue(std::move(options)) {}
+};
+
+}  // namespace
+
 Queue::Queue(Options options) : options_(std::move(options)) {}
+
+std::shared_ptr<Queue> Queue::Create(Options options) {
+  return std::make_shared<QueueCreator>(std::move(options));
+}
 
 std::string Queue::to_s() const {
   return fmt::format("Queue(name={})", options().name);
+}
+
+bool Queue::is_closed() {
+  iree::slim_mutex_lock_guard g(lock_);
+  return closed_;
+}
+
+void Queue::WriteNoDelay(Message::Ref mr) {
+  std::optional<MessageFuture> future;
+  {
+    iree::slim_mutex_lock_guard g(lock_);
+    if (pending_readers_.empty()) {
+      // No readers. Just add to the backlog.
+      backlog_.push_back(std::move(mr));
+      return;
+    } else {
+      // Signal a reader. We must do this within the queue lock to avoid
+      // a QueueReader lifetime hazard. But we defer actually setting the
+      // future until out of the lock.
+      QueueReader *reader = pending_readers_.front();
+      pending_readers_.pop_front();
+      future = *reader->read_result_future_;
+      // Reset the worker for a new read.
+      reader->worker_ = nullptr;
+      reader->read_result_future_.reset();
+    }
+  }
+
+  // Signal the future outside of our lock.
+  future->set_result(std::move(mr));
 }
 
 void Queue::Close() {
@@ -56,48 +98,27 @@ void Queue::Close() {
 }
 
 QueueWriter::QueueWriter(Queue &queue, Options options)
-    : queue_(queue), options_(std::move(options)) {}
+    : queue_(queue.shared_from_this()), options_(std::move(options)) {}
 
 QueueWriter::~QueueWriter() = default;
 
 CompletionEvent QueueWriter::Write(Message::Ref mr) {
-  std::optional<MessageFuture> future;
-  {
-    iree::slim_mutex_lock_guard g(queue_.lock_);
-    if (queue_.pending_readers_.empty()) {
-      // No readers. Just add to the backlog.
-      queue_.backlog_.push_back(std::move(mr));
-      return CompletionEvent();
-    } else {
-      // Signal a reader. We must do this within the queue lock to avoid
-      // a QueueReader lifetime hazard. But we defer actually setting the
-      // future until out of the lock.
-      QueueReader *reader = queue_.pending_readers_.front();
-      queue_.pending_readers_.pop_front();
-      future = *reader->read_result_future_;
-      // Reset the worker for a new read.
-      reader->worker_ = nullptr;
-      reader->read_result_future_.reset();
-    }
-  }
-
-  // Signal the future outside of our lock.
-  future->set_result(std::move(mr));
+  queue().WriteNoDelay(std::move(mr));
   return CompletionEvent();
 }
 
 QueueReader::QueueReader(Queue &queue, Options options)
-    : queue_(queue), options_(std::move(options)) {}
+    : queue_(queue.shared_from_this()), options_(std::move(options)) {}
 
 QueueReader::~QueueReader() {
-  iree::slim_mutex_lock_guard g(queue_.lock_);
+  iree::slim_mutex_lock_guard g(queue().lock_);
   if (read_result_future_) {
     logging::warn("QueueReader destroyed while pending");
     // Reader is in progress: Cancel it from the queue.
-    auto it = std::find(queue_.pending_readers_.begin(),
-                        queue_.pending_readers_.end(), this);
-    if (it != queue_.pending_readers_.end()) {
-      queue_.pending_readers_.erase(it);
+    auto it = std::find(queue().pending_readers_.begin(),
+                        queue().pending_readers_.end(), this);
+    if (it != queue().pending_readers_.end()) {
+      queue().pending_readers_.erase(it);
     }
   }
 }
@@ -105,7 +126,7 @@ QueueReader::~QueueReader() {
 MessageFuture QueueReader::Read() {
   // TODO: It should be possible to further constrain the scope of this lock,
   // but it is set here to be conservatively safe pending a full analysis.
-  iree::slim_mutex_lock_guard g(queue_.lock_);
+  iree::slim_mutex_lock_guard g(queue().lock_);
   if (worker_) {
     throw std::logic_error(
         "Cannot read concurrently from a single QueueReader");
@@ -118,17 +139,17 @@ MessageFuture QueueReader::Read() {
   }
 
   // See if there is a backlog that we can immediately satisfy.
-  if (!queue_.backlog_.empty()) {
+  if (!queue().backlog_.empty()) {
     // Service from the backlog.
     MessageFuture imm_future(worker_);
-    imm_future.set_result(std::move(queue_.backlog_.front()));
-    queue_.backlog_.pop_front();
+    imm_future.set_result(std::move(queue().backlog_.front()));
+    queue().backlog_.pop_front();
     worker_ = nullptr;
     return imm_future;
   }
 
   // Handle close.
-  if (queue_.closed_) {
+  if (queue().closed_) {
     MessageFuture imm_future(worker_);
     imm_future.set_result(Message::Ref());
     worker_ = nullptr;
@@ -136,7 +157,7 @@ MessageFuture QueueReader::Read() {
   }
 
   // Settle in for a wait.
-  queue_.pending_readers_.push_back(this);
+  queue().pending_readers_.push_back(this);
   read_result_future_ = MessageFuture(worker_);
   return *read_result_future_;
 }

--- a/libshortfin/src/shortfin/local/process.cc
+++ b/libshortfin/src/shortfin/local/process.cc
@@ -12,10 +12,13 @@
 
 namespace shortfin::local {
 
-detail::BaseProcess::BaseProcess(std::shared_ptr<Scope> scope)
-    : scope_(std::move(scope)) {}
+detail::BaseProcess::BaseProcess() = default;
+detail::BaseProcess::~BaseProcess() = default;
 
-detail::BaseProcess::~BaseProcess() {}
+void detail::BaseProcess::Initialize(std::shared_ptr<Scope> scope) {
+  assert(!scope_ && "BaseProcess::Initialize already called");
+  scope_ = std::move(scope);
+}
 
 int64_t detail::BaseProcess::pid() const {
   iree::slim_mutex_lock_guard g(lock_);
@@ -80,5 +83,7 @@ CompletionEvent detail::BaseProcess::OnTermination() {
   }
   return CompletionEvent(terminated_event_);
 }
+
+Process::Process(std::shared_ptr<Scope> scope) { Initialize(std::move(scope)); }
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/process.h
+++ b/libshortfin/src/shortfin/local/process.h
@@ -26,7 +26,7 @@ namespace detail {
 // structure and external lifetime management.
 class SHORTFIN_API BaseProcess {
  public:
-  BaseProcess(std::shared_ptr<Scope> scope);
+  BaseProcess();
   BaseProcess(const BaseProcess &) = delete;
   virtual ~BaseProcess();
 
@@ -39,6 +39,14 @@ class SHORTFIN_API BaseProcess {
   CompletionEvent OnTermination();
 
  protected:
+  // Derived classes must arrange to call Initialize() before any operation
+  // is taken on the instance. In C++ subclasses, this will typically be done
+  // in the constructor, but for bindings, this can be separated.
+  void Initialize(std::shared_ptr<Scope> scope);
+
+  // Whether subclass initialization has been done.
+  bool is_initialized() const { return scope_.get(); }
+
   // Launches the process.
   void Launch();
 
@@ -73,7 +81,7 @@ class SHORTFIN_API BaseProcess {
 // driven fashion (i.e. cps, async/await, co-routines, etc).
 class SHORTFIN_API Process : public detail::BaseProcess {
  public:
-  using BaseProcess::BaseProcess;
+  Process(std::shared_ptr<Scope> scope);
 };
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/scheduler.h
+++ b/libshortfin/src/shortfin/local/scheduler.h
@@ -199,7 +199,7 @@ class SHORTFIN_API Account {
   // Returns a future that is satisfied when the timeline of this account
   // reaches its current idle timepoint (i.e. all currently pending work
   // is complete).
-  CompletionEvent OnSync();
+  VoidFuture OnSync();
 
  private:
   void Initialize();
@@ -273,7 +273,8 @@ class SHORTFIN_API Scheduler {
   System &system() { return system_; }
 
  private:
-  void Initialize(std::span<Device *const> devices);
+  void Initialize(
+      std::span<const std::pair<std::string_view, Device *>> devices);
   System &system_;
 
   // Each distinct hal device gets an account.

--- a/libshortfin/src/shortfin/local/scope.cc
+++ b/libshortfin/src/shortfin/local/scope.cc
@@ -58,18 +58,16 @@ void Scope::AddDevice(std::string_view device_class, Device *device) {
   auto &count = device_class_count_[device_class];
   std::string_view device_name =
       interner_.intern(fmt::format("{}{}", device_class, count++));
-  named_devices_[device_name] = device;
-  devices_.push_back(device);
+  devices_.push_back(std::make_pair(device_name, device));
 }
 
 Device *Scope::raw_device(std::string_view name) const {
-  auto it = named_devices_.find(name);
-  if (it == named_devices_.end()) [[unlikely]] {
-    throw std::invalid_argument(
-        fmt::format("Device '{}' not found (available: {})", name,
-                    fmt::join(device_names(), ", ")));
+  for (auto &it : devices_) {
+    if (it.first == name) return it.second;
   }
-  return it->second;
+  throw std::invalid_argument(
+      fmt::format("Device '{}' not found (available: {})", name,
+                  fmt::join(device_names(), ", ")));
 }
 
 Device *Scope::raw_device(std::size_t ordinal) const {
@@ -77,13 +75,13 @@ Device *Scope::raw_device(std::size_t ordinal) const {
     throw std::invalid_argument(
         fmt::format("Device ordinal ({}) out of bounds", ordinal));
   }
-  return devices_[ordinal];
+  return devices_[ordinal].second;
 }
 
 std::vector<std::string_view> Scope::device_names() const {
   std::vector<std::string_view> names;
-  names.reserve(named_devices_.size());
-  for (auto &it : named_devices_) {
+  names.reserve(devices_.size());
+  for (auto &it : devices_) {
     names.push_back(it.first);
   }
   return names;
@@ -93,7 +91,7 @@ std::vector<std::string_view> Scope::device_names() const {
 // ScopedDevice
 // -------------------------------------------------------------------------- //
 
-CompletionEvent ScopedDevice::OnSync(bool flush) {
+VoidFuture ScopedDevice::OnSync(bool flush) {
   if (flush) {
     scope().scheduler().Flush();
   }

--- a/libshortfin/src/shortfin/local/scope.h
+++ b/libshortfin/src/shortfin/local/scope.h
@@ -52,7 +52,7 @@ class SHORTFIN_API ScopedDevice {
   // Returns a future which will be satisfied when the primary device timeline
   // of this affinity set progresses to "now". This will be true when all
   // currently queued work on the device has been completed.
-  CompletionEvent OnSync(bool flush = true);
+  VoidFuture OnSync(bool flush = true);
 
  private:
   Scope *scope_ = nullptr;
@@ -103,12 +103,11 @@ class SHORTFIN_API Scope : public std::enable_shared_from_this<Scope> {
   // Device access.
   // Throws std::invalid_argument on lookup failure.
   Device *raw_device(std::string_view name) const;
-  const std::unordered_map<std::string_view, Device *> named_devices() const {
-    return named_devices_;
-  }
   Device *raw_device(std::size_t index) const;
   Device *raw_device(Device *device) const { return device; }
-  const std::vector<Device *> &raw_devices() const { return devices_; }
+  std::span<const std::pair<std::string_view, Device *>> raw_devices() const {
+    return devices_;
+  }
   std::vector<std::string_view> device_names() const;
 
   // Variadic helper for making a DeviceAffinity from any of:
@@ -145,10 +144,8 @@ class SHORTFIN_API Scope : public std::enable_shared_from_this<Scope> {
 
   // Map of `<device_class>` to the count of that class contained.
   std::unordered_map<std::string_view, int> device_class_count_;
-  // Ordered devices.
-  std::vector<Device *> devices_;
-  // Map of `<device_class><index>` to Device.
-  std::unordered_map<std::string_view, Device *> named_devices_;
+  // Ordered devices named as `<device_class><index>`.
+  std::vector<std::pair<std::string_view, Device *>> devices_;
 };
 
 }  // namespace shortfin::local

--- a/libshortfin/src/shortfin/local/system.h
+++ b/libshortfin/src/shortfin/local/system.h
@@ -101,8 +101,9 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   Device *FindDeviceByName(std::string_view name);
 
   // Queue access.
-  Queue &CreateQueue(Queue::Options options);
-  Queue &named_queue(std::string_view name);
+  QueuePtr CreateQueue(Queue::Options options);
+  QueuePtr CreateQueue() { return CreateQueue(Queue::Options()); }
+  QueuePtr named_queue(std::string_view name);
 
   // Access the system wide blocking executor thread pool. This can be used
   // to execute thunks that can block on a dedicated thread and is needed
@@ -192,7 +193,7 @@ class SHORTFIN_API System : public std::enable_shared_from_this<System> {
   BlockingExecutor blocking_executor_;
 
   // Queues.
-  std::vector<std::unique_ptr<Queue>> queues_ SHORTFIN_GUARDED_BY(lock_);
+  std::vector<std::shared_ptr<Queue>> queues_ SHORTFIN_GUARDED_BY(lock_);
   std::unordered_map<std::string_view, Queue *> queues_by_name_
       SHORTFIN_GUARDED_BY(lock_);
 

--- a/libshortfin/src/shortfin/support/CMakeLists.txt
+++ b/libshortfin/src/shortfin/support/CMakeLists.txt
@@ -25,7 +25,11 @@ shortfin_cc_component(
     # TODO: Maybe reclassify some of these low level, shared support entities
     # as externally usable.
     iree_base_internal_threading
+    iree_io_file_handle
     iree_hal_hal
+    iree_io_parameter_index
+    iree_io_parameter_index_provider
+    iree_io_parameter_provider
     iree_modules_hal_types
     spdlog::spdlog
 )

--- a/libshortfin/src/shortfin/support/iree_helpers.h
+++ b/libshortfin/src/shortfin/support/iree_helpers.h
@@ -13,6 +13,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/file_io.h"
 #include "iree/hal/api.h"
+#include "iree/io/parameter_index_provider.h"
 #include "iree/modules/hal/types.h"
 #include "iree/vm/api.h"
 #include "iree/vm/ref_cc.h"
@@ -169,6 +170,9 @@ SHORTFIN_IREE_DEF_PTR(hal_device);
 SHORTFIN_IREE_DEF_PTR(hal_driver);
 SHORTFIN_IREE_DEF_PTR(hal_fence);
 SHORTFIN_IREE_DEF_PTR(hal_semaphore);
+SHORTFIN_IREE_DEF_PTR(io_file_handle);
+SHORTFIN_IREE_DEF_PTR(io_parameter_index);
+SHORTFIN_IREE_DEF_PTR(io_parameter_provider);
 SHORTFIN_IREE_DEF_PTR(vm_context);
 SHORTFIN_IREE_DEF_PTR(vm_instance);
 SHORTFIN_IREE_DEF_PTR(vm_list);

--- a/libshortfin/src/shortfin/support/logging.h
+++ b/libshortfin/src/shortfin/support/logging.h
@@ -7,6 +7,7 @@
 #ifndef SHORTFIN_SUPPORT_LOGGING_H
 #define SHORTFIN_SUPPORT_LOGGING_H
 
+#include "shortfin/support/api.h"
 #include "spdlog/spdlog.h"
 
 #if !defined(SHORTFIN_LOG_LIFETIMES)
@@ -22,6 +23,8 @@
 #endif
 
 namespace shortfin::logging {
+
+SHORTFIN_API void InitializeFromEnv();
 
 // TODO: Re-export doesn't really work like this. Need to define API
 // exported trampolines for cross library use.

--- a/libshortfin/tests/examples/async_test.py
+++ b/libshortfin/tests/examples/async_test.py
@@ -18,7 +18,7 @@ example_dir = project_dir / "examples" / "python"
 
 def run_example(path: Path):
     try:
-        subprocess.check_call([sys.executable, str(path)])
+        subprocess.check_call([sys.executable, str(path)], timeout=30)
     except subprocess.CalledProcessError:
         pytest.skip(
             f"Suppressed flaky test for {path}: "

--- a/libshortfin/tests/examples/async_test.py
+++ b/libshortfin/tests/examples/async_test.py
@@ -18,7 +18,12 @@ example_dir = project_dir / "examples" / "python"
 
 def run_example(path: Path):
     try:
-        subprocess.check_call([sys.executable, str(path)], timeout=30)
+        subprocess.check_call([sys.executable, str(path)], timeout=15)
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            f"Suppressed flaky test for {path}: "
+            f"https://github.com/nod-ai/sharktank/issues/178"
+        )
     except subprocess.CalledProcessError:
         pytest.skip(
             f"Suppressed flaky test for {path}: "

--- a/libshortfin/tests/local_scope_test.py
+++ b/libshortfin/tests/local_scope_test.py
@@ -32,11 +32,8 @@ def test_raw_device_access(scope):
     assert isinstance(first_device, sfl.local.host.HostCPUDevice)
     assert first_device is scope.raw_device(first_name)  # By name
     print(first_device)
-    devices = scope.raw_devices
-    named_devices = scope.named_devices
+    named_devices = scope.devices_dict
     assert first_name in named_devices
-    assert devices[0] is named_devices[first_name]
-    assert devices[0] is first_device
     with pytest.raises(ValueError):
         scope.raw_device("cpu1")
     with pytest.raises(ValueError):
@@ -54,6 +51,8 @@ def test_devices_collection_access(scope):
         scope.devices.cpu1
     with pytest.raises(ValueError):
         scope.devices[1]
+    iter_list = list(scope.devices)
+    assert iter_list == [scope.device(0)]
 
 
 def test_device_affinity_repr(scope):


### PR DESCRIPTION
Core:

* Convert Queue to shared ownership.
* Allow creation of anonymous Queues.
* Adds asyncio loop support for `call_at`
* Fixes `VoidFuture::set_success` to also signal callbacks
* Adds `StaticProgramParameters` and ability to construct a `ParameterProvider`
* Fixes the hacky `Account::OnSync()` to return a `VoidFuture` and use it to route any wait error (instead of aborting)

Bindings:

* Adds `name` and `compute_dense_nd_size` bindings to `DType`
* Makes `Process` subclassing more natural by supporting split new/init (allows arbitrary arguments to the subclass constructor)
* Disables nanobind leak detector in debug builds of CPython (it seems to rely on immortalization of certain identifiers which are properly cleaned up in debug builds but left allocated forever in release builds)
* Initialize logging from environment on load
* Adds repr to `ProgramInvocation`
* Reworks `Scope.devices` to support iteration and act like a built-in
* Adds `Queue.write_nodelay` and `Queue.closed`
* Adds `VoidFuture.set_success()`
* Reworks optional dep handling to be more verbose/precise
* Adds a module to perfom logging setup to the native logger

FastAPI interop:

* Replace `close_with_error` with `ensure_response` that can be used universally in a finally block.
* Auto casts responses of `bytes` to a `Response`