### PR TITLE
[libshortfin] Rework array mapping python bindings.

### DIFF
--- a/libshortfin/python/array_binding.cc
+++ b/libshortfin/python/array_binding.cc
@@ -35,7 +35,7 @@ update the contents.
 Equivalent to `array.storage.fill(pattern)`.
 )";
 
-static const char DOCSTRING_MAPPING_ITEMS[] =
+static const char DOCSTRING_ARRAY_ITEMS[] =
     R"(Convenience shorthand for map(...).items)";
 
 static const char DOCSTRING_ARRAY_MAP[] =

--- a/libshortfin/tests/api/array_storage_test.py
+++ b/libshortfin/tests/api/array_storage_test.py
@@ -155,52 +155,22 @@ def test_map_discard(lsys, device):
     lsys.run(main())
 
 
-def test_mapping_fill1(lsys, device):
+@pytest.mark.parametrize(
+    "alloc_bytes,fill_value,expected_value",
+    [
+        (8, b"9", b"99999999"),
+        (8, b"98", b"98989898"),
+        (8, b"9876", b"98769876"),
+        (8, b"98765432", b"98765432"),
+        (20, b"9876543210", b"98765432109876543210"),
+    ],
+)
+def test_mapping_fill1(lsys, device, alloc_bytes, fill_value, expected_value):
     async def main():
-        src = sfnp.storage.allocate_host(device, 8)
+        src = sfnp.storage.allocate_host(device, alloc_bytes)
         with src.map(discard=True) as m:
-            m.fill(b"9")
-        assert bytes(src.map(read=True)) == b"99999999"
-
-    lsys.run(main())
-
-
-def test_mapping_fill2(lsys, device):
-    async def main():
-        src = sfnp.storage.allocate_host(device, 8)
-        with src.map(discard=True) as m:
-            m.fill(b"98")
-        assert bytes(src.map(read=True)) == b"98989898"
-
-    lsys.run(main())
-
-
-def test_mapping_fill4(lsys, device):
-    async def main():
-        src = sfnp.storage.allocate_host(device, 8)
-        with src.map(discard=True) as m:
-            m.fill(b"9876")
-        assert bytes(src.map(read=True)) == b"98769876"
-
-    lsys.run(main())
-
-
-def test_mapping_fill8(lsys, device):
-    async def main():
-        src = sfnp.storage.allocate_host(device, 8)
-        with src.map(discard=True) as m:
-            m.fill(b"98765432")
-        assert bytes(src.map(read=True)) == b"98765432"
-
-    lsys.run(main())
-
-
-def test_mapping_fill10(lsys, device):
-    async def main():
-        src = sfnp.storage.allocate_host(device, 20)
-        with src.map(discard=True) as m:
-            m.fill(b"9876543210")
-        assert bytes(src.map(read=True)) == b"98765432109876543210"
+            m.fill(fill_value)
+        assert bytes(src.map(read=True)) == expected_value
 
     lsys.run(main())
 

--- a/libshortfin/tests/api/array_storage_test.py
+++ b/libshortfin/tests/api/array_storage_test.py
@@ -30,12 +30,12 @@ def device(scope):
 
 def test_allocate_host(device):
     s = sfnp.storage.allocate_host(device, 32)
-    assert len(bytes(s.data)) == 32
+    assert len(bytes(s.map(read=True))) == 32
 
 
 def test_allocate_device(device):
     s = sfnp.storage.allocate_device(device, 64)
-    assert len(bytes(s.data)) == 64
+    assert len(bytes(s.map(read=True))) == 64
 
 
 def test_fill1(lsys, device):
@@ -43,7 +43,7 @@ def test_fill1(lsys, device):
         s = sfnp.storage.allocate_host(device, 8)
         s.fill(b"0")
         await device
-        assert bytes(s.data) == b"00000000"
+        assert bytes(s.map(read=True)) == b"00000000"
 
     lsys.run(main())
 
@@ -53,7 +53,7 @@ def test_fill2(lsys, device):
         s = sfnp.storage.allocate_host(device, 8)
         s.fill(b"01")
         await device
-        assert bytes(s.data) == b"01010101"
+        assert bytes(s.map(read=True)) == b"01010101"
 
     lsys.run(main())
 
@@ -63,7 +63,7 @@ def test_fill4(lsys, device):
         s = sfnp.storage.allocate_host(device, 8)
         s.fill(b"0123")
         await device
-        assert bytes(s.data) == b"01230123"
+        assert bytes(s.map(read=True)) == b"01230123"
 
     lsys.run(main())
 
@@ -135,7 +135,7 @@ def test_map_write(lsys, device):
             mv = memoryview(m)
             assert not mv.readonly
             mv[0] = ord(b"9")
-        assert bytes(src.data) == b"91230123"
+        assert bytes(src.map(read=True)) == b"91230123"
 
     lsys.run(main())
 
@@ -150,16 +150,57 @@ def test_map_discard(lsys, device):
             assert not mv.readonly
             for i in range(8):
                 mv[i] = ord(b"9") - i
-        assert bytes(src.data) == b"98765432"
+        assert bytes(src.map(read=True)) == b"98765432"
 
     lsys.run(main())
 
 
-def test_data_write(lsys, device):
+def test_mapping_fill1(lsys, device):
     async def main():
         src = sfnp.storage.allocate_host(device, 8)
