### PR TITLE
[shortfin] Fix nd array view indexing bug.

### DIFF
--- a/libshortfin/python/array_binding.cc
+++ b/libshortfin/python/array_binding.cc
@@ -496,20 +496,24 @@ void BindArray(py::module_ &m) {
       .def_prop_ro("shape", &base_array::shape);
   py::class_<device_array, base_array>(m, "device_array")
       .def("__init__", [](py::args, py::kwargs) {})
-      .def_static("__new__",
-                  [](py::handle py_type, class storage storage,
-                     std::span<const size_t> shape, DType dtype) {
-                    return custom_new_keep_alive<device_array>(
-                        py_type, /*keep_alive=*/storage.scope(), storage, shape,
-                        dtype);
-                  })
-      .def_static("__new__",
-                  [](py::handle py_type, local::ScopedDevice &device,
-                     std::span<const size_t> shape, DType dtype) {
-                    return custom_new_keep_alive<device_array>(
-                        py_type, /*keep_alive=*/device.scope(),
-                        device_array::for_device(device, shape, dtype));
-                  })
+      .def_static(
+          "__new__",
+          [](py::handle py_type, class storage storage,
+             std::span<const size_t> shape, DType dtype) {
+            return custom_new_keep_alive<device_array>(
+                py_type, /*keep_alive=*/storage.scope(), storage, shape, dtype);
+          },
+          py::arg("cls"), py::arg("storage"), py::arg("shape"),
+          py::arg("dtype"))
+      .def_static(
+          "__new__",
+          [](py::handle py_type, local::ScopedDevice &device,
+             std::span<const size_t> shape, DType dtype) {
+            return custom_new_keep_alive<device_array>(
+                py_type, /*keep_alive=*/device.scope(),
+                device_array::for_device(device, shape, dtype));
+          },
+          py::arg("cls"), py::arg("device"), py::arg("shape"), py::arg("dtype"))
       .def("__sfinv_marshal__",
            [](device_array *self, py::capsule inv_capsule, int barrier) {
              auto *inv =

--- a/libshortfin/src/shortfin/array/array.cc
+++ b/libshortfin/src/shortfin/array/array.cc
@@ -152,6 +152,10 @@ device_array device_array::view(Dims &offsets, Dims &sizes) {
       has_stride = true;
     }
 
+    // Since we are only narrowing a dense, row major slice, as we traverse
+    // the dims, we are narrowing the memory view at each step by advancing
+    // the beginning based on the requested offset and pulling the end in
+    // by the difference in size.
     start_offset += row_stride * slice_offset;
     span_size -= row_stride * (new_dims[i] - slice_size);
     new_dims[i] = slice_size;

--- a/libshortfin/src/shortfin/array/array.cc
+++ b/libshortfin/src/shortfin/array/array.cc
@@ -152,9 +152,9 @@ device_array device_array::view(Dims &offsets, Dims &sizes) {
       has_stride = true;
     }
 
-    new_dims[i] = slice_size;
     start_offset += row_stride * slice_offset;
-    span_size = row_stride * slice_size;
+    span_size -= row_stride * (new_dims[i] - slice_size);
+    new_dims[i] = slice_size;
   }
 
   return device_array(storage().subspan(start_offset, span_size),


### PR DESCRIPTION
We were incorrectly truncating the view on inner index access. Used the newer APIs for data manipulation to construct a test which better validates. Kept the original test, even though it is not comprehensive.

Also adds arg names to the array constructor.