### PR TITLE
[libshortfin] Add missing scheduler dependency.

### DIFF
--- a/libshortfin/src/shortfin/local/systems/host.cc
+++ b/libshortfin/src/shortfin/local/systems/host.cc
@@ -26,6 +26,16 @@ HostCPUSystemBuilder::Deps::Deps(iree_allocator_t host_allocator) {
   iree_task_executor_options_initialize(&task_executor_options);
   iree_hal_task_device_params_initialize(&task_params);
   iree_task_topology_initialize(&task_topology_options);
+
+#ifndef NDEBUG
+  // TODO: In normal IREE programs, this is exposed as --task_abort_on_failure.
+  // It is a critical debug feature as it forces an eager program crash at
+  // the point encountered vs as a later, rolled up async status. Since it
+  // guards things that are API usage bugs in how we are using the runtime,
+  // from our perspective, it is assert like, and we treat it as such.
+  // However, it would be best to be independently controllable.
+  task_params.queue_scope_flags |= IREE_TASK_SCOPE_FLAG_ABORT_ON_FAILURE;
+#endif
 }
 
 HostCPUSystemBuilder::Deps::~Deps() {

--- a/libshortfin/tests/examples/async_test.py
+++ b/libshortfin/tests/examples/async_test.py
@@ -17,18 +17,7 @@ example_dir = project_dir / "examples" / "python"
 
 
 def run_example(path: Path):
-    try:
-        subprocess.check_call([sys.executable, str(path)], timeout=15)
-    except subprocess.TimeoutExpired:
-        pytest.skip(
-            f"Suppressed flaky test for {path}: "
-            f"https://github.com/nod-ai/sharktank/issues/178"
-        )
-    except subprocess.CalledProcessError:
-        pytest.skip(
-            f"Suppressed flaky test for {path}: "
-            f"https://github.com/nod-ai/sharktank/issues/178"
-        )
+    subprocess.check_call([sys.executable, str(path)], timeout=60)
 
 
 def test_async_basic_asyncio():


### PR DESCRIPTION
As written, command buffers could be scheduled out of order (with signal < deps). We need a more enlightened scheduler soon, but for the moment, this makes it correct.

Also sets the IREE runtime IREE_TASK_SCOPE_FLAG_ABORT_ON_FAILURE in debug builds, which will cause an eager assert-like crash. Since in our usage, this is always a critical error, it makes sense to treat it like an assert (and I would like to add finer grained control in the future). In release builds, it will propagate as a soft error, but it is basically fatal as it will lock the accounting structures into a persistent error state.

Fixes #178 