-        src.data = b"98765432"
-        assert bytes(src.data) == b"98765432"
+        with src.map(discard=True) as m:
+            m.fill(b"9")
+        assert bytes(src.map(read=True)) == b"99999999"
+
+    lsys.run(main())
+
+
+def test_mapping_fill2(lsys, device):
+    async def main():
+        src = sfnp.storage.allocate_host(device, 8)
+        with src.map(discard=True) as m:
+            m.fill(b"98")
+        assert bytes(src.map(read=True)) == b"98989898"
+
+    lsys.run(main())
+
+
+def test_mapping_fill4(lsys, device):
+    async def main():
+        src = sfnp.storage.allocate_host(device, 8)
+        with src.map(discard=True) as m:
+            m.fill(b"9876")
+        assert bytes(src.map(read=True)) == b"98769876"
+
+    lsys.run(main())
+
+
+def test_mapping_fill8(lsys, device):
+    async def main():
+        src = sfnp.storage.allocate_host(device, 8)
+        with src.map(discard=True) as m:
+            m.fill(b"98765432")
+        assert bytes(src.map(read=True)) == b"98765432"
+
+    lsys.run(main())
+
+
+def test_mapping_fill10(lsys, device):
+    async def main():
+        src = sfnp.storage.allocate_host(device, 20)
+        with src.map(discard=True) as m:
+            m.fill(b"9876543210")
+        assert bytes(src.map(read=True)) == b"98765432109876543210"
 
     lsys.run(main())
 

--- a/libshortfin/tests/api/array_test.py
+++ b/libshortfin/tests/api/array_test.py
@@ -114,13 +114,51 @@ def test_shape_overflow(lsys, device):
 )
 def test_xtensor_types(scope, dtype, code, py_value, expected_str):
     ary = sfnp.device_array.for_host(scope.device(0), [2, 4], dtype)
-    ary.storage.data = array.array(code, [py_value] * 8)
+    with ary.map(discard=True) as m:
+        m.fill(py_value)
     s = str(ary)
     print("__str__ =", s)
     assert expected_str == s, f"Expected '{expected_str}' == '{s}'"
     r = repr(ary)
     print("__repr__ =", r)
     assert expected_str in r, f"Expected '{expected_str}' in '{r}'"
+
+
+@pytest.mark.parametrize(
+    "dtype,value,",
+    [
+        (sfnp.int8, 42),
+        (sfnp.int16, 42),
+        (sfnp.int32, 42),
+        (sfnp.int64, 42),
+        (sfnp.float32, 42.0),
+        (sfnp.float64, 42.0),
+    ],
+)
+def test_items(scope, dtype, value):
+    ary = sfnp.device_array.for_host(scope.device(0), [2, 4], dtype)
+    ary.items = [value] * 8
+    readback = ary.items.tolist()
+    assert readback == [value] * 8
+
+
+@pytest.mark.parametrize(
+    "dtype,value,",
+    [
+        (sfnp.int8, 42),
+        (sfnp.int16, 42),
+        (sfnp.int32, 42),
+        (sfnp.int64, 42),
+        (sfnp.float32, 42.0),
+        (sfnp.float64, 42.0),
+    ],
+)
+def test_typed_fill(scope, dtype, value):
+    ary = sfnp.device_array.for_host(scope.device(0), [2, 4], dtype)
+    with ary.map(discard=True) as m:
+        m.fill(value)
+    readback = ary.items.tolist()
+    assert readback == [value] * 8
 
 
 @pytest.mark.parametrize(

--- a/libshortfin/tests/api/array_test.py
+++ b/libshortfin/tests/api/array_test.py
@@ -153,12 +153,22 @@ def test_items(scope, dtype, value):
         (sfnp.float64, 42.0),
     ],
 )
-def test_typed_fill(scope, dtype, value):
+def test_typed_mapping(scope, dtype, value):
     ary = sfnp.device_array.for_host(scope.device(0), [2, 4], dtype)
     with ary.map(discard=True) as m:
         m.fill(value)
     readback = ary.items.tolist()
     assert readback == [value] * 8
+
+    # Map as read/write and validate.
+    with ary.map(read=True, write=True) as m:
+        new_values = m.items.tolist()
+        for i in range(len(new_values)):
+            new_values[i] += 1
+        m.items = new_values
+
+    readback = ary.items.tolist()
+    assert readback == [value + 1] * 8
 
 
 @pytest.mark.parametrize(

--- a/libshortfin/tests/invocation/mobilenet_program_test.py
+++ b/libshortfin/tests/invocation/mobilenet_program_test.py
@@ -49,8 +49,7 @@ def test_invoke_mobilenet(lsys, scope, mobilenet_compiled_cpu_path):
         host_output = device_output.for_transfer()
         host_output.copy_from(device_output)
         await device
-        flat_output = array.array("f")
-        flat_output.frombytes(host_output.storage.data)
+        flat_output = host_output.items
         absmean = functools.reduce(
             lambda x, y: x + abs(y) / len(flat_output), flat_output, 0.0
         )

--- a/libshortfin/tests/invocation/mobilenet_program_test.py
+++ b/libshortfin/tests/invocation/mobilenet_program_test.py
@@ -42,7 +42,8 @@ def test_invoke_mobilenet(lsys, scope, mobilenet_compiled_cpu_path):
     async def main():
         device_input = sfnp.device_array(device, [1, 3, 224, 224], sfnp.float32)
         staging_input = device_input.for_transfer()
-        staging_input.storage.data = dummy_data
+        with staging_input.map(discard=True) as m:
+            m.fill(dummy_data)
         device_input.copy_from(staging_input)
         (device_output,) = await main_function(device_input)
         host_output = device_output.for_transfer()


### PR DESCRIPTION
After a bit of use, I decided that some of the array API around fill and mappings needed some rework:

* Clarified that device_array.fill is asynchronous.
* Implemented `fill` and `items` on `mapping`, which matches the semantics of what they do (i.e. accessing mappable contents in a synchronous fashion).
* Implemented `mapping.fill` to operate either on a buffer pattern or primitive types.
* Made `device_array.items` an alias for `mapping.items`, mainly for convenience.