### PR TITLE
[shortfin] Add argmax host op.

### DIFF
--- a/libshortfin/python/CMakeLists.txt
+++ b/libshortfin/python/CMakeLists.txt
@@ -20,6 +20,7 @@ FetchContent_MakeAvailable(nanobind)
 
 nanobind_add_module(shortfin_python_extension NB_STATIC LTO
   array_binding.cc
+  array_host_ops.cc
   lib_ext.cc
 )
 

--- a/libshortfin/python/array_binding.cc
+++ b/libshortfin/python/array_binding.cc
@@ -605,6 +605,8 @@ void BindArray(py::module_ &m) {
         if (!contents) return "<<unmappable>>";
         return *contents;
       });
+
+  BindArrayHostOps(m);
 }
 
 }  // namespace shortfin::python

--- a/libshortfin/python/array_host_ops.cc
+++ b/libshortfin/python/array_host_ops.cc
@@ -1,0 +1,77 @@
+// Copyright 2024 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "./lib_ext.h"
+#include "./utils.h"
+#include "shortfin/array/api.h"
+#include "shortfin/support/logging.h"
+#include "xtensor/xsort.hpp"
+#include "xtl/xhalf_float.hpp"
+
+using namespace shortfin::array;
+
+namespace shortfin::python {
+
+namespace {
+
+static const char DOCSTRING_ARGMAX[] =
+    R"(Returns the indices of the maximum values along an axis.
+
+See documentation for numpy.argmax which this operator emulates.
+
+Implemented dtypes: float16, float32.
+)";
+
+}  // namespace
+
+#define SF_UNARY_COMPUTE_CASE(dtype_name, cpp_type) \
+  case DType::dtype_name():                         \
+    return compute.template operator()<cpp_type>()
+
+void BindArrayHostOps(py::module_ &m) {
+  m.def(
+      "argmax",
+      [](device_array &input, int axis, std::optional<device_array> out,
+         bool keepdims, bool device_visible) {
+        if (axis < 0) axis += input.shape().size();
+        if (axis < 0 || axis >= input.shape().size()) {
+          throw std::invalid_argument(
+              fmt::format("Axis out of range: Must be [0, {}) but got {}",
+                          input.shape().size(), axis));
+        }
+        if (out && (out->dtype() != DType::int64())) {
+          throw std::invalid_argument("out array must have dtype=int64");
+        }
+        auto compute = [&]<typename EltTy>() {
+          auto input_t = input.map_xtensor<EltTy>();
+          auto result = xt::argmax(*input_t, axis);
+          if (!out) {
+            out.emplace(device_array::for_host(input.device(), result.shape(),
+                                               DType::int64(), device_visible));
+          }
+          auto out_t = out->map_xtensor_w<int64_t>();
+          *out_t = result;
+          if (keepdims) {
+            out->expand_dims(axis);
+          }
+          return *out;
+        };
+
+        switch (input.dtype()) {
+          SF_UNARY_COMPUTE_CASE(float16, half_float::half);
+          SF_UNARY_COMPUTE_CASE(float32, float);
+          default:
+            throw std::invalid_argument(
+                fmt::format("Unsupported dtype({}) for operator argmax",
+                            input.dtype().name()));
+        }
+      },
+      py::arg("input"), py::arg("axis") = -1, py::arg("out") = py::none(),
+      py::kw_only(), py::arg("keepdims") = false,
+      py::arg("device_visible") = false, DOCSTRING_ARGMAX);
+}
+
+}  // namespace shortfin::python

--- a/libshortfin/python/array_host_ops.cc
+++ b/libshortfin/python/array_host_ops.cc
@@ -20,9 +20,21 @@ namespace {
 static const char DOCSTRING_ARGMAX[] =
     R"(Returns the indices of the maximum values along an axis.
 
-See documentation for numpy.argmax which this operator emulates.
+Implemented for dtypes: float16, float32.
 
-Implemented dtypes: float16, float32.
+Args:
+  input: An input array.
+  axis: Axis along which to sort. Defaults to the last axis (note that the
+    numpy default is into the flattened array, which we do not support).
+  keepdims: Whether to preserve the sort axis. If true, this will become a unit
+    dim. If false, it will be removed.
+  out: Array to write into. If specified, it must have an expected shape and
+    int64 dtype.
+  device_visible: Whether to make the result array visible to devices. Defaults to
+    False.
+
+Returns:
+  A device_array of dtype=int64, allocated on the host and not visible to the device.
 )";
 
 }  // namespace

--- a/libshortfin/python/lib_ext.h
+++ b/libshortfin/python/lib_ext.h
@@ -25,6 +25,7 @@ namespace shortfin::python {
 namespace py = nanobind;
 
 void BindArray(py::module_ &module);
+void BindArrayHostOps(py::module_ &module);
 void BindLocal(py::module_ &module);
 void BindHostSystem(py::module_ &module);
 void BindAMDGPUSystem(py::module_ &module);

--- a/libshortfin/python/shortfin/array.py
+++ b/libshortfin/python/shortfin/array.py
@@ -40,6 +40,8 @@ device_array = _sfl.array.device_array
 storage = _sfl.array.storage
 DType = _sfl.array.DType
 
+# Ops.
+argmax = _sfl.array.argmax
 
 __all__ = [
     # DType aliases.
@@ -74,4 +76,6 @@ __all__ = [
     "device_array",
     "storage",
     "DType",
+    # Ops.
+    "argmax",
 ]

--- a/libshortfin/src/shortfin/array/array.cc
+++ b/libshortfin/src/shortfin/array/array.cc
@@ -18,6 +18,29 @@ namespace shortfin::array {
 template class InlinedDims<iree_hal_dim_t>;
 
 // -------------------------------------------------------------------------- //
+// base_array
+// -------------------------------------------------------------------------- //
+
+void base_array::expand_dims(Dims::value_type axis) {
+  auto shape = this->shape();
+  if (axis > shape.size()) {
+    throw std::invalid_argument(
+        fmt::format("expand_dims axis must be <= rank ({}) but was {}",
+                    shape.size(), axis));
+  }
+  Dims new_dims(shape.size() + 1);
+  size_t j = 0;
+  for (size_t i = 0; i < axis; ++i) {
+    new_dims[j++] = shape[i];
+  }
+  new_dims[j++] = 1;
+  for (size_t i = axis; i < shape.size(); ++i) {
+    new_dims[j++] = shape[i];
+  }
+  set_shape(new_dims.span());
+}
+
+// -------------------------------------------------------------------------- //
 // device_array
 // -------------------------------------------------------------------------- //
 

--- a/libshortfin/src/shortfin/array/array.h
+++ b/libshortfin/src/shortfin/array/array.h
@@ -21,6 +21,26 @@
 
 namespace shortfin::array {
 
+// Wraps an owned mapping and an adapted xtensor together, ensuring that the
+// mapping remains live for the duration of the tensor. This presents as a
+// smart pointer or iterator in that you dereference the tensor via `*` or
+// `->`.
+template <typename EltTy>
+struct mapped_xtensor_holder {
+ public:
+  using xtensor_type =
+      decltype(xt::adapt(static_cast<EltTy *>(nullptr), Dims()));
+  mapped_xtensor_holder(class mapping mapping, xtensor_type t)
+      : mapping(std::move(mapping)), t(std::move(t)) {}
+
+  xtensor_type &operator*() { return t; }
+  xtensor_type &operator->() { return t; }
+
+ private:
+  class mapping mapping;
+  xtensor_type t;
+};
+
 // Either a host or device nd-array view.
 class SHORTFIN_API base_array {
  public:
@@ -48,6 +68,9 @@ class SHORTFIN_API base_array {
   // etc).
   Dims &shape_container() { return shape_; }
   const Dims &shape_container() const { return shape_; }
+
+  // Inserts a unit dim at axis, which must be <= rank.
+  void expand_dims(Dims::value_type axis);
 
  private:
   DType dtype_;
@@ -78,9 +101,10 @@ class SHORTFIN_API device_array
   // arrays that are visible from different combinations of host/device.
   static device_array for_host(local::ScopedDevice &device,
                                std::span<const Dims::value_type> shape,
-                               DType dtype) {
+                               DType dtype, bool device_visible = true) {
     return device_array(
-        storage::allocate_host(device, dtype.compute_dense_nd_size(shape)),
+        storage::allocate_host(device, dtype.compute_dense_nd_size(shape),
+                               device_visible),
         shape, dtype);
   }
 
@@ -125,19 +149,56 @@ class SHORTFIN_API device_array
   // Typed access to the backing data.
   template <typename EltTy>
   typed_mapping<EltTy> typed_data() {
+    dtype().AssertCompatibleSize<EltTy>();
     return typed_mapping<EltTy>(data());
   }
   template <typename EltTy>
   typed_mapping<const EltTy> typed_data() const {
+    dtype().AssertCompatibleSize<EltTy>();
     return typed_mapping<const EltTy>(data());
   }
   template <typename EltTy>
   typed_mapping<EltTy> typed_data_rw() {
+    dtype().AssertCompatibleSize<EltTy>();
     return typed_mapping<EltTy>(data_rw());
   }
   template <typename EltTy>
   typed_mapping<EltTy> typed_data_w() {
+    dtype().AssertCompatibleSize<EltTy>();
     return typed_mapping<EltTy>(data_w());
+  }
+
+  // Maps a read-only xtensor for the given EltTy (which must be compatible with
+  // the array dtype). The returned holder maintains the mapping and the
+  // xtensor, allowing the xtensor to be dereferenced via `*` or `->` like a
+  // pointer.
+  template <typename EltTy>
+  auto map_xtensor() {
+    dtype().AssertCompatibleSize<EltTy>();
+    auto m = data();
+    auto *data = static_cast<EltTy *>(static_cast<void *>((m.data())));
+    return mapped_xtensor_holder<EltTy>(
+        std::move(m), xt::adapt(static_cast<EltTy *>(data), shape_container()));
+  }
+
+  // Same as `map_xtensor()` but maps read-write.
+  template <typename EltTy>
+  auto map_xtensor_rw() {
+    dtype().AssertCompatibleSize<EltTy>();
+    auto m = data_rw();
+    auto *data = static_cast<EltTy *>(static_cast<void *>((m.data())));
+    return mapped_xtensor_holder<EltTy>(
+        std::move(m), xt::adapt(static_cast<EltTy *>(data), shape_container()));
+  }
+
+  // Same as `map_xtensor()` but maps write-only.
+  template <typename EltTy>
+  auto map_xtensor_w() {
+    dtype().AssertCompatibleSize<EltTy>();
+    auto m = data_w();
+    auto *data = static_cast<EltTy *>(static_cast<void *>((m.data())));
+    return mapped_xtensor_holder<EltTy>(
+        std::move(m), xt::adapt(static_cast<EltTy *>(data), shape_container()));
   }
 
   // Creates a device array which aliases the backing storage by slicing. Only

--- a/libshortfin/src/shortfin/array/dims.h
+++ b/libshortfin/src/shortfin/array/dims.h
@@ -40,17 +40,36 @@ class SHORTFIN_API InlinedDims {
     using reference = T &;
     using iterator_category = std::random_access_iterator_tag;
     iterator(pointer p) : p(p) {}
-    iterator &operator++() {
+    constexpr iterator &operator++() {
       p++;
       return *this;
     }
-    iterator &operator++(int) {
+    constexpr iterator operator++(int) {
+      auto tmp = *this;
       p++;
+      return tmp;
+    }
+    constexpr iterator &operator--() {
+      p--;
       return *this;
     }
-    bool operator==(iterator other) const { return p == other.p; }
-    bool operator!=(iterator other) const { return p != other.p; }
-    reference operator*() { return *p; }
+    constexpr iterator operator--(int) {
+      auto tmp = *this;
+      p--;
+      return tmp;
+    }
+    constexpr bool operator==(iterator other) const { return p == other.p; }
+    constexpr bool operator!=(iterator other) const { return p != other.p; }
+    constexpr reference operator*() { return *p; }
+    constexpr iterator operator+(difference_type d) const {
+      return iterator(p + d);
+    }
+    constexpr iterator operator-(difference_type d) const {
+      return iterator(p - d);
+    }
+    constexpr difference_type operator-(iterator rhs) const {
+      return reinterpret_cast<difference_type>(p - rhs.p);
+    }
 
    private:
     pointer p;
@@ -64,17 +83,40 @@ class SHORTFIN_API InlinedDims {
     using iterator_category = std::random_access_iterator_tag;
 
     const_iterator(pointer p) : p(p) {}
-    const_iterator &operator++() {
+    constexpr const_iterator &operator++() {
       p++;
       return *this;
     }
-    const_iterator &operator++(int) {
+    constexpr const_iterator operator++(int) {
+      auto tmp = *this;
       p++;
+      return tmp;
+    }
+    constexpr const_iterator &operator--() {
+      p--;
       return *this;
     }
-    bool operator==(const_iterator other) const { return p == other.p; }
-    bool operator!=(const_iterator other) const { return p != other.p; }
-    reference operator*() { return *p; }
+    constexpr const_iterator operator--(int) {
+      auto tmp = *this;
+      p--;
+      return tmp;
+    }
+    constexpr bool operator==(const_iterator other) const {
+      return p == other.p;
+    }
+    constexpr bool operator!=(const_iterator other) const {
+      return p != other.p;
+    }
+    constexpr reference operator*() { return *p; }
+    constexpr const_iterator operator+(difference_type d) const {
+      return const_iterator(p + d);
+    }
+    constexpr const_iterator operator-(difference_type d) const {
+      return const_iterator(p - d);
+    }
+    constexpr difference_type operator-(const_iterator rhs) const {
+      return reinterpret_cast<difference_type>(p - rhs.p);
+    }
 
    private:
     pointer p;
@@ -94,6 +136,10 @@ class SHORTFIN_API InlinedDims {
       new (&dims_.inline_dims) InlineTy();
       std::fill(dims_.inline_dims.begin(), dims_.inline_dims.end(), value);
     }
+  }
+  template <std::contiguous_iterator BeginTy, typename EndTy>
+  InlinedDims(BeginTy begin, EndTy end) {
+    set(std::span<const size_type>(&(*begin), end - begin));
   }
   InlinedDims(const InlinedDims &other) {
     new (&dims_.inline_dims) InlineTy();
@@ -168,6 +214,12 @@ class SHORTFIN_API InlinedDims {
   const_iterator end() const { return const_iterator(data() + size()); }
   const_iterator cbegin() const { return const_iterator(data()); }
   const_iterator cend() const { return const_iterator(data() + size()); }
+  reverse_iterator rbegin() { return reverse_iterator(begin()); }
+  reverse_iterator rend() { return reverse_iterator(end()); }
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(begin());
+  }
+  const_reverse_iterator rend() const { return const_reverse_iterator(end()); }
 
   void resize(size_type count) { resize_impl(count, value_type()); }
   void resize(size_type count, value_type value) { resize_impl(count, value); }

--- a/libshortfin/src/shortfin/array/dims.h
+++ b/libshortfin/src/shortfin/array/dims.h
@@ -139,6 +139,7 @@ class SHORTFIN_API InlinedDims {
   }
   template <std::contiguous_iterator BeginTy, typename EndTy>
   InlinedDims(BeginTy begin, EndTy end) {
+    assert(end > begin);
     set(std::span<const size_type>(&(*begin), end - begin));
   }
   InlinedDims(const InlinedDims &other) {

--- a/libshortfin/src/shortfin/array/dtype.h
+++ b/libshortfin/src/shortfin/array/dtype.h
@@ -20,11 +20,11 @@ namespace shortfin::array {
 class SHORTFIN_API DType {
  public:
 #define SHORTFIN_DTYPE_HANDLE(et, ident) \
-  static DType ident() { return DType(et, #ident); }
+  static constexpr DType ident() { return DType(et, #ident); }
 #include "shortfin/array/dtypes.inl"
 #undef SHORTFIN_DTYPE_HANDLE
 
-  operator iree_hal_element_type_t() const { return et_; }
+  constexpr operator iree_hal_element_type_t() const { return et_; }
 
   std::string_view name() const { return name_; }
 
@@ -56,13 +56,23 @@ class SHORTFIN_API DType {
   // pre-condition
   iree_device_size_t compute_dense_nd_size(std::span<const size_t> dims);
 
-  bool operator==(const DType &other) const { return et_ == other.et_; }
+  constexpr bool operator==(const DType &other) const {
+    return et_ == other.et_;
+  }
 
   // Imports a raw iree_hal_element_type_t from the ether.
   static DType import_element_type(iree_hal_element_type_t et);
 
+  // Asserts that the sizeof EltTy is equal to the size of this dtype.
+  template <typename EltTy>
+  void AssertCompatibleSize() {
+    if (!is_byte_aligned() || sizeof(EltTy) != dense_byte_count()) {
+      throw std::invalid_argument("Incompatible element size");
+    }
+  }
+
  private:
-  DType(iree_hal_element_type_t et, std::string_view name)
+  constexpr DType(iree_hal_element_type_t et, std::string_view name)
       : et_(et), name_(name) {}
   iree_hal_element_type_t et_;
   std::string_view name_;

--- a/libshortfin/src/shortfin/array/storage.h
+++ b/libshortfin/src/shortfin/array/storage.h
@@ -91,9 +91,11 @@ class SHORTFIN_API storage : public local::ProgramInvocationMarshalable {
   // By default, if there are any affinity bits set in the device, then
   // the storage will be device visible and have permitted usage for
   // transfers. This default policy can be overriden based on device defaults
-  // or explicit options.
+  // or explicit options. Pass `device_visible=false` to create a pure host
+  // heap buffer.
   static storage allocate_host(local::ScopedDevice &device,
-                               iree_device_size_t allocation_size);
+                               iree_device_size_t allocation_size,
+                               bool device_visible = true);
 
   // Creates a subspan view of the current storage given a byte offset and
   // length. The returned storage shares the underlying allocation and

--- a/libshortfin/tests/api/array_ops.py
+++ b/libshortfin/tests/api/array_ops.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import array
+import math
+import pytest
+
+import shortfin as sf
+import shortfin.array as sfnp
+
+
+@pytest.fixture
+def lsys():
+    sc = sf.host.CPUSystemBuilder()
+    lsys = sc.create_system()
+    yield lsys
+    lsys.shutdown()
+
+
+@pytest.fixture
+def scope(lsys):
+    return lsys.create_scope()
+
+
+@pytest.fixture
+def device(scope):
+    return scope.device(0)
+
+
+def test_argmax(device):
+    src = sfnp.device_array(device, [4, 16, 128], dtype=sfnp.float32)
+    data = [float(i) for i in range(math.prod([1, 16, 128]))]
+    for i in range(4):
+        src.view(i).items = data
+        data.reverse()
+
+    # default variant
+    result = sfnp.argmax(src)
+    assert result.shape == [4, 16]
+    assert result.view(0).items.tolist() == [127] * 16
+    assert result.view(1).items.tolist() == [0] * 16
+    assert result.view(2).items.tolist() == [127] * 16
+    assert result.view(3).items.tolist() == [0] * 16
+
+    # keepdims variant
+    result = sfnp.argmax(src, keepdims=True)
+    assert result.shape == [4, 16, 1]
+
+    # out= variant
+    out = sfnp.device_array(device, [4, 16], dtype=sfnp.int64)
+    sfnp.argmax(src, out=out)
+    assert out.shape == [4, 16]
+    assert out.view(0).items.tolist() == [127] * 16
+    assert out.view(1).items.tolist() == [0] * 16
+    assert out.view(2).items.tolist() == [127] * 16
+    assert out.view(3).items.tolist() == [0] * 16
+
+    # out= keepdims variant
+    out = sfnp.device_array(device, [4, 16, 1], dtype=sfnp.int64)
+    sfnp.argmax(src, keepdims=True, out=out)
+    assert out.shape == [4, 16, 1]
+    assert out.view(0).items.tolist() == [127] * 16
+    assert out.view(1).items.tolist() == [0] * 16
+    assert out.view(2).items.tolist() == [127] * 16
+    assert out.view(3).items.tolist() == [0] * 16
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        sfnp.float16,
+        sfnp.float32,
+    ],
+)
+def test_argmax_dtypes(device, dtype):
+    # Just verifies that the dtype functions. We don't have IO support for
+    # some of these.
+    src = sfnp.device_array(device, [4, 16, 128], dtype=dtype)
+    sfnp.argmax(src)

--- a/libshortfin/tests/api/array_ops_test.py
+++ b/libshortfin/tests/api/array_ops_test.py
@@ -21,13 +21,13 @@ def lsys():
 
 
 @pytest.fixture
-def scope(lsys):
-    return lsys.create_scope()
+def fiber(lsys):
+    return lsys.create_fiber()
 
 
 @pytest.fixture
-def device(scope):
-    return scope.device(0)
+def device(fiber):
+    return fiber.device(0)
 
 
 def test_argmax(device):


### PR DESCRIPTION
Adds `shortfin.array.argmax`, following closely to numpy conventions.

In the C++ implementation, this forced completion of some APIs around accessing shortfin arrays via xtensor. 

C++ based users will just use the `device_array::map_xtensor*` helpers to access xtensor expressions directly.

For Python, we export select eager op kernels to match common situations. The intent here is to just be able to do some lightweight algebra and data manipulation common in host-side ML (without deps